### PR TITLE
Update copyright to 2026 and switch to SPDX license headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ DemoApp/target
 # CI-provisioned credentials
 demoapp/keystore.jks
 demoapp/publisher.json
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Technical questions should be posted using the [androidplot tag](http://stackove
 # License
 Androidplot has been made available under the Apache 2.0 license:
 
-    Copyright 2021 Androidplot.com
+    Copyright 2026 Androidplot.com
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ If you enjoy the lib, please [rate us on codix.io](http://codix.io/gh/repo/halfh
 Technical questions should be posted using the [androidplot tag](http://stackoverflow.com/questions/tagged/androidplot) on Stack Overflow.  For everything else use the [Google Groups forum](https://groups.google.com/d/forum/androidplot).
 
 # License
-Androidplot has been made available under the Apache 2.0 license:
+Androidplot has been made available under the Apache 2.0 license. Source files carry an
+[SPDX](https://spdx.dev/learn/handling-license-info/) `SPDX-License-Identifier: Apache-2.0` tag
+in place of a full license header; the full text is in [LICENSE.md](LICENSE.md).
 
     Copyright 2026 Androidplot.com
 

--- a/androidplot-core/build.gradle
+++ b/androidplot-core/build.gradle
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     id 'com.android.library'

--- a/androidplot-core/src/main/AndroidManifest.xml
+++ b/androidplot-core/src/main/AndroidManifest.xml
@@ -1,18 +1,4 @@
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <!-- This file has been intentionally left empty; values should be
 set in android.defaultConfig in build.gradle wherever possible.-->

--- a/androidplot-core/src/main/java/com/androidplot/LineLabelFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/LineLabelFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/main/java/com/androidplot/PlotListener.java
+++ b/androidplot-core/src/main/java/com/androidplot/PlotListener.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/main/java/com/androidplot/Region.java
+++ b/androidplot-core/src/main/java/com/androidplot/Region.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 
 package com.androidplot;

--- a/androidplot-core/src/main/java/com/androidplot/Series.java
+++ b/androidplot-core/src/main/java/com/androidplot/Series.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/main/java/com/androidplot/SeriesRegistry.java
+++ b/androidplot-core/src/main/java/com/androidplot/SeriesRegistry.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/main/java/com/androidplot/SimpleLineLabelFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/SimpleLineLabelFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/main/java/com/androidplot/pie/PieChart.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/PieChart.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.pie;
 

--- a/androidplot-core/src/main/java/com/androidplot/pie/PieLegendItem.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/PieLegendItem.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.pie;
 
 

--- a/androidplot-core/src/main/java/com/androidplot/pie/PieLegendWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/PieLegendWidget.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.pie;
 
 import android.graphics.Canvas;

--- a/androidplot-core/src/main/java/com/androidplot/pie/PieRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/PieRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.pie;
 

--- a/androidplot-core/src/main/java/com/androidplot/pie/PieWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/PieWidget.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.pie;
 

--- a/androidplot-core/src/main/java/com/androidplot/pie/Segment.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/Segment.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.pie;
 

--- a/androidplot-core/src/main/java/com/androidplot/pie/SegmentBundle.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/SegmentBundle.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.pie;
 
 import com.androidplot.ui.*;

--- a/androidplot-core/src/main/java/com/androidplot/pie/SegmentFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/SegmentFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.pie;
 

--- a/androidplot-core/src/main/java/com/androidplot/pie/SegmentRegistry.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/SegmentRegistry.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.pie;
 
 import com.androidplot.*;

--- a/androidplot-core/src/main/java/com/androidplot/ui/Anchor.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/Anchor.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/BoxModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/BoxModel.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/BoxModelable.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/BoxModelable.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/DynamicTableModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/DynamicTableModel.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/FixedTableModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/FixedTableModel.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/Formatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/Formatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/HorizontalPosition.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/HorizontalPosition.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/HorizontalPositioning.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/HorizontalPositioning.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/Insets.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/Insets.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/LayoutManager.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/LayoutManager.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/LayoutMetric.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/LayoutMetric.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/PositionMetric.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/PositionMetric.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/PositionMetrics.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/PositionMetrics.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/RenderBundle.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/RenderBundle.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/RenderStack.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/RenderStack.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/Resizable.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/Resizable.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/SeriesBundle.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/SeriesBundle.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/SeriesRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/SeriesRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/Size.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/Size.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/SizeMetric.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/SizeMetric.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/SizeMode.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/SizeMode.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/TableModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/TableModel.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/TableOrder.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/TableOrder.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/TableSizingMethod.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/TableSizingMethod.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/TextOrientation.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/TextOrientation.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/VerticalPosition.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/VerticalPosition.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/VerticalPositioning.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/VerticalPositioning.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendItem.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendItem.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.ui.widget;
 
 /**

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendWidget.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.ui.widget;
 
 import android.graphics.Canvas;

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/TextLabelWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/TextLabelWidget.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui.widget;
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/Widget.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/Widget.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui.widget;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/APTrace.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/APTrace.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.util;
 
 import android.os.*;

--- a/androidplot-core/src/main/java/com/androidplot/util/AttrUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/AttrUtils.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/DisplayDimensions.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/DisplayDimensions.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/FastNumber.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/FastNumber.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.util;
 
 import androidx.annotation.NonNull;

--- a/androidplot-core/src/main/java/com/androidplot/util/FontUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/FontUtils.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/LayerHash.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/LayerHash.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/LayerListOrganizer.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/LayerListOrganizer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/Layerable.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/Layerable.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/LinkedLayerList.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/LinkedLayerList.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/Mapping.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/Mapping.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/PixelUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/PixelUtils.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/PlotStatistics.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/PlotStatistics.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/RectFUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/RectFUtils.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/Redrawer.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/Redrawer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/util/SeriesUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/SeriesUtils.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/AdvancedLineAndPointRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/AdvancedLineAndPointRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/Axis.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/Axis.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/BarFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BarFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 import android.content.*;

--- a/androidplot-core/src/main/java/com/androidplot/xy/BarRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BarRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/BoundaryMode.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BoundaryMode.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/BubbleFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BubbleFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/BubbleRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BubbleRenderer.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import android.graphics.*;

--- a/androidplot-core/src/main/java/com/androidplot/xy/BubbleSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BubbleSeries.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import java.util.*;

--- a/androidplot-core/src/main/java/com/androidplot/xy/CandlestickFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/CandlestickFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/CandlestickMaker.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/CandlestickMaker.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/CandlestickRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/CandlestickRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/CandlestickSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/CandlestickSeries.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/CatmullRomInterpolator.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/CatmullRomInterpolator.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/EditableXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/EditableXYSeries.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/Estimator.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/Estimator.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/FastLineAndPointRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/FastLineAndPointRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/FastXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/FastXYSeries.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/FillDirection.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/FillDirection.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/FixedSizeEditableXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/FixedSizeEditableXYSeries.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import androidx.annotation.NonNull;

--- a/androidplot-core/src/main/java/com/androidplot/xy/GroupRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/GroupRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/InterpolationParams.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/InterpolationParams.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/Interpolator.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/Interpolator.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/LTTBSampler.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/LTTBSampler.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import android.util.*;

--- a/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/NormedXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/NormedXYSeries.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.Region;

--- a/androidplot-core/src/main/java/com/androidplot/xy/OrderedXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/OrderedXYSeries.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import android.graphics.RectF;

--- a/androidplot-core/src/main/java/com/androidplot/xy/PointLabelFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/PointLabelFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/PointLabeler.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/PointLabeler.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/RectRegion.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/RectRegion.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/SampledXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/SampledXYSeries.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.*;

--- a/androidplot-core/src/main/java/com/androidplot/xy/Sampler.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/Sampler.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/ScalingXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/ScalingXYSeries.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/SimpleXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/SimpleXYSeries.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/Step.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/Step.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/StepFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/StepFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/StepMode.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/StepMode.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/StepModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/StepModel.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/StepModelFit.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/StepModelFit.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.Region;

--- a/androidplot-core/src/main/java/com/androidplot/xy/StepRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/StepRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/ValueMarker.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/ValueMarker.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XValueMarker.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XValueMarker.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYCoords.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYCoords.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYFramingModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYFramingModel.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYGraphWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYGraphWidget.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYLegendItem.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYLegendItem.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import androidx.annotation.NonNull;

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYLegendWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYLegendWidget.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYRegionFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYRegionFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYSeries.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesBundle.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesBundle.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.ui.*;

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesFormatter.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesRegistry.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesRegistry.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.*;

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesRenderer.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYStepCalculator.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYStepCalculator.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/YValueMarker.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/YValueMarker.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/ZoomEstimator.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/ZoomEstimator.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/package-info.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/package-info.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /**
  * Classes involved in the creation and presentation of {@link com.androidplot.xy.XYPlot}.
  */

--- a/androidplot-core/src/main/res/values/attrs.xml
+++ b/androidplot-core/src/main/res/values/attrs.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--NODOC
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!--NODOC SPDX-License-Identifier: Apache-2.0 -->
 
 <!--
 _This documentation is auto generated from [attrs.xml](../androidplot-core/src/main/res/values/attrs.xml)._

--- a/androidplot-core/src/main/res/values/color.xml
+++ b/androidplot-core/src/main/res/values/color.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2016 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <resources>
 

--- a/androidplot-core/src/main/res/values/style.xml
+++ b/androidplot-core/src/main/res/values/style.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2016 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <resources>
 

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/test/java/com/androidplot/RegionTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/RegionTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/test/java/com/androidplot/SeriesRegistryTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/SeriesRegistryTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot;
 

--- a/androidplot-core/src/test/java/com/androidplot/pie/PieRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/pie/PieRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.pie;
 

--- a/androidplot-core/src/test/java/com/androidplot/test/AndroidplotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/test/AndroidplotTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.test;
 

--- a/androidplot-core/src/test/java/com/androidplot/test/MyTestRunner.java
+++ b/androidplot-core/src/test/java/com/androidplot/test/MyTestRunner.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.test;
 
 import org.junit.runners.model.*;

--- a/androidplot-core/src/test/java/com/androidplot/test/TestUtils.java
+++ b/androidplot-core/src/test/java/com/androidplot/test/TestUtils.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.test;
 
 import android.annotation.*;

--- a/androidplot-core/src/test/java/com/androidplot/ui/DynamicTableModelTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/DynamicTableModelTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/test/java/com/androidplot/ui/FixedTableModelTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/FixedTableModelTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.ui;
 

--- a/androidplot-core/src/test/java/com/androidplot/ui/RenderStackTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/RenderStackTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.ui;
 
 import com.androidplot.Plot;

--- a/androidplot-core/src/test/java/com/androidplot/ui/widget/TextLabelWidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/widget/TextLabelWidgetTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.ui.widget;
 
 import android.graphics.Canvas;

--- a/androidplot-core/src/test/java/com/androidplot/ui/widget/WidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/widget/WidgetTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.ui.widget;
 
 import android.graphics.Canvas;

--- a/androidplot-core/src/test/java/com/androidplot/util/FastNumberTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/FastNumberTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.util;
 
 import android.annotation.SuppressLint;

--- a/androidplot-core/src/test/java/com/androidplot/util/InstrumentedXYPlot.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/InstrumentedXYPlot.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.util;
 
 import android.content.*;

--- a/androidplot-core/src/test/java/com/androidplot/util/LayerHashTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/LayerHashTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/test/java/com/androidplot/util/LinkedLayerListOrganizerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/LinkedLayerListOrganizerTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/test/java/com/androidplot/util/PixelUtilsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/PixelUtilsTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/test/java/com/androidplot/util/PlotStatisticsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/PlotStatisticsTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/test/java/com/androidplot/util/SeriesUtilsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/SeriesUtilsTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.util;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/AdvanceLineAndPointRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/AdvanceLineAndPointRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/BarRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/BarRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/BubbleRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/BubbleRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/CandlestickRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/CandlestickRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/CandlestickSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/CandlestickSeriesTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/CatmullRomInterpolatorTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/CatmullRomInterpolatorTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import org.junit.Test;

--- a/androidplot-core/src/test/java/com/androidplot/xy/FastLineAndPointRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/FastLineAndPointRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/LTTBSamplerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/LTTBSamplerTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/LineAndPointRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/LineAndPointRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/NormedXYSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/NormedXYSeriesTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.test.AndroidplotTest;

--- a/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/RectRegionTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/RectRegionTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/SampledXYSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/SampledXYSeriesTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.test.*;

--- a/androidplot-core/src/test/java/com/androidplot/xy/ScalingXYSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/ScalingXYSeriesTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.test.AndroidplotTest;

--- a/androidplot-core/src/test/java/com/androidplot/xy/SimpleXYSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/SimpleXYSeriesTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/StepCalculatorTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/StepCalculatorTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/StepModelFitTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/StepModelFitTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.Region;

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYGraphWidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYGraphWidgetTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYLegendWidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYLegendWidgetTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYSeriesRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYSeriesRendererTest.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.xy;
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/ZoomEstimatorTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/ZoomEstimatorTest.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
 import com.androidplot.test.*;

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 ext {
     theCompileSdkVersion = 37

--- a/demoapp-wearable/build.gradle
+++ b/demoapp-wearable/build.gradle
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 buildscript {
     repositories {

--- a/demoapp-wearable/src/main/AndroidManifest.xml
+++ b/demoapp-wearable/src/main/AndroidManifest.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.androidplot.demo.wearable" >

--- a/demoapp-wearable/src/main/java/com/androidplot/demo/wearable/MainActivity.java
+++ b/demoapp-wearable/src/main/java/com/androidplot/demo/wearable/MainActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demo.wearable;
 

--- a/demoapp-wearable/src/main/res/layout/activity_main.xml
+++ b/demoapp-wearable/src/main/res/layout/activity_main.xml
@@ -1,18 +1,4 @@
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp-wearable/src/main/res/xml/line_point_formatter_with_labels.xml
+++ b/demoapp-wearable/src/main/res/xml/line_point_formatter_with_labels.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     linePaint.strokeWidth="5dp"

--- a/demoapp-wearable/src/main/res/xml/line_point_formatter_with_labels_2.xml
+++ b/demoapp-wearable/src/main/res/xml/line_point_formatter_with_labels_2.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     linePaint.strokeWidth="5dp"

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 plugins {
     id 'com.android.application'

--- a/demoapp/src/main/AndroidManifest.xml
+++ b/demoapp/src/main/AndroidManifest.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/demoapp/src/main/java/com/androidplot/demos/AnimatedXYPlotActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/AnimatedXYPlotActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/BarPlotExampleActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/BarPlotExampleActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/BubbleChartActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/BubbleChartActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/CandlestickChartActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/CandlestickChartActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/DemoApplication.java
+++ b/demoapp/src/main/java/com/androidplot/demos/DemoApplication.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.demos;
 
 import android.app.*;

--- a/demoapp/src/main/java/com/androidplot/demos/DualScaleActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/DualScaleActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/DynamicXYPlotActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/DynamicXYPlotActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 import android.app.Activity;

--- a/demoapp/src/main/java/com/androidplot/demos/ECGExample.java
+++ b/demoapp/src/main/java/com/androidplot/demos/ECGExample.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/FXPlotExampleActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/FXPlotExampleActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2016 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/ListViewActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/ListViewActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/MainActivity.kt
+++ b/demoapp/src/main/java/com/androidplot/demos/MainActivity.kt
@@ -1,18 +1,4 @@
-/*
- * Copyright 2021 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.demos
 
 import android.app.Activity

--- a/demoapp/src/main/java/com/androidplot/demos/OrientationSensorExampleActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/OrientationSensorExampleActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/RecyclerViewActivity.kt
+++ b/demoapp/src/main/java/com/androidplot/demos/RecyclerViewActivity.kt
@@ -1,18 +1,4 @@
-/*
- * Copyright 2021 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.demos
 
 import android.app.Activity

--- a/demoapp/src/main/java/com/androidplot/demos/ScatterPlotActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/ScatterPlotActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/SimplePieChartActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/SimplePieChartActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/SimpleXYPlotActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/SimpleXYPlotActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2018 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/StepChartExampleActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/StepChartExampleActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/TimeSeriesActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/TimeSeriesActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/TouchZoomExampleActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/TouchZoomExampleActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/Util.java
+++ b/demoapp/src/main/java/com/androidplot/demos/Util.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.androidplot.demos;
 
 import android.app.*;

--- a/demoapp/src/main/java/com/androidplot/demos/XYPlotWithBgImgActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/XYPlotWithBgImgActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/XYRegionExampleActivity.java
+++ b/demoapp/src/main/java/com/androidplot/demos/XYRegionExampleActivity.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos;
 

--- a/demoapp/src/main/java/com/androidplot/demos/widget/DemoAppWidgetProvider.java
+++ b/demoapp/src/main/java/com/androidplot/demos/widget/DemoAppWidgetProvider.java
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 package com.androidplot.demos.widget;
 

--- a/demoapp/src/main/res/layout/bar_plot_example.xml
+++ b/demoapp/src/main/res/layout/bar_plot_example.xml
@@ -1,18 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<?xml version="1.0" encoding="utf-8"?><!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/bubble_chart_example.xml
+++ b/demoapp/src/main/res/layout/bubble_chart_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/candlestick_example.xml
+++ b/demoapp/src/main/res/layout/candlestick_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2016 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/demo_app_widget.xml
+++ b/demoapp/src/main/res/layout/demo_app_widget.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/demoapp/src/main/res/layout/dual_scale_example.xml
+++ b/demoapp/src/main/res/layout/dual_scale_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/dynamic_xyplot_example.xml
+++ b/demoapp/src/main/res/layout/dynamic_xyplot_example.xml
@@ -1,18 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<?xml version="1.0" encoding="utf-8"?><!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/ecg_example.xml
+++ b/demoapp/src/main/res/layout/ecg_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2016 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/fx_plot_example.xml
+++ b/demoapp/src/main/res/layout/fx_plot_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2016 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/listview_example.xml
+++ b/demoapp/src/main/res/layout/listview_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout android:id="@+id/LinearLayout01"
               android:layout_width="fill_parent"

--- a/demoapp/src/main/res/layout/listview_example_item.xml
+++ b/demoapp/src/main/res/layout/listview_example_item.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/main.xml
+++ b/demoapp/src/main/res/layout/main.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:orientation="vertical"

--- a/demoapp/src/main/res/layout/orientation_sensor_example.xml
+++ b/demoapp/src/main/res/layout/orientation_sensor_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/pie_chart.xml
+++ b/demoapp/src/main/res/layout/pie_chart.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/demoapp/src/main/res/layout/recyclerview_example.xml
+++ b/demoapp/src/main/res/layout/recyclerview_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout android:id="@+id/LinearLayout01"
               android:layout_width="fill_parent"

--- a/demoapp/src/main/res/layout/recyclerview_example_item.xml
+++ b/demoapp/src/main/res/layout/recyclerview_example_item.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <com.androidplot.xy.XYPlot xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/scatter_plot_example.xml
+++ b/demoapp/src/main/res/layout/scatter_plot_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/simple_xy_plot_example.xml
+++ b/demoapp/src/main/res/layout/simple_xy_plot_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/spinner_item.xml
+++ b/demoapp/src/main/res/layout/spinner_item.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
           android:layout_width="match_parent"
           android:layout_height="match_parent"

--- a/demoapp/src/main/res/layout/step_chart_example.xml
+++ b/demoapp/src/main/res/layout/step_chart_example.xml
@@ -1,18 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<?xml version="1.0" encoding="utf-8"?><!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/time_series_example.xml
+++ b/demoapp/src/main/res/layout/time_series_example.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/touch_zoom_example.xml
+++ b/demoapp/src/main/res/layout/touch_zoom_example.xml
@@ -1,18 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<?xml version="1.0" encoding="utf-8"?><!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/xy_plot_with_bq_img_example.xml
+++ b/demoapp/src/main/res/layout/xy_plot_with_bq_img_example.xml
@@ -1,18 +1,4 @@
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/layout/xyregion_example.xml
+++ b/demoapp/src/main/res/layout/xyregion_example.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:ap="http://schemas.android.com/apk/res-auto"

--- a/demoapp/src/main/res/values-hdpi/dimens.xml
+++ b/demoapp/src/main/res/values-hdpi/dimens.xml
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <resources>
     <dimen name="title_font_size">30dp</dimen>
     <dimen name="pie_segment_label_font_size">20dp</dimen>

--- a/demoapp/src/main/res/values/dimens.xml
+++ b/demoapp/src/main/res/values/dimens.xml
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <resources>
 
     <!-- Default screen margins, per the Android Design guidelines. -->

--- a/demoapp/src/main/res/values/strings.xml
+++ b/demoapp/src/main/res/values/strings.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <resources>
     <string name="app_name">Androidplot Demos</string>

--- a/demoapp/src/main/res/xml/bubble_formatter1.xml
+++ b/demoapp/src/main/res/xml/bubble_formatter1.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     strokePaint.color="#FFCC66"

--- a/demoapp/src/main/res/xml/bubble_formatter2.xml
+++ b/demoapp/src/main/res/xml/bubble_formatter2.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     strokePaint.color="#2255AA"

--- a/demoapp/src/main/res/xml/bubble_formatter3.xml
+++ b/demoapp/src/main/res/xml/bubble_formatter3.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     strokePaint.color="#A18459"

--- a/demoapp/src/main/res/xml/candlestick_formatter.xml
+++ b/demoapp/src/main/res/xml/candlestick_formatter.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     wickPaint.color="#000000"

--- a/demoapp/src/main/res/xml/demo_app_widget_provider_info.xml
+++ b/demoapp/src/main/res/xml/demo_app_widget_provider_info.xml
@@ -1,20 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
                     android:minWidth="@dimen/sample_widget_width"

--- a/demoapp/src/main/res/xml/line_point_formatter.xml
+++ b/demoapp/src/main/res/xml/line_point_formatter.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2016 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     linePaint.strokeWidth="5dp"

--- a/demoapp/src/main/res/xml/line_point_formatter_with_labels.xml
+++ b/demoapp/src/main/res/xml/line_point_formatter_with_labels.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     linePaint.strokeWidth="5dp"

--- a/demoapp/src/main/res/xml/line_point_formatter_with_labels_2.xml
+++ b/demoapp/src/main/res/xml/line_point_formatter_with_labels_2.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     linePaint.strokeWidth="5dp"

--- a/demoapp/src/main/res/xml/pie_segment_formatter1.xml
+++ b/demoapp/src/main/res/xml/pie_segment_formatter1.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
         fillPaint.color="#FF0000"

--- a/demoapp/src/main/res/xml/pie_segment_formatter2.xml
+++ b/demoapp/src/main/res/xml/pie_segment_formatter2.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
         fillPaint.color="#00FF00"

--- a/demoapp/src/main/res/xml/pie_segment_formatter3.xml
+++ b/demoapp/src/main/res/xml/pie_segment_formatter3.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
         fillPaint.color="#0000FF"

--- a/demoapp/src/main/res/xml/pie_segment_formatter4.xml
+++ b/demoapp/src/main/res/xml/pie_segment_formatter4.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
         fillPaint.color="#FF00FF"

--- a/demoapp/src/main/res/xml/point_formatter.xml
+++ b/demoapp/src/main/res/xml/point_formatter.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     linePaint.color="#00000000"

--- a/demoapp/src/main/res/xml/point_formatter_2.xml
+++ b/demoapp/src/main/res/xml/point_formatter_2.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright 2015 AndroidPlot.com
-  ~
-  ~    Licensed under the Apache License, Version 2.0 (the "License");
-  ~    you may not use this file except in compliance with the License.
-  ~    You may obtain a copy of the License at
-  ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~    Unless required by applicable law or agreed to in writing, software
-  ~    distributed under the License is distributed on an "AS IS" BASIS,
-  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~    See the License for the specific language governing permissions and
-  ~    limitations under the License.
-  -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 <config
     linePaint.color="#00000000"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 AndroidPlot.com
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+// SPDX-License-Identifier: Apache-2.0
 
 rootProject.name = 'androidplot'
 include 'androidplot-core'


### PR DESCRIPTION
## Summary

- **README**: project copyright notice updated from 2021 to 2026, plus a sentence explaining the SPDX tag.
- **SPDX headers**: the fifteen-line Apache boilerplate at the top of 197 source files is replaced by a single `SPDX-License-Identifier: Apache-2.0` line. The 44 source files that had no header at all get the same line. Copyright is stated once in the README; the full license text stays in `LICENSE.md`.
- `.DS_Store` added to `.gitignore`.

## Details

- CRLF line endings in the 52 files that use them are preserved.
- `attrs.xml` keeps its `NODOC` marker on the comment so the attrs docs generator continues to skip it; verified the generated `docs/attrs.md` is unaffected.
- `gradlew` / `gradlew.bat` carry Gradle's own copyright and are untouched, as is `LICENSE.md`.
- Tests, lint and debug/release builds pass.
