### PR TITLE
Dependabot: ignore kotlin-stdlib

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      # kotlin-stdlib must match the Kotlin compiler bundled with AGP's
+      # built-in Kotlin support; bump it by hand alongside AGP.
+      - dependency-name: org.jetbrains.kotlin:kotlin-stdlib
     groups:
       # Batch routine dependency bumps into a single PR.
       gradle-dependencies:


### PR DESCRIPTION
## Summary

Dependabot's first Gradle PR (#128) bumped `kotlin-stdlib` to 2.4.10, which fails to compile: the Kotlin compiler is bundled with AGP's built-in Kotlin support at 2.2.10 and cannot read 2.4 metadata. The stdlib version has to move in lockstep with AGP, so this tells Dependabot to leave it alone. It gets bumped by hand when AGP is upgraded.

Closes #128 by superseding it.
