### PR TITLE
Fix Jetifier being required

### DIFF
--- a/androidplot-core/build.gradle
+++ b/androidplot-core/build.gradle
@@ -89,7 +89,7 @@ def gitUrl = 'https://github.com/halfhp/androidplot.git'
 dependencies {
 
     implementation 'com.halfhp.fig:figlib:1.0.11'
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.annotation:annotation:1.4.0'
 
     testImplementation "org.mockito:mockito-core:4.0.0"
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'


### PR DESCRIPTION
This prevents the library from being flagged in Jetifier check build analyzer task. No other changes are needed :) (that I know of)