### PR TITLE
Publish snapshots to Maven Central from master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,3 +97,14 @@ jobs:
           name: Demoapp APK
           path: demoapp/build/outputs/apk/release/*.apk
           retention-days: 30
+
+      # Publishes <version>-SNAPSHOT of the core library so unreleased changes
+      # can be consumed by Maven coordinates from the Central snapshots repo.
+      - name: Publish Snapshot to Maven Central
+        if: github.ref_name == 'master'
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+        run: ./gradlew :androidplot-core:publish -Psnapshot

--- a/androidplot-core/build.gradle
+++ b/androidplot-core/build.gradle
@@ -98,7 +98,9 @@ android {
 }
 
 group = 'com.androidplot'
-version = rootProject.ext.theVersionName
+// Pass -Psnapshot to publish a <version>-SNAPSHOT build to the Central snapshots
+// repository; without it the exact version is published as a release.
+version = rootProject.ext.theVersionName + (project.hasProperty('snapshot') ? '-SNAPSHOT' : '')
 
 def siteUrl = 'http://androidplot.com'
 def gitUrl = 'https://github.com/halfhp/androidplot.git'
@@ -137,11 +139,14 @@ afterEvaluate {
     publishing {
         repositories {
             maven {
-                // Central Publisher Portal, via its OSSRH-compatible staging API.
-                // Uploads land as a pending deployment; the release workflow then
-                // calls the Portal's manual API to publish them.
+                // Central Publisher Portal. Releases go via its OSSRH-compatible
+                // staging API and land as a pending deployment that the release
+                // workflow then asks the Portal to publish. Snapshots go straight
+                // to the Central snapshots repository.
                 name = "MavenCentral"
-                url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+                url = version.endsWith('-SNAPSHOT')
+                        ? "https://central.sonatype.com/repository/maven-snapshots/"
+                        : "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
                 credentials {
                     username = System.getenv("MAVEN_CENTRAL_USERNAME")
                     password = System.getenv("MAVEN_CENTRAL_PASSWORD")
@@ -156,7 +161,7 @@ afterEvaluate {
                 // You can then customize attributes of the publication as shown below.
                 groupId = 'com.androidplot'
                 artifactId = 'androidplot-core'
-                version = rootProject.ext.theVersionName
+                version = project.version
 
                 pom {
                     packaging = 'aar'

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,6 +18,19 @@ dependencies {
 }
 ```
 
+To try unreleased changes, every push to master publishes a snapshot build. Add the Central
+snapshots repository and depend on the `-SNAPSHOT` version of the next release:
+
+```groovy
+repositories {
+    maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
+}
+
+dependencies {
+    implementation "com.androidplot:androidplot-core:1.5.11-SNAPSHOT"
+}
+```
+
 *NOTE: As of version 1.5.8 Androidplot has migrated over from the Android Support Libraries to androidx.
 If you have a very old project and experience issues, may need to stay on version 1.5.7*
 


### PR DESCRIPTION
## Summary

Follow-up to #130. Lets people consume unreleased changes by Maven coordinates instead of downloading an AAR.

- **`androidplot-core/build.gradle`**: passing `-Psnapshot` appends `-SNAPSHOT` to the version and routes publishing to `https://central.sonatype.com/repository/maven-snapshots/`. Without it the exact version is published as a release via the staging API, unchanged from #130. The version in `build.gradle` stays a plain number, so there's no suffix to strip at release time.
- **`build.yml`**: publishes a snapshot on every push to master, using the same Portal token and GPG secrets as releases.
- **`docs/quickstart.md`**: documents the snapshots repository and `-SNAPSHOT` coordinates.

Verified locally that both modes produce the correct POM version and select the correct repository URL.

## Before merging

Enable SNAPSHOT publishing for the `com.androidplot` namespace in the Central Portal (Namespaces, the namespace's menu, Enable SNAPSHOTs). Without it the snapshot upload on merge is rejected.
