### PR TITLE
Fix clicks on pie segments larger than half the pie

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/pie/PieRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/PieRenderer.java
@@ -299,14 +299,11 @@ public class PieRenderer extends SeriesRenderer<PieChart, Segment, SegmentFormat
             offset += sweep;
             offset = offset % FULL_PIE_DEGS;
 
-            final double dist = signedDistance(offset, angle);
-            double endDist = signedDistance(offset, lastOffset);
-            if(endDist < 0) {
-                // segment accounts for more than 50% of the pie and wrapped around
-                // need to correct:
-                endDist = FULL_PIE_DEGS + endDist;
-            }
-            if(dist > 0 && dist <= endDist) {
+            // segments are drawn clockwise from lastOffset, so the point is inside this segment
+            // if its clockwise angular distance from the segment's start is less than the sweep.
+            // Unlike a shortest-path distance this holds for segments larger than a half pie.
+            final double distFromStart = clockwiseDistance(lastOffset, angle);
+            if (distFromStart < sweep) {
                 return sfPair.getSeries();
             }
             i++;
@@ -328,6 +325,14 @@ public class PieRenderer extends SeriesRenderer<PieChart, Segment, SegmentFormat
         } else {
             return degs;
         }
+    }
+
+    /**
+     * Compute the clockwise angular distance in screen degrees from {@code fromAngle} to
+     * {@code toAngle}.  The result is always in the range 0 (inclusive) to 360 (exclusive).
+     */
+    protected static double clockwiseDistance(double fromAngle, double toAngle) {
+        return ((toAngle - fromAngle) % FULL_PIE_DEGS + FULL_PIE_DEGS) % FULL_PIE_DEGS;
     }
 
     /**

--- a/androidplot-core/src/test/java/com/androidplot/pie/PieRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/pie/PieRendererTest.java
@@ -175,6 +175,47 @@ public class PieRendererTest extends AndroidplotTest {
         assertEquals(segment1, renderer.getContainingSegment(new PointF(100, 0)));
     }
 
+    /**
+     * Regression test for https://github.com/halfhp/androidplot/issues/118: with values 8, 1, 1
+     * the first segment sweeps 288 degrees clockwise from east; the region just past its start
+     * (first quadrant) and the region just before its end must both hit it.
+     */
+    @Test
+    public void getContainingSegment_hitsWholeOfSegmentLargerThanHalfPie() throws Exception {
+        Segment big = spy(new Segment("big", 8));
+        Segment small1 = spy(new Segment("small1", 1));
+        Segment small2 = spy(new Segment("small2", 1));
+        SegmentFormatter formatter = spy(
+                new SegmentFormatter(Color.GREEN, Color.GREEN, Color.GREEN, Color.GREEN));
+        PieRenderer renderer = formatter.getRendererInstance(pieChart);
+
+        pieChart.addSegment(big, formatter);
+        pieChart.addSegment(small1, formatter);
+        pieChart.addSegment(small2, formatter);
+
+        // screen angle 0 is east, increasing clockwise (south is 90).
+        // big spans 0..288, small1 288..324, small2 324..360.
+        RectF area = pieChart.getPie().getWidgetDimensions().marginatedRect;
+        PointF origin = new PointF(area.centerX(), area.centerY());
+        assertEquals(big, renderer.getContainingSegment(atScreenDegs(origin, 1)));
+        assertEquals(big, renderer.getContainingSegment(atScreenDegs(origin, 45)));
+        assertEquals(big, renderer.getContainingSegment(atScreenDegs(origin, 90)));
+        assertEquals(big, renderer.getContainingSegment(atScreenDegs(origin, 180)));
+        assertEquals(big, renderer.getContainingSegment(atScreenDegs(origin, 270)));
+        assertEquals(big, renderer.getContainingSegment(atScreenDegs(origin, 287)));
+        assertEquals(small1, renderer.getContainingSegment(atScreenDegs(origin, 289)));
+        assertEquals(small1, renderer.getContainingSegment(atScreenDegs(origin, 323)));
+        assertEquals(small2, renderer.getContainingSegment(atScreenDegs(origin, 325)));
+        assertEquals(small2, renderer.getContainingSegment(atScreenDegs(origin, 359)));
+    }
+
+    /** A point 40px from origin at the given screen angle (clockwise from east). */
+    private static PointF atScreenDegs(PointF origin, double degs) {
+        double rad = Math.toRadians(degs);
+        return new PointF((float) (origin.x + 40 * Math.cos(rad)),
+                (float) (origin.y + 40 * Math.sin(rad)));
+    }
+
     @Test
     public void testDegsToScreenDegs() throws Exception {
         assertEquals(0f, PieRenderer.degsToScreenDegs(0));

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,8 @@ For details on what to expect in general when updating to a new version of Andro
 [versioning doc](versioning.md).
 
 # 1.5.12
+* (#118) Fix pie chart segments larger than half the pie not responding to clicks over part of
+  their area.
 * (#88) Fix crash when a formatter config or `androidPlot.` attribute references a color, dimension
   or integer resource.  Negative integer values are now accepted as well.
 * The XML configuration engine (formerly the separate Fig library) is now part of androidplot-core;


### PR DESCRIPTION
Fixes #118

## Cause

`PieRenderer.getContainingSegment` located the clicked segment using `signedDistance`, which returns the shortest angular path between two angles and is therefore capped at 180 degrees. For a segment sweeping more than 180 degrees, a click in the part of the segment nearest its start measures as lying "behind" the segment's end and is rejected. With values 8, 1, 1 the first segment sweeps 288 degrees, and clicks in roughly its first 108 degrees returned no segment. The reporter's diagnosis pointed at exactly this calculation.

## Fix

Segments are drawn clockwise from their start angle, so a point is inside a segment when its clockwise distance from the segment's start is less than the sweep. A new `clockwiseDistance` helper computes that in the 0 to 360 range, and the containment check uses it. The old `signedDistance` is left in place since it's a protected static that subclasses may use, but it is no longer involved in hit-testing.

## Verification

- New `PieRendererTest` case builds the 8/1/1 pie from the report and probes ten angles across all three segments, including one degree past the big segment's start and one degree either side of each boundary. It fails on the old code at the first probe and passes on the fix.
- Existing hit-test cases, including the one for a 51 percent segment, still pass.
- Full suite: 212 tests, 0 failures. Lint, core release AAR and demoapp debug build pass.
- Release note added under 1.5.12.
