### PR TITLE
Bump version to 1.5.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ ext {
     theCompileSdkVersion = 37
     theTargetSdkVersion = 37
     theMinSdkVersion = 5
-    theVersionName = '1.5.11'
-    theVersionCode = 227
+    theVersionName = '1.5.12'
+    theVersionCode = 228
     gitUrl = 'https://github.com/halfhp/androidplot.git'
 }
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.androidplot:androidplot-core:1.5.11-SNAPSHOT"
+    implementation "com.androidplot:androidplot-core:1.5.12-SNAPSHOT"
 }
 ```
 


### PR DESCRIPTION
## Summary

1.5.11 was already released to Maven Central on 2024-08-22, so the current snapshot coordinates (`1.5.11-SNAPSHOT`) point at a version that's already final, and a tagged release of 1.5.11 would be rejected by Central.

- `theVersionName` 1.5.11 → 1.5.12, `theVersionCode` 227 → 228
- Quickstart snapshot example updated to `1.5.12-SNAPSHOT`

Merging publishes the first `1.5.12-SNAPSHOT` to the Central snapshots repository. The stale `1.5.11-SNAPSHOT` build can be left to expire.
