### PR TITLE
Implement descriptive toString() methods for RectRegion and related classes

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/Region.java
+++ b/androidplot-core/src/main/java/com/androidplot/Region.java
@@ -17,7 +17,7 @@
 
 package com.androidplot;
 
-import com.androidplot.util.*;
+import com.androidplot.util.FastNumber;
 
 /**
  * A one dimensional region represented by a starting and ending value.
@@ -248,5 +248,21 @@ public class Region {
      */
     public boolean isDefined() {
         return min != null && max != null;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("Region{");
+        sb.append("min=").append(min);
+        sb.append(", max=").append(max);
+        sb.append(", cachedLength=").append(cachedLength);
+        sb.append(", defaults=");
+        if (defaults != this) {
+            sb.append(defaults);
+        } else {
+            sb.append("this");
+        }
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/androidplot-core/src/main/java/com/androidplot/util/FastNumber.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/FastNumber.java
@@ -63,4 +63,9 @@ public class FastNumber extends Number {
         }
         return doublePrimitive;
     }
+
+    @Override
+    public String toString() {
+        return String.valueOf(doubleValue());
+    }
 }

--- a/androidplot-core/src/main/java/com/androidplot/util/SeriesUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/SeriesUtils.java
@@ -16,10 +16,14 @@
 
 package com.androidplot.util;
 
-import com.androidplot.*;
-import com.androidplot.xy.*;
+import com.androidplot.Region;
+import com.androidplot.xy.FastXYSeries;
+import com.androidplot.xy.OrderedXYSeries;
+import com.androidplot.xy.RectRegion;
+import com.androidplot.xy.XYConstraints;
+import com.androidplot.xy.XYSeries;
 
-import java.util.*;
+import java.util.List;
 
 /**
  * Utilities for dealing with Series data.
@@ -83,18 +87,18 @@ public class SeriesUtils {
 
                 // if this is an advanced xy series then minMax have already been calculated for us:
                 if(series instanceof FastXYSeries) {
-                    final RectRegion b = ((FastXYSeries) series).minMax();
-                    if(b == null) {
+                    final RectRegion seriesBounds = ((FastXYSeries) series).minMax();
+                    if (seriesBounds == null) {
                         continue;
                     }
                     if(constraints == null) {
-                        bounds.union(b);
+                        bounds.union(seriesBounds);
                     } else {
-                        if(constraints.contains(b.getMinX(), b.getMinY())) {
-                            bounds.union(b.getMinX(), b.getMinY());
+                        if (constraints.contains(seriesBounds.getMinX(), seriesBounds.getMinY())) {
+                            bounds.union(seriesBounds.getMinX(), seriesBounds.getMinY());
                         }
-                        if(constraints.contains(b.getMaxX(), b.getMaxY())) {
-                            bounds.union(b.getMaxX(), b.getMaxY());
+                        if (constraints.contains(seriesBounds.getMaxX(), seriesBounds.getMaxY())) {
+                            bounds.union(seriesBounds.getMaxX(), seriesBounds.getMaxY());
                         }
                     }
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/RectRegion.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/RectRegion.java
@@ -20,6 +20,7 @@ import android.graphics.PointF;
 import android.graphics.RectF;
 
 import com.androidplot.Region;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -343,5 +344,14 @@ public class RectRegion {
      */
     public boolean contains(Number x, Number y) {
         return getxRegion().contains(x) && getyRegion().contains(y);
+    }
+
+    @Override
+    public String toString() {
+        return "RectRegion{" +
+                "xRegion=" + xRegion +
+                ", yRegion=" + yRegion +
+                ", label='" + label + '\'' +
+                '}';
     }
 }

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
@@ -153,4 +153,21 @@ public class XYConstraints {
     public void setMaxY(Number maxY) {
         this.maxY = maxY;
     }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("XYConstraints{");
+        sb.append("domainFramingModel=").append(domainFramingModel);
+        sb.append(", rangeFramingModel=").append(rangeFramingModel);
+        sb.append(", domainUpperBoundaryMode=").append(domainUpperBoundaryMode);
+        sb.append(", domainLowerBoundaryMode=").append(domainLowerBoundaryMode);
+        sb.append(", rangeUpperBoundaryMode=").append(rangeUpperBoundaryMode);
+        sb.append(", rangeLowerBoundaryMode=").append(rangeLowerBoundaryMode);
+        sb.append(", minX=").append(minX);
+        sb.append(", maxX=").append(maxX);
+        sb.append(", minY=").append(minY);
+        sb.append(", maxY=").append(maxY);
+        sb.append('}');
+        return sb.toString();
+    }
 }

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
@@ -18,6 +18,7 @@ package com.androidplot.xy;
 
 /**
  * Calculates the min/max constraints for an xy plane.
+ *
  * @since 0.9.7
  */
 public class XYConstraints {
@@ -52,26 +53,26 @@ public class XYConstraints {
     }
 
     public boolean contains(Number x, Number y) {
-        if(x == null || y == null) {
+        if (x == null || y == null) {
             // this is essentially an invisible point:
             return false;
-        } else {
-            final double dx = x.doubleValue();
-
-            if(minX != null && dx < minX.doubleValue()) {
-                return false;
-            } else if(maxX != null && dx > maxX.doubleValue()) {
-               return false;
-            } else {
-                final double dy = y.doubleValue();
-                if(minY != null && dy < minY.doubleValue()) {
-                    return false;
-                } else if(maxY != null && dy > maxY.doubleValue()) {
-                    return false;
-                }
-            }
-            return true;
         }
+
+        final double dx = x.doubleValue();
+        if (minX != null && dx < minX.doubleValue()) {
+            return false;
+        } else if (maxX != null && dx > maxX.doubleValue()) {
+            return false;
+        }
+
+        final double dy = y.doubleValue();
+        if (minY != null && dy < minY.doubleValue()) {
+            return false;
+        } else if (maxY != null && dy > maxY.doubleValue()) {
+            return false;
+        }
+
+        return true;
     }
 
     public Number getMinX() {


### PR DESCRIPTION
This set of changes are non-functional changes I made in the course of debugging a separate issue.

I've implemented `toString` for RectRegion and related classes.

I reduced the nesting in some if else logic.

My editor automatically converted wildcard import statements to explicit imports - google style guidelines prefer explicit imports in most cases.