### PR TITLE
Fix crash when a formatter XML references a color resource

### DIFF
--- a/androidplot-core/build.gradle
+++ b/androidplot-core/build.gradle
@@ -93,7 +93,6 @@ def gitUrl = 'https://github.com/halfhp/androidplot.git'
 
 dependencies {
 
-    implementation 'com.halfhp.fig:figlib:1.0.11'
     implementation 'androidx.annotation:annotation:1.10.0'
 
     testImplementation "org.mockito:mockito-core:5.23.0"

--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -34,8 +34,8 @@ import com.androidplot.ui.widget.TextLabelWidget;
 import com.androidplot.util.AttrUtils;
 import com.androidplot.util.DisplayDimensions;
 import com.androidplot.util.PixelUtils;
-import com.halfhp.fig.Fig;
-import com.halfhp.fig.FigException;
+import com.androidplot.util.fig.Fig;
+import com.androidplot.util.fig.FigException;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;

--- a/androidplot-core/src/main/java/com/androidplot/ui/Formatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/Formatter.java
@@ -4,7 +4,7 @@ package com.androidplot.ui;
 
 import android.content.Context;
 import com.androidplot.Plot;
-import com.halfhp.fig.*;
+import com.androidplot.util.fig.*;
 
 /**
  * Base class of all Formatters.  Encapsulates visual elements of a series; line style, color etc.

--- a/androidplot-core/src/main/java/com/androidplot/util/fig/Fig.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/fig/Fig.java
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util.fig;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.content.res.XmlResourceParser;
+import android.graphics.Color;
+
+import org.xmlpull.v1.*;
+
+import java.io.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.regex.Pattern;
+
+/**
+ * Configures an object from XML by mapping attribute names onto setter methods.
+ *
+ * Originally the standalone library com.halfhp.fig:figlib (Apache 2.0, by the
+ * Androidplot author); folded into Androidplot as it is the sole consumer.
+ */
+public abstract class Fig {
+
+    private static final String CFG_ELEMENT_NAME = "config";
+    private static final String PATH_SEPARATOR = "/";
+    private static final String DOT_SEPARATOR = ".";
+    private static final String RESOURCE_ID_PREFIX = "@";
+    private static final String GETTER_PREFIX = "get";
+    private static final String SETTER_PREFIX = "set";
+    private static final String COLOR_TRANSPARENT_COMPRESSED_HEX = "#0";
+    private static final Pattern INTEGER_PATTERN = Pattern.compile("^-?\\d+$");
+    private static final String RES_TYPE_COLOR = "color";
+    private static final String RES_TYPE_DIMEN = "dimen";
+
+    /**
+     * Parse a resource id either as a raw string ref such as '@dimen/some_resource' or
+     * as a reference such as '@1234342'.
+     *
+     * @param ctx
+     * @param value
+     * @return The int resourceId corresponding to the input.
+     * @throws IllegalArgumentException If the resoureId cannot be obtained from the input.
+     */
+    private static int parseResId(Context ctx, String value) {
+        if (value.startsWith(RESOURCE_ID_PREFIX)) {
+            if (value.contains(PATH_SEPARATOR)) {
+                String[] split = value.split(PATH_SEPARATOR);
+                String pack = split[0].replace(RESOURCE_ID_PREFIX, "");
+                String name = split[1];
+                return ctx.getResources().getIdentifier(name, pack, ctx.getPackageName());
+            } else {
+                // starting with gradle tools 3.0.1, it appears that dimen refs are now inlined
+                // at compile time using the form '@intRef'
+                return Integer.parseInt(value.substring(1));
+            }
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Treats value as an int parameter.  It may be a plain integer, a resource reference such
+     * as '@color/foo' or '@2131034163' (the compiled form AAPT emits for references in res/xml
+     * files), or a color in one of the forms accepted by {@link Color#parseColor(String)}.
+     */
+    private static int parseIntAttr(Context ctx, String value) {
+        if (INTEGER_PATTERN.matcher(value).matches()) {
+            return Integer.parseInt(value);
+        } else if (value.startsWith(RESOURCE_ID_PREFIX)) {
+            return resolveIntResource(ctx, value);
+        } else {
+            // it's a hex val
+            if (value.equalsIgnoreCase(COLOR_TRANSPARENT_COMPRESSED_HEX)) {
+                // for some reason, since gradle tools 3.x.x #00000000 gets
+                // converted to #0.
+                return Color.TRANSPARENT;
+            } else {
+                // value starts with a non-digit char so its either a color, or an invalid value
+                return Color.parseColor(value);
+            }
+        }
+    }
+
+    /**
+     * Resolves a resource reference to an int according to the resource's type: colors yield
+     * the color value, dimensions the pixel size, and anything else is read as an integer.
+     */
+    @SuppressWarnings("deprecation") // Resources.getColor(int): minSdk predates the themed variant
+    private static int resolveIntResource(Context ctx, String value) {
+        final Resources res = ctx.getResources();
+        final int resId = parseResId(ctx, value);
+        final String type;
+        try {
+            type = res.getResourceTypeName(resId);
+        } catch (Resources.NotFoundException e) {
+            throw new IllegalArgumentException("Unable to resolve resource reference: " + value, e);
+        }
+        if (RES_TYPE_COLOR.equals(type)) {
+            return res.getColor(resId);
+        } else if (RES_TYPE_DIMEN.equals(type)) {
+            return res.getDimensionPixelSize(resId);
+        } else {
+            return res.getInteger(resId);
+        }
+    }
+
+    /**
+     * Treats value as a float parameter.  First value is tested to see whether
+     * it contains a resource identifier.  Failing that, it is tested to see whether
+     * a dimension suffix (dp, em, mm etc.) exists.  Failing that, it is evaluated as
+     * a plain old float.
+     *
+     * @param ctx
+     * @param value
+     * @return
+     */
+    private static float parseFloatAttr(Context ctx, String value) {
+        try {
+            return ctx.getResources().getDimension(parseResId(ctx, value));
+        } catch (IllegalArgumentException e1) {
+            try {
+                return FigUtils.stringToDimension(ctx, value);
+            } catch (Exception e2) {
+                return Float.parseFloat(value);
+            }
+        }
+    }
+
+    private static String parseStringAttr(Context ctx, String value) {
+        try {
+            return ctx.getResources().getString(parseResId(ctx, value));
+        } catch (IllegalArgumentException e1) {
+            return value;
+        }
+    }
+
+    private static Method getMethodByName(Class clazz, final String methodName)
+            throws NoSuchMethodException {
+        final Method[] methods = clazz.getMethods();
+        for (Method method : methods) {
+            if (method.getName().equalsIgnoreCase(methodName)) {
+                return method;
+            }
+        }
+        throw new NoSuchMethodException("No such public method (case insensitive): " +
+                methodName + " in " + clazz);
+    }
+
+
+    private static Method getSetter(Class clazz, final String fieldId) throws NoSuchMethodException {
+        return getMethodByName(clazz, SETTER_PREFIX + fieldId);
+    }
+
+    private static Method getGetter(Class clazz, final String fieldId) throws NoSuchMethodException {
+        return getMethodByName(clazz, GETTER_PREFIX + fieldId);
+    }
+
+    /**
+     * Returns the object containing the field specified by path.
+     *
+     * @param obj
+     * @param path Path through member hierarchy to the destination field.
+     * @return null if the object at path cannot be found.
+     * @throws java.lang.reflect.InvocationTargetException
+     * @throws IllegalAccessException
+     */
+    static Object getObjectContaining(Object obj, String path) throws
+            InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        if (obj == null) {
+            throw new NullPointerException("Attempt to call getObjectContaining(...) " +
+                    "on a null Object instance.  Path was: " + path);
+        }
+        int separatorIndex = path.indexOf(DOT_SEPARATOR);
+        if (separatorIndex > 0) {
+            String lhs = path.substring(0, separatorIndex);
+            String rhs = path.substring(separatorIndex + 1, path.length());
+            Method m = getGetter(obj.getClass(), lhs);
+            if (m == null) {
+                throw new NoSuchMethodException("No getter found for field: " + lhs + " within " + obj.getClass());
+            }
+            Object o = m.invoke(obj);
+            return getObjectContaining(o, rhs);
+        } else {
+            return obj;
+        }
+    }
+
+    private static Object[] inflateParams(Context ctx, Class[] params, String[] vals) throws NoSuchMethodException,
+            InvocationTargetException, IllegalAccessException {
+        Object[] out = new Object[params.length];
+        int i = 0;
+        for (Class param : params) {
+            if (Enum.class.isAssignableFrom(param)) {
+                out[i] = param.getMethod("valueOf", String.class).invoke(null, vals[i].toUpperCase());
+            } else if (param.equals(Float.TYPE) || param == Float.class) {
+                out[i] = parseFloatAttr(ctx, vals[i]);
+            } else if (param.equals(Integer.TYPE) || param == Integer.class) {
+                out[i] = parseIntAttr(ctx, vals[i]);
+            } else if (param.equals(Boolean.TYPE) || param == Boolean.class) {
+                out[i] = Boolean.valueOf(vals[i]);
+            } else if (param.equals(String.class)) {
+                out[i] = parseStringAttr(ctx, vals[i]);
+            } else {
+                throw new IllegalArgumentException("Error inflating XML: Setter requires param of unsupported type: " + param);
+            }
+            i++;
+        }
+        return out;
+    }
+
+    /**
+     * Configure from a File.
+     *
+     * @param ctx
+     * @param obj  The object to be configured
+     * @param file The file containing the config xml.
+     * @throws FigException
+     */
+    public static void configure(Context ctx, Object obj, File file) throws FigException {
+
+        try {
+            XmlPullParserFactory xppf = XmlPullParserFactory.newInstance();
+            xppf.setNamespaceAware(true);
+            XmlPullParser xpp = xppf.newPullParser();
+            FileInputStream fis = new FileInputStream(file);
+            xpp.setInput(fis, null);
+            configure(ctx, obj, xpp);
+        } catch (FileNotFoundException e) {
+            throw new FigException("Failed to open file for parsing", e);
+        } catch (XmlPullParserException e) {
+            throw new FigException("Error while parsing file", e);
+        }
+    }
+
+    /**
+     * @param ctx
+     * @param obj
+     * @param params
+     * @throws FigException
+     */
+    public static void configure(Context ctx, Object obj, HashMap<String, String> params) throws FigException {
+        for (String key : params.keySet()) {
+            configure(ctx, obj, key, params.get(key));
+        }
+    }
+
+    /**
+     * @param ctx
+     * @param obj
+     * @param xrp
+     * @throws FigException
+     */
+    private static void configure(Context ctx, Object obj, XmlPullParser xrp) throws FigException {
+        try {
+            HashMap<String, String> params = new HashMap<>();
+            while (xrp.getEventType() != XmlResourceParser.END_DOCUMENT) {
+                xrp.next();
+                String name = xrp.getName();
+                if (xrp.getEventType() == XmlResourceParser.START_TAG) {
+                    if (name.equalsIgnoreCase(CFG_ELEMENT_NAME))
+                        for (int i = 0; i < xrp.getAttributeCount(); i++) {
+                            final String attrName = xrp.getAttributeName(i);
+                            final String attrVal = xrp.getAttributeValue(i);
+                            params.put(attrName, attrVal);
+                        }
+                    break;
+                }
+            }
+            configure(ctx, obj, params);
+        } catch (XmlPullParserException e) {
+            throw new FigException("Error while parsing XML configuration", e);
+        } catch (IOException e) {
+            throw new FigException("Error while parsing XML configuration", e);
+        }
+    }
+
+    /**
+     * Configure from a res/xml resource
+     *
+     * @param ctx
+     * @param obj       The object to be configured
+     * @param xmlFileId ID of an XML config file in /res/xml
+     * @throws FigException
+     */
+    public static void configure(Context ctx, Object obj, int xmlFileId) throws FigException {
+        XmlResourceParser xrp = ctx.getResources().getXml(xmlFileId);
+        try {
+            configure(ctx, obj, xrp);
+        } finally {
+            xrp.close();
+        }
+    }
+
+    /**
+     * Recursively descend into an object using key as the pathway and invoking the corresponding setter
+     * if one exists.
+     *
+     * @param key
+     * @param value
+     * @throws FigException
+     */
+    private static void configure(Context ctx, Object obj, String key, String value) throws FigException {
+        try {
+            Object o = getObjectContaining(obj, key);
+            if (o != null) {
+                int idx = key.lastIndexOf(DOT_SEPARATOR);
+                String fieldId = idx > 0 ? key.substring(idx + 1, key.length()) : key;
+
+                Method m = getSetter(o.getClass(), fieldId);
+                Class[] paramTypes = m.getParameterTypes();
+                // TODO: add support for generic type params
+                if (paramTypes.length >= 1) {
+
+                    // split on "|"
+                    // TODO: add support for String args containing a '|'
+                    String[] paramStrs = value.split("\\|");
+                    if (paramStrs.length == paramTypes.length) {
+                        Object[] oa = inflateParams(ctx, paramTypes, paramStrs);
+                        m.invoke(o, oa);
+                    } else {
+                        throw new IllegalArgumentException("Error inflating XML: Unexpected number of argments passed to \""
+                                + m.getName() + "\".  Expected: " + paramTypes.length + " Got: " + paramStrs.length);
+                    }
+                } else {
+                    // this is not a setter
+                    throw new IllegalArgumentException("Error inflating XML: no setter method found for param \"" +
+                            fieldId + "\".");
+                }
+            }
+        } catch (IllegalAccessException e) {
+            throw new FigException("Error while parsing key: " + key + " value: " + value, e);
+        } catch (InvocationTargetException e) {
+            throw new FigException("Error while parsing key: " + key + " value: " + value, e);
+        } catch (NoSuchMethodException e) {
+            throw new FigException("Error while parsing key: " + key + " value: " + value, e);
+        }
+    }
+}
+

--- a/androidplot-core/src/main/java/com/androidplot/util/fig/FigException.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/fig/FigException.java
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util.fig;
+
+public class FigException extends Exception {
+
+    public FigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/androidplot-core/src/main/java/com/androidplot/util/fig/FigUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/fig/FigUtils.java
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util.fig;
+
+import android.content.*;
+import android.util.*;
+
+import java.util.*;
+import java.util.regex.*;
+
+/**
+ * Utilities used by {@link Fig}.
+ */
+abstract class FigUtils {
+
+    protected static final String DIMENSION_REGEX = "^\\-?\\s*(\\d+(\\.\\d+)*)\\s*([a-zA-Z]+)\\s*$";
+    protected static final Pattern DIMENSION_PATTERN = Pattern.compile(DIMENSION_REGEX);
+
+    /**
+     *
+     * CODE BELOW IS ADAPTED IN PART FROM MINDRIOT'S SAMPLE CODE HERE:
+     * http://stackoverflow.com/questions/8343971/how-to-parse-a-dimension-string-and-convert-it-to-a-dimension-value
+     */
+    // Initialize dimension string to constant lookup.
+    public static final Map<String, Integer> dimensionConstantLookup = initDimensionConstantLookup();
+
+    private static Map<String, Integer> initDimensionConstantLookup() {
+        Map<String, Integer> m = new HashMap<String, Integer>();
+        m.put("px", TypedValue.COMPLEX_UNIT_PX);
+        m.put("dip", TypedValue.COMPLEX_UNIT_DIP);
+        m.put("dp", TypedValue.COMPLEX_UNIT_DIP);
+        m.put("sp", TypedValue.COMPLEX_UNIT_SP);
+        m.put("pt", TypedValue.COMPLEX_UNIT_PT);
+        m.put("in", TypedValue.COMPLEX_UNIT_IN);
+        m.put("mm", TypedValue.COMPLEX_UNIT_MM);
+        return Collections.unmodifiableMap(m);
+    }
+
+    private static class InternalDimension {
+        float value;
+        int unit;
+
+        public InternalDimension(float value, int unit) {
+            this.value = value;
+            this.unit = unit;
+        }
+    }
+
+    public static float stringToDimension(Context context, String dimension) {
+        // Mimics TypedValue.complexToDimension(int data, DisplayMetrics metrics).
+        InternalDimension internalDimension = stringToInternalDimension(dimension);
+        return TypedValue.applyDimension(internalDimension.unit,
+                internalDimension.value, context.getResources().getDisplayMetrics());
+    }
+
+    private static InternalDimension stringToInternalDimension(String dimension) {
+        // Match target against pattern.
+        Matcher matcher = DIMENSION_PATTERN.matcher(dimension);
+        if (matcher.matches()) {
+            // Match found; extract value.
+            float value = Float.valueOf(matcher.group(1));
+            // Extract dimension units.
+            String unit = matcher.group(3).toLowerCase();
+            // Get Android dimension constant.
+            Integer dimensionUnit = dimensionConstantLookup.get(unit);
+            if (dimensionUnit == null) {
+                // Invalid format.
+                throw new NumberFormatException();
+            } else {
+                // Return valid dimension.
+                return new InternalDimension(value, dimensionUnit);
+            }
+        } else {
+            // Invalid format.
+            throw new NumberFormatException();
+        }
+    }
+}

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYRegionFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYRegionFormatter.java
@@ -5,7 +5,7 @@ package com.androidplot.xy;
 import android.content.Context;
 import android.graphics.Paint;
 
-import com.halfhp.fig.*;
+import com.androidplot.util.fig.*;
 
 /**
  * Base class of all XYRegionFormatters.

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -8,7 +8,7 @@ import android.util.*;
 
 import com.androidplot.test.*;
 import com.androidplot.ui.*;
-import com.halfhp.fig.*;
+import com.androidplot.util.fig.*;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;

--- a/androidplot-core/src/test/java/com/androidplot/util/fig/FigTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/fig/FigTest.java
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util.fig;
+
+import android.graphics.Color;
+
+import com.androidplot.test.AndroidplotTest;
+
+import org.junit.Test;
+import org.robolectric.RuntimeEnvironment;
+
+import java.io.*;
+import java.net.*;
+import java.util.HashMap;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+public class FigTest extends AndroidplotTest {
+
+    class A {
+        private int d = 0;
+        private float f = 0;
+        private float p = 0;
+        private boolean aBooleanPrimitive;
+
+        public int getD() {
+            return d;
+        }
+
+        public void setD(int d) {
+            this.d = d;
+        }
+
+        public boolean isaBooleanPrimitive() {
+            return aBooleanPrimitive;
+        }
+
+        public void setaBooleanPrimitive(boolean aBooleanPrimitive) {
+            this.aBooleanPrimitive = aBooleanPrimitive;
+        }
+
+        public float getF() {
+            return f;
+        }
+
+        public void setF(float f) {
+            this.f = f;
+        }
+
+        public float getP() {
+            return p;
+        }
+
+        public void setP(float p) {
+            this.p = p;
+        }
+    }
+
+    class B {
+        private A a = new A();
+
+        public A getA() {
+            return a;
+        }
+
+        public void setA(A a) {
+            this.a = a;
+        }
+    }
+
+    class C {
+        private B b = new B();
+
+        public B getB() {
+            return b;
+        }
+
+        public void setB(B a) {
+            this.b = b;
+        }
+    }
+
+    @Test
+    public void testGetFieldAt() throws Exception {
+        C c = new C();
+        assertEquals(c, Fig.getObjectContaining(c, "b"));
+        assertEquals(c.getB(), Fig.getObjectContaining(c, "b.a"));
+        assertEquals(c.getB().getA(), Fig.getObjectContaining(c, "b.a.d"));
+    }
+
+    @Test
+    public void testConfigure() throws Exception {
+        C c = new C();
+        assertFalse(c.getB().getA().isaBooleanPrimitive());
+        assertEquals(0, c.getB().getA().getD());
+
+        // load xml config and verify:
+        File f = getFileFromPath("c_config.xml");
+        Fig.configure(RuntimeEnvironment.application, c, f);
+
+        assertTrue(c.getB().getA().isaBooleanPrimitive());
+        assertEquals(99, c.getB().getA().getD());
+        assertEquals(2f, c.getB().getA().getF());
+        assertEquals(6.6666665f, c.getB().getA().getP());
+    }
+
+    /**
+     * Regression test for https://github.com/halfhp/androidplot/issues/88: an int attribute
+     * given as a compiled color resource reference (the '@<id>' form AAPT emits for
+     * '@color/foo' in res/xml) must resolve to the color value rather than crash.
+     */
+    @Test
+    public void testConfigure_intFromColorResourceReference() throws Exception {
+        A a = new A();
+        HashMap<String, String> params = new HashMap<>();
+        params.put("d", "@" + android.R.color.black);
+        Fig.configure(RuntimeEnvironment.application, a, params);
+        assertEquals(Color.BLACK, a.getD());
+    }
+
+    @Test
+    public void testConfigure_intFromIntegerResourceReference() throws Exception {
+        A a = new A();
+        HashMap<String, String> params = new HashMap<>();
+        params.put("d", "@" + android.R.integer.config_shortAnimTime);
+        Fig.configure(RuntimeEnvironment.application, a, params);
+        assertEquals(RuntimeEnvironment.application.getResources()
+                .getInteger(android.R.integer.config_shortAnimTime), a.getD());
+    }
+
+    @Test
+    public void testConfigure_intFromHexColor() throws Exception {
+        A a = new A();
+        HashMap<String, String> params = new HashMap<>();
+        params.put("d", "#FF00AA00");
+        Fig.configure(RuntimeEnvironment.application, a, params);
+        assertEquals(0xFF00AA00, a.getD());
+    }
+
+    @Test
+    public void testConfigure_negativeInt() throws Exception {
+        A a = new A();
+        HashMap<String, String> params = new HashMap<>();
+        params.put("d", "-7");
+        Fig.configure(RuntimeEnvironment.application, a, params);
+        assertEquals(-7, a.getD());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConfigure_unresolvableResourceReference() throws Exception {
+        A a = new A();
+        HashMap<String, String> params = new HashMap<>();
+        params.put("d", "@color/does_not_exist");
+        Fig.configure(RuntimeEnvironment.application, a, params);
+    }
+
+    private File getFileFromPath(String fileName) {
+        ClassLoader classLoader = getClass().getClassLoader();
+        URL resource = classLoader.getResource(fileName);
+        return new File(resource.getPath());
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
@@ -5,7 +5,7 @@ package com.androidplot.xy;
 import android.graphics.*;
 import com.androidplot.Plot;
 import com.androidplot.test.AndroidplotTest;
-import com.halfhp.fig.*;
+import com.androidplot.util.fig.*;
 
 import org.junit.After;
 import org.junit.Before;

--- a/androidplot-core/src/test/resources/c_config.xml
+++ b/androidplot-core/src/test/resources/c_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<config b.a.aBooleanPrimitive="true"
+        b.a.d="99"
+        b.a.f="2dp"
+        b.a.p="3pt"/>

--- a/demoapp/src/main/res/values/colors.xml
+++ b/demoapp/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<resources>
+    <color name="line_point_formatter_line">#00AA00</color>
+</resources>

--- a/demoapp/src/main/res/xml/line_point_formatter.xml
+++ b/demoapp/src/main/res/xml/line_point_formatter.xml
@@ -3,6 +3,6 @@
 
 <config
     linePaint.strokeWidth="5dp"
-    linePaint.color="#00AA00"
+    linePaint.color="@color/line_point_formatter_line"
     vertexPaint.color="#00000000"
     fillPaint.color="#00000000"/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,8 @@ Source code examples of the various plot types.
 * [f(x) Plot](../demoapp/src/main/java/com/androidplot/demos/FXPlotExampleActivity.java)
 
 # XML Attributes
-A complete list of XML attributes is [available here](attrs.md).
+A complete list of XML attributes is [available here](attrs.md).  Formatters and plots can also be
+styled through property paths, described in [XML Configuration](xml_configuration.md).
 # Javadoc
 Javadocs for versions through 1.5.7 are [available here](https://javadoc.io/doc/com.androidplot/androidplot-core).  Due to a build issue
 producing Javadocs for the latest releases has been paused.  There have been very

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -64,7 +64,7 @@ This example uses a default style to decorate the plot.  The full list of XML st
 [available here](attrs.md).  While new attributes are added regularly,
 not all configurable properties are yet available.  
 
-If something you need is missing, use [Fig Syntax](https://github.com/halfhp/fig)
+If something you need is missing, use the [XML configuration syntax](xml_configuration.md)
 directly within your Plot's XML, prefixing each property with "androidPlot".  Example:
 
 ```xml

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -195,7 +195,7 @@ public class SimpleXYPlotActivity extends Activity {
 
 One potentially confusing section of the code above are the initializations of LineAndPointFormatter   
 You probably noticed that they take a mysterious reference to an xml resource file. This is actually 
-using [Fig](https://github.com/halfhp/fig) to configure the instance properties from XML.  
+using [XML configuration](xml_configuration.md) to configure the instance properties from XML.  
 
 If you'd prefer to avoid the XML and keep everything in Java, just replace the code:
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,15 @@
 For details on what to expect in general when updating to a new version of Androiplot, check out the
 [versioning doc](versioning.md).
 
+# 1.5.12
+* (#88) Fix crash when a formatter config or `androidPlot.` attribute references a color, dimension
+  or integer resource.  Negative integer values are now accepted as well.
+* The XML configuration engine (formerly the separate Fig library) is now part of androidplot-core;
+  the library no longer has a dependency on `com.halfhp.fig:figlib`.  See the new
+  [XML Configuration](xml_configuration.md) doc.
+* Compile and target SDK 37; build updated to AGP 9.4 / Gradle 9.7 / Kotlin 2.2.
+* Snapshot builds of unreleased changes are now published to the Central snapshots repository.
+
 # 1.5.11
 * Update project to latest gradle / build tools
 * Fix issue with jetifier flagging an outdated dependency

--- a/docs/xml_configuration.md
+++ b/docs/xml_configuration.md
@@ -1,0 +1,83 @@
+# XML Configuration
+
+Androidplot lets you style formatters and plots from XML by mapping attribute names onto the
+setter methods of the object being configured.  This is the mechanism behind formatter config files
+such as `R.xml.line_point_formatter` and the `androidPlot.` prefixed attributes usable in layouts.
+
+# Formatter Config Files
+Place a config file in your `/res/xml` directory and pass its id to a formatter's constructor:
+
+**/res/xml/line_point_formatter.xml**
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<config
+    linePaint.strokeWidth="5dp"
+    linePaint.color="@color/plot_line"
+    vertexPaint.color="#007700"
+    fillPaint.color="#00000000"/>
+```
+
+```java
+LineAndPointFormatter formatter = new LineAndPointFormatter(this, R.xml.line_point_formatter);
+```
+
+Because they are ordinary resources, config files can be qualified by screen size, density,
+orientation and so on using the standard resource directory conventions.
+
+# Property Paths
+Each attribute name is a path of JavaBean properties, separated by dots, ending in the property
+to set.  Every segment except the last must have a getter; the last must have a setter.  Matching
+is case insensitive.
+
+```xml
+linePaint.strokeWidth="5dp"
+```
+
+is equivalent to:
+
+```java
+formatter.getLinePaint().setStrokeWidth(...);
+```
+
+Any property reachable this way can be configured, not just the ones Androidplot documents.
+
+# Values
+Values are converted according to the type of the setter's parameter.
+
+| Setter parameter | Accepted values |
+|---|---|
+| `int` | A plain integer such as `3` or `-1`; a color such as `#00AA00`, `#FF00AA00` or `red`; or a resource reference such as `@color/plot_line`, `@dimen/marker_size` or `@integer/max_points`. Color references yield the color value, dimension references the size in pixels. |
+| `float` | A dimension with units such as `5dp`, `12sp`, `2mm`; a `@dimen` reference; or a plain float. Prefer `dp` and `sp` so sizes scale consistently across devices. |
+| `boolean` | `true` or `false`. |
+| `String` | A literal, or a `@string` reference. |
+| enum | The constant's name, case insensitive, for example `fillDirection="bottom"`. |
+
+Setters taking more than one parameter are given the values separated by `|`, in order:
+
+```xml
+ap:lineLabels="left|bottom"
+```
+
+# Configuring Plots From Layout XML
+The `Plot` styleable attributes listed in the [XML attributes reference](attrs.md) cover the most
+commonly used properties.  For anything not yet available as a dedicated attribute, the same
+property-path syntax can be used directly in the layout by prefixing it with `androidPlot.`:
+
+```xml
+<com.androidplot.xy.XYPlot
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    androidPlot.title="My Plot"
+    androidPlot.graph.domainGridLinePaint.color="#33FFFFFF"/>
+```
+
+# Obfuscation
+Configuration relies on reflection over method names, so classes configured this way must keep
+their members intact through ProGuard or R8.  Androidplot's own classes are covered by the rule
+from the [quickstart](quickstart.md):
+
+```
+-keep class com.androidplot.** { *; }
+```
+
+If you configure your own classes through this mechanism, add an equivalent rule for them.


### PR DESCRIPTION
Fixes #88

## Cause

Formatter XML such as `linePaint.color="@color/accent_blue"` crashed with `IllegalArgumentException: Unknown color`. AAPT2 compiles that reference to the form `@2131034163`, and Fig's `parseIntAttr` passed any value starting with `@` straight to `Color.parseColor`, which only understands hex and named colors. The 2019 comment on the issue said this would be fixed in Fig for 1.5.8, but the fix never landed: figlib 1.0.11 on Maven Central still has the bug.

## Fix

- `parseIntAttr` now resolves `@` values as resource references and reads them by resource type: `color` yields the color value, `dimen` the pixel size, anything else the integer. Both the compiled `@<id>` form and the `@color/name` string form are handled.
- Negative integers are now accepted too; they previously fell through to `Color.parseColor` as well.
- An unresolvable reference throws an `IllegalArgumentException` naming the value, instead of the opaque "Unknown color".

## Fig folded into androidplot-core

Fig (`com.halfhp.fig:figlib`) is a three-file library by the same author whose only known consumer is Androidplot, and whose publishing pipeline is defunct. Its sources and test now live in `com.androidplot.util.fig`, under the SPDX header. Callers in `Plot`, `Formatter` and `XYRegionFormatter` are rewired, and the external dependency is gone from the published POM, which now lists only `androidx.annotation`. Nothing in Androidplot's public API exposed Fig types.

## Documentation

- New `docs/xml_configuration.md` describes the property-path syntax, accepted value types (including resource references), the `androidPlot.` layout prefix, and the ProGuard requirement. Adapted from Fig's README in Androidplot terms.
- The quickstart's two links to the external Fig repo now point at that page; the index links it from the XML Attributes section.
- `docs/release_notes.md` gains a 1.5.12 entry covering this fix, the Fig merge, the SDK 37 toolchain and snapshot publishing.

## Verification

- New `FigTest` cases cover a color reference, an integer reference, hex color, negative int and an unresolvable reference. The reference cases fail on the old logic and pass on the fix (checked both ways).
- Fig's original `FigTest` cases pass after the move.
- Full suite: 211 tests, 0 failures. Lint, coverage report, core release AAR and demoapp debug build all pass.
- The demoapp's `line_point_formatter.xml` now references a color resource, and `aapt2 dump xmltree` confirms it compiles to a reference. It's used by the Animated XY Plot and FX Plot examples, so those screens act as a live regression check.
