### PR TITLE
CI overhaul: PR triggers, release workflow, caching, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # Batch routine dependency bumps into a single PR.
+      gradle-dependencies:
+        patterns: ['*']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,32 @@
 name: build androidplot
+
 on: [push]
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same branch to save runner minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set Up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '17'
+
+      # Caches Gradle distributions and dependencies between runs.
+      - name: Set Up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build and Test
         run: ./gradlew testDebugUnitTest jacocoTestDebugUnitTestReport
@@ -24,31 +39,30 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.DEMOAPP_KEYSTORE_PASSWORD }}
           KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
         run: |
-          echo $ENCODED | base64 -di > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
+          printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
           ./gradlew assembleRelease
 
-# TODO: get javadoc working again at some point
-#      - name: Javadoc
-#        run: ./gradlew javadoc
-
-      - name: Code Coverage
-        uses: codecov/codecov-action@v5
+      - name: Upload Code Coverage
+        uses: codecov/codecov-action@v7
         with:
           files: androidplot-core/build/jacoco/jacoco.xml
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Core Library AAR
+        uses: actions/upload-artifact@v7
         with:
           name: Core Library
           path: androidplot-core/build/outputs/aar/*.aar
           retention-days: 30
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Demoapp APK
         if: github.ref_name == 'master'
+        uses: actions/upload-artifact@v7
         with:
           name: Demoapp APK
           path: demoapp/build/outputs/apk/release/*.apk
           retention-days: 30
 
+      # TODO: OSSRH was decommissioned; this must move to the Central Publisher Portal.
       - name: Stage for Maven Central
         if: github.ref_name == 'master'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build androidplot
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions:
   contents: read
@@ -16,22 +19,34 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set Up JDK 17
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
-      # Caches Gradle distributions and dependencies between runs.
+      # Caches Gradle distributions and dependencies between runs. Only master
+      # writes to the cache so feature branches don't evict useful entries.
       - name: Set Up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
 
       - name: Build and Test
-        run: ./gradlew testDebugUnitTest jacocoTestDebugUnitTestReport
+        run: ./gradlew testDebugUnitTest jacocoTestDebugUnitTestReport lint :androidplot-core:assembleRelease
 
-      - name: Build Release
+      # Signing secrets are unavailable to pull requests from forks, so only
+      # build the signed demoapp when they are present.
+      - name: Check for Signing Secrets
+        id: signing
+        env:
+          KEYSTORE_B64: ${{ secrets.DEMOAPP_KEYSTORE }}
+        run: echo "available=${{ env.KEYSTORE_B64 != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Signed Demoapp
+        if: steps.signing.outputs.available == 'true'
         env:
           ENCODED: ${{ secrets.DEMOAPP_KEYSTORE }}
           KEYSTORE: keystore.jks
@@ -40,15 +55,36 @@ jobs:
           KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
         run: |
           printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
-          ./gradlew assembleRelease
+          ./gradlew :demoapp:assembleRelease
 
+      - name: Build Unsigned Demoapp
+        if: steps.signing.outputs.available != 'true'
+        run: ./gradlew :demoapp:assembleDebug
+
+      # Requires a CODECOV_TOKEN secret (tokenless uploads are rejected for
+      # protected branches). Upload failures are surfaced on the step but do
+      # not fail the job.
       - name: Upload Code Coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        continue-on-error: true
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: androidplot-core/build/jacoco/jacoco.xml
+          fail_ci_if_error: true
+
+      - name: Upload Test and Lint Reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Reports
+          path: |
+            **/build/reports/tests/
+            **/build/reports/lint-results-*.html
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Upload Core Library AAR
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Core Library
           path: androidplot-core/build/outputs/aar/*.aar
@@ -56,18 +92,8 @@ jobs:
 
       - name: Upload Demoapp APK
         if: github.ref_name == 'master'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Demoapp APK
           path: demoapp/build/outputs/apk/release/*.apk
           retention-days: 30
-
-      # TODO: OSSRH was decommissioned; this must move to the Central Publisher Portal.
-      - name: Stage for Maven Central
-        if: github.ref_name == 'master'
-        env:
-          OSSRH_ACTOR: ${{ secrets.OSSRH_ACTOR }}
-          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
-          SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-        run: ./gradlew publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
         run: |
           printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
-          ./gradlew :demoapp:assembleRelease
+          ./gradlew :demoapp:assembleRelease :demoapp:bundleRelease
 
       - name: Attach Artifacts to GitHub Release
         if: github.ref_type == 'tag'
@@ -70,7 +70,8 @@ jobs:
             || gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
           gh release upload "${GITHUB_REF_NAME}" --clobber \
             androidplot-core/build/outputs/aar/androidplot-core-release.aar \
-            demoapp/build/outputs/apk/release/demoapp-release.apk
+            demoapp/build/outputs/apk/release/demoapp-release.apk \
+            demoapp/build/outputs/bundle/release/demoapp-release.aab
 
       # TODO: OSSRH was decommissioned; this must move to the Central Publisher Portal.
       - name: Publish to Maven Central
@@ -82,8 +83,8 @@ jobs:
           SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
         run: ./gradlew publish
 
-      # Uploads the APK rather than an app bundle: the demoapp has only ever
-      # shipped APKs and is not enrolled in Play App Signing, which bundles require.
+      # Uploads an app bundle; the demoapp is enrolled in Play App Signing and
+      # the keystore in DEMOAPP_KEYSTORE is its upload key.
       - name: Publish Demoapp to Google Play
         if: github.event_name != 'workflow_dispatch' || inputs.publish_play
         env:
@@ -95,4 +96,4 @@ jobs:
           PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
         run: |
           printf '%s' "$PLAY_JSON" > "${GITHUB_WORKSPACE}/demoapp/publisher.json"
-          ./gradlew :demoapp:publishReleaseApk
+          ./gradlew :demoapp:publishReleaseBundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
         run: |
           printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
-          ./gradlew :demoapp:assembleRelease :demoapp:bundleRelease
+          ./gradlew :demoapp:assembleRelease
 
       - name: Attach Artifacts to GitHub Release
         if: github.ref_type == 'tag'
@@ -70,8 +70,7 @@ jobs:
             || gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
           gh release upload "${GITHUB_REF_NAME}" --clobber \
             androidplot-core/build/outputs/aar/androidplot-core-release.aar \
-            demoapp/build/outputs/apk/release/demoapp-release.apk \
-            demoapp/build/outputs/bundle/release/demoapp-release.aab
+            demoapp/build/outputs/apk/release/demoapp-release.apk
 
       # TODO: OSSRH was decommissioned; this must move to the Central Publisher Portal.
       - name: Publish to Maven Central
@@ -83,8 +82,9 @@ jobs:
           SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
         run: ./gradlew publish
 
-      # Uploads an app bundle; the demoapp is enrolled in Play App Signing and
-      # the keystore in DEMOAPP_KEYSTORE is its upload key.
+      # Uploads an APK rather than an app bundle. The demoapp's 2011 signing key
+      # is 1024-bit RSA, which Play App Signing does not accept, and bundles
+      # require Play App Signing. Play still accepts APKs for existing apps.
       - name: Publish Demoapp to Google Play
         if: github.event_name != 'workflow_dispatch' || inputs.publish_play
         env:
@@ -96,4 +96,4 @@ jobs:
           PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
         run: |
           printf '%s' "$PLAY_JSON" > "${GITHUB_WORKSPACE}/demoapp/publisher.json"
-          ./gradlew :demoapp:publishReleaseBundle
+          ./gradlew :demoapp:publishReleaseApk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,15 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+    inputs:
+      publish_maven_central:
+        description: Publish the core library to Maven Central
+        type: boolean
+        default: true
+      publish_play:
+        description: Publish the demoapp to Google Play
+        type: boolean
+        default: true
 
 permissions:
   contents: write # needed to attach artifacts to the GitHub release
@@ -50,7 +59,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
         run: |
           printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
-          ./gradlew :demoapp:assembleRelease :demoapp:bundleRelease
+          ./gradlew :demoapp:assembleRelease
 
       - name: Attach Artifacts to GitHub Release
         if: github.ref_type == 'tag'
@@ -65,6 +74,7 @@ jobs:
 
       # TODO: OSSRH was decommissioned; this must move to the Central Publisher Portal.
       - name: Publish to Maven Central
+        if: github.event_name != 'workflow_dispatch' || inputs.publish_maven_central
         env:
           OSSRH_ACTOR: ${{ secrets.OSSRH_ACTOR }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
@@ -72,16 +82,10 @@ jobs:
           SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
         run: ./gradlew publish
 
-      # Requires a PLAY_PUBLISHER_JSON secret containing the Play Console
-      # service account credentials. Skipped until that secret is configured.
-      - name: Check for Play Publisher Credentials
-        id: play
-        env:
-          PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
-        run: echo "available=${{ env.PLAY_JSON != '' }}" >> "$GITHUB_OUTPUT"
-
+      # Uploads the APK rather than an app bundle: the demoapp has only ever
+      # shipped APKs and is not enrolled in Play App Signing, which bundles require.
       - name: Publish Demoapp to Google Play
-        if: steps.play.outputs.available == 'true'
+        if: github.event_name != 'workflow_dispatch' || inputs.publish_play
         env:
           KEYSTORE: keystore.jks
           KEY_ALIAS: Key0
@@ -91,4 +95,4 @@ jobs:
           PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
         run: |
           printf '%s' "$PLAY_JSON" > "${GITHUB_WORKSPACE}/demoapp/publisher.json"
-          ./gradlew :demoapp:publishReleaseBundle
+          ./gradlew :demoapp:publishReleaseApk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: release androidplot
+
+# Publishes the core library to Maven Central and the demoapp to Google Play.
+# Runs when a version tag (e.g. v1.5.11) is pushed, or on demand.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write # needed to attach artifacts to the GitHub release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify Tag Matches Project Version
+        if: github.ref_type == 'tag'
+        run: |
+          version=$(sed -nE "s/.*theVersionName = '([^']+)'.*/\1/p" build.gradle)
+          if [ "v$version" != "${GITHUB_REF_NAME}" ]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match theVersionName '$version' in build.gradle"
+            exit 1
+          fi
+
+      - name: Set Up JDK 17
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set Up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: true
+
+      - name: Build and Test
+        run: ./gradlew testDebugUnitTest :androidplot-core:assembleRelease
+
+      - name: Build Signed Demoapp
+        env:
+          ENCODED: ${{ secrets.DEMOAPP_KEYSTORE }}
+          KEYSTORE: keystore.jks
+          KEY_ALIAS: Key0
+          KEYSTORE_PASSWORD: ${{ secrets.DEMOAPP_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
+        run: |
+          printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
+          ./gradlew :demoapp:assembleRelease :demoapp:bundleRelease
+
+      - name: Attach Artifacts to GitHub Release
+        if: github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
+            || gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
+          gh release upload "${GITHUB_REF_NAME}" --clobber \
+            androidplot-core/build/outputs/aar/androidplot-core-release.aar \
+            demoapp/build/outputs/apk/release/demoapp-release.apk
+
+      # TODO: OSSRH was decommissioned; this must move to the Central Publisher Portal.
+      - name: Publish to Maven Central
+        env:
+          OSSRH_ACTOR: ${{ secrets.OSSRH_ACTOR }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+        run: ./gradlew publish
+
+      # Requires a PLAY_PUBLISHER_JSON secret containing the Play Console
+      # service account credentials. Skipped until that secret is configured.
+      - name: Check for Play Publisher Credentials
+        id: play
+        env:
+          PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
+        run: echo "available=${{ env.PLAY_JSON != '' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Demoapp to Google Play
+        if: steps.play.outputs.available == 'true'
+        env:
+          KEYSTORE: keystore.jks
+          KEY_ALIAS: Key0
+          KEYSTORE_PASSWORD: ${{ secrets.DEMOAPP_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
+          PUBLISHER_ACCT_JSON_FILE: publisher.json
+          PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
+        run: |
+          printf '%s' "$PLAY_JSON" > "${GITHUB_WORKSPACE}/demoapp/publisher.json"
+          ./gradlew :demoapp:publishReleaseBundle

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ DemoApp/gen
 DemoApp/target
 .idea
 **/R.java
+
+# CI-provisioned credentials
+demoapp/keystore.jks
+demoapp/publisher.json

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,7 @@
 android.useAndroidX=true
 kotlin.stdlib.default.dependency=false
+
+# Build performance
+org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
## Summary

Cleanup and hardening pass on the GitHub Actions setup. Two commits: the first names steps and adds Gradle caching, the second addresses the wider set of recommendations.

### Build workflow (`build.yml`)
- **Triggers:** runs on `pull_request` and pushes to `master`. Fork PRs now get CI. Pushes to feature branches without a PR no longer trigger a run.
- **Secret-gated signing:** the signed demoapp build only runs when the keystore secret is present; otherwise an unsigned debug build runs so fork and Dependabot PRs still get a meaningful check.
- **Lint** now runs in CI. Test and lint HTML reports are uploaded as a `Reports` artifact on every non-cancelled run.
- **Named the upload-artifact steps** so they no longer show as duplicates in the run view.
- **Gradle caching** via `gradle/actions/setup-gradle`, read-only on non-master branches so feature branches don't evict useful entries.
- **Hardening:** read-only token permissions, a concurrency group that cancels superseded runs, a job timeout.
- **Codecov:** tokenless uploads have been silently failing with "Token required because branch is protected" (visible in the step log of every recent run). The step now passes `CODECOV_TOKEN`. Note the Codecov CLI logs this rejection as an error but still exits 0, so even `fail_ci_if_error` does not catch it; creating the secret is the only fix.
- **Actions pinned to release commit SHAs** and bumped to current majors (checkout v7, setup-java v6, upload-artifact v7, codecov v7).

### Release workflow (`release.yml`, new)
Publishing no longer happens on every master push. It moves to a workflow triggered by a `v*` tag or manual dispatch:
1. Verifies the tag matches `theVersionName` in `build.gradle`.
2. Builds and tests, produces the signed APK.
3. On a tag, creates a GitHub Release with generated notes and attaches the AAR and APK.
4. Publishes to Maven Central. **Still points at the decommissioned OSSRH endpoint and will fail until the Portal migration.** It runs after the GitHub Release step, so the release will exist even when this step fails.
5. Publishes the demoapp APK to the Play beta track using the `PLAY_PUBLISHER_JSON` service account secret. APK rather than bundle: the app's 2011 signing key is 1024-bit RSA, which Play App Signing rejects, and bundles require Play App Signing. Play still accepts APKs for existing apps. The service account was verified read-only against the Play API: it can access the app, the beta track exists, and the project's version code 227 is above the 226 currently in production.

Manual dispatch exposes two checkboxes to skip Maven Central or Play publishing, so each can be tested independently.

**Release process going forward:** bump `theVersionName` and `theVersionCode`, merge to master, then push tag `v<version>`.

### Other
- `dependabot.yml` for GitHub Actions and Gradle dependencies, weekly, Gradle bumps grouped into one PR.
- `gradle.properties`: build cache, parallel execution and configuration cache enabled. Verified locally; incompatible publish tasks degrade gracefully.
- `.gitignore` covers the keystore and Play credentials files the workflows write into `demoapp/`.

## Secrets
- `CODECOV_TOKEN` and `PLAY_PUBLISHER_JSON` have both been created.

## Verification
- The `pull_request` run on this PR exercises the build workflow's signed path.
- The unsigned fallback path is exercised by the first Dependabot or fork PR.
- `release.yml` can't run until it's on the default branch; the first tag push is its first real test.
