### PR TITLE
Fix crash when clearing SimpleXYSeries with SimpleXYSeries.ArrayFormat.Y_VALS_ONLY

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/xy/SimpleXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/SimpleXYSeries.java
@@ -341,7 +341,9 @@ public class SimpleXYSeries implements EditableXYSeries, OrderedXYSeries, PlotLi
     public void clear() {
         lock.writeLock().lock();
         try {
-            xVals.clear();
+            if (xVals != null) {
+              xVals.clear();
+            }
             yVals.clear();
         } finally {
             lock.writeLock().unlock();


### PR DESCRIPTION
Calling `clear()` on a `SimpleXYSeries` with ArrayFormat `SimpleXYSeries.ArrayFormat.Y_VALS_ONLY` causes a crash due to a null pointer exception on `xVals.clear();`

**Stack Trace:** 
```
E/AndroidRuntime: FATAL EXCEPTION: main
                  Process: com.mikeriv.stepup, PID: 23454
                  java.lang.NullPointerException: Attempt to invoke virtual method 'void java.util.LinkedList.clear()' on a null object reference
                      at com.androidplot.xy.SimpleXYSeries.clear(SimpleXYSeries.java:344)
                      at com.mikeriv.stepup.StepUpMainActivity.resetAccelerometerData(StepUpMainActivity.java:179)
                      at com.mikeriv.stepup.StepUpMainActivity.onSensorData(StepUpMainActivity.java:151)
                      at com.mikeriv.stepup.sensors.SensorController.onSensorChanged(SensorController.java:68)
                      at android.hardware.SystemSensorManager$SensorEventQueue.dispatchSensorEvent(SystemSensorManager.java:466)
                      at android.os.MessageQueue.nativePollOnce(Native Method)
                      at android.os.MessageQueue.next(MessageQueue.java:143)
                      at android.os.Looper.loop(Looper.java:122)
                      at android.app.ActivityThread.main(ActivityThread.java:5254)
                      at java.lang.reflect.Method.invoke(Native Method)
                      at java.lang.reflect.Method.invoke(Method.java:372)
                      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:903)
                      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:698)
I/Process: Sending signal. PID: 23454 SIG: 9
Disconnected from the target VM, address: 'localhost:8600', transport: 'socket'`
```