### PR TITLE
Fix background-mode plot never rendering after a zero-sized layout; rework the render loop

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -173,10 +173,91 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     private RegistryType registry;
     private final ArrayList<PlotListener> listeners;
 
-    private Thread renderThread;
-    // both guarded by renderSync
-    private boolean keepRunning = false;
-    private boolean redrawRequested = false;
+    // the current render thread, if any.  Replaced under renderSync; read without the lock
+    // where only a best-effort check is needed.
+    private volatile RenderThread renderThread;
+    /**
+     * Renders the plot into {@link #pingPong} whenever a redraw is requested.  Each instance owns
+     * its own stop flag, so stopping a thread that is being replaced (eg. a quick detach and
+     * re-attach in a RecyclerView) cannot affect its successor, and an exiting thread only tears
+     * down shared state if it is still the plot's current thread.
+     */
+    private class RenderThread extends Thread {
+        // both guarded by renderSync
+        private boolean keepRunning = true;
+        private boolean redrawRequested = false;
+
+        RenderThread() {
+            super("Androidplot renderThread");
+        }
+
+        void requestRedraw() {
+            synchronized (renderSync) {
+                redrawRequested = true;
+                renderSync.notify();
+            }
+        }
+
+        void requestStop() {
+            synchronized (renderSync) {
+                keepRunning = false;
+                renderSync.notify();
+            }
+        }
+
+        /** @return true if this thread has been asked to stop and will not render again. */
+        boolean isStopping() {
+            synchronized (renderSync) {
+                return !keepRunning;
+            }
+        }
+
+        @Override
+        public void run() {
+            System.out.println("Thread started with id " + Plot.this.hashCode());
+            while (true) {
+                // lock order: pingPong, then this (inside renderOnCanvas).  onSizeChanged
+                // takes the same locks in the same order.
+                synchronized (pingPong) {
+                    Canvas c = pingPong.getCanvas();
+                    renderOnCanvas(c);
+                    pingPong.swap();
+                }
+                postInvalidate();
+
+                // sleep until the next redraw request.  Requests made while rendering are
+                // remembered in redrawRequested rather than dropped, so the loop immediately
+                // renders again with the latest data; several requests coalesce into one pass.
+                synchronized (renderSync) {
+                    while (keepRunning && !redrawRequested) {
+                        try {
+                            renderSync.wait();
+                        } catch (InterruptedException e) {
+                            // prevent this thread from becoming an orphan
+                            // after the view is destroyed
+                            keepRunning = false;
+                        }
+                    }
+                    if (!keepRunning) {
+                        break;
+                    }
+                    redrawRequested = false;
+                }
+            }
+            System.out.println("Thread exited with id " + Plot.this.hashCode());
+
+            // release the buffers, but only if no replacement thread has taken over in the
+            // meantime; otherwise they now belong to it.
+            synchronized (pingPong) {
+                synchronized (renderSync) {
+                    if (renderThread == this) {
+                        renderThread = null;
+                        pingPong.recycle();
+                    }
+                }
+            }
+        }
+    }
 
     {
         listeners = new ArrayList<>();
@@ -411,53 +492,16 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
         }
     }
 
+    /**
+     * Creates the render thread if the plot does not currently have one.  The thread is not
+     * started here; that happens once the view has a size.
+     */
     protected void startBackgroundRendering() {
-        if(renderThread != null) {
-            return;
+        synchronized (renderSync) {
+            if (renderThread == null || renderThread.isStopping()) {
+                renderThread = new RenderThread();
+            }
         }
-
-        renderThread = new Thread(() -> {
-            System.out.println("Thread started with id " + this.hashCode());
-
-            synchronized (renderSync) {
-                keepRunning = true;
-                // the first pass below renders unconditionally, which satisfies any request
-                // made before the thread started.
-                redrawRequested = false;
-            }
-            while (true) {
-                // lock order: pingPong, then this (inside renderOnCanvas).  onSizeChanged
-                // takes the same locks in the same order.
-                synchronized (pingPong) {
-                    Canvas c = pingPong.getCanvas();
-                    renderOnCanvas(c);
-                    pingPong.swap();
-                }
-                postInvalidate();
-
-                // sleep until the next redraw request.  Requests made while rendering are
-                // remembered in redrawRequested rather than dropped, so the loop immediately
-                // renders again with the latest data; several requests coalesce into one pass.
-                synchronized (renderSync) {
-                    while (keepRunning && !redrawRequested) {
-                        try {
-                            renderSync.wait();
-                        } catch (InterruptedException e) {
-                            // prevent this thread from becoming an orphan
-                            // after the view is destroyed
-                            keepRunning = false;
-                        }
-                    }
-                    if (!keepRunning) {
-                        break;
-                    }
-                    redrawRequested = false;
-                }
-            }
-            System.out.println("Thread exited with id " + this.hashCode());
-            renderThread = null;
-            pingPong.recycle();
-        }, "Androidplot renderThread");
     }
 
     /**
@@ -763,11 +807,11 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
 
         if (renderMode == RenderMode.USE_BACKGROUND_THREAD) {
 
-            // record the request so it is honored even if the render thread is busy drawing
-            // or has not started yet; renderSync is only ever held briefly.
-            synchronized (renderSync) {
-                redrawRequested = true;
-                renderSync.notify();
+            // the request is recorded so it is honored even if the thread is busy drawing;
+            // a thread that has not started yet renders unconditionally on its first pass.
+            RenderThread t = renderThread;
+            if (t != null) {
+                t.requestRedraw();
             }
 
         } else if(renderMode == RenderMode.USE_MAIN_THREAD) {
@@ -792,9 +836,9 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     @Override
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
-        synchronized(renderSync) {
-            keepRunning = false;
-            renderSync.notify();
+        RenderThread t = renderThread;
+        if (t != null) {
+            t.requestStop();
         }
     }
 
@@ -802,11 +846,23 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
 
-        // necessary to support rendering in recyclerview etc.
-        if(renderMode == RenderMode.USE_BACKGROUND_THREAD && renderThread == null) {
-            pingPong.resizeToLast();
-            startBackgroundRendering();
-            renderThread.start();
+        // necessary to support rendering in recyclerview etc.  A thread that was stopped by
+        // onDetachedFromWindow but has not yet exited is replaced here; it will notice it is no
+        // longer current when it exits and leave the buffers alone.
+        if(renderMode == RenderMode.USE_BACKGROUND_THREAD) {
+            RenderThread toStart = null;
+            synchronized (pingPong) {
+                synchronized (renderSync) {
+                    if (renderThread == null || renderThread.isStopping()) {
+                        pingPong.resizeToLast();
+                        renderThread = new RenderThread();
+                        toStart = renderThread;
+                    }
+                }
+            }
+            if (toStart != null) {
+                toStart.start();
+            }
         }
     }
 
@@ -842,13 +898,14 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
             layout(dims);
         }
         super.onSizeChanged(w, h, oldw, oldh);
-        if(renderThread != null) {
-            if (!renderThread.isAlive()) {
-                renderThread.start();
+        RenderThread t = renderThread;
+        if(t != null) {
+            if (t.getState() == Thread.State.NEW) {
+                t.start();
             } else {
                 // the render thread already drew at the previous size and the buffers were just
                 // replaced with blank ones, so render again at the new size.  (#120)
-                redraw();
+                t.requestRedraw();
             }
         }
     }

--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -174,9 +174,9 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     private final ArrayList<PlotListener> listeners;
 
     private Thread renderThread;
+    // both guarded by renderSync
     private boolean keepRunning = false;
-    // written by the render thread, read by redraw() on the UI thread
-    private volatile boolean isIdle = true;
+    private boolean redrawRequested = false;
 
     {
         listeners = new ArrayList<>();
@@ -239,7 +239,7 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
             }
         }
 
-        public void recycle() {
+        public synchronized void recycle() {
             /**
              * TODO: Issue #93 There have been rare reports of NPE's originating from here.
              * Most likely there is something deeper that is amiss, but for now we'll simply
@@ -419,25 +419,39 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
         renderThread = new Thread(() -> {
             System.out.println("Thread started with id " + this.hashCode());
 
-            keepRunning = true;
-            while (keepRunning) {
-                isIdle = false;
+            synchronized (renderSync) {
+                keepRunning = true;
+                // the first pass below renders unconditionally, which satisfies any request
+                // made before the thread started.
+                redrawRequested = false;
+            }
+            while (true) {
+                // lock order: pingPong, then this (inside renderOnCanvas).  onSizeChanged
+                // takes the same locks in the same order.
                 synchronized (pingPong) {
                     Canvas c = pingPong.getCanvas();
                     renderOnCanvas(c);
                     pingPong.swap();
                 }
+                postInvalidate();
+
+                // sleep until the next redraw request.  Requests made while rendering are
+                // remembered in redrawRequested rather than dropped, so the loop immediately
+                // renders again with the latest data; several requests coalesce into one pass.
                 synchronized (renderSync) {
-                    postInvalidate();
-                    // prevent this thread from becoming an orphan
-                    // after the view is destroyed
-                    if (keepRunning) {
+                    while (keepRunning && !redrawRequested) {
                         try {
                             renderSync.wait();
                         } catch (InterruptedException e) {
+                            // prevent this thread from becoming an orphan
+                            // after the view is destroyed
                             keepRunning = false;
                         }
                     }
+                    if (!keepRunning) {
+                        break;
+                    }
+                    redrawRequested = false;
                 }
             }
             System.out.println("Thread exited with id " + this.hashCode());
@@ -749,13 +763,11 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
 
         if (renderMode == RenderMode.USE_BACKGROUND_THREAD) {
 
-            // only enter synchronized block if the call is expected to block OR
-            // if the render thread is idle, so we know that we won't have to wait to
-            // obtain a lock.
-            if (renderThread != null && isIdle) {
-                synchronized (renderSync) {
-                    renderSync.notify();
-                }
+            // record the request so it is honored even if the render thread is busy drawing
+            // or has not started yet; renderSync is only ever held briefly.
+            synchronized (renderSync) {
+                redrawRequested = true;
+                renderSync.notify();
             }
 
         } else if(renderMode == RenderMode.USE_MAIN_THREAD) {
@@ -799,7 +811,7 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     }
 
     @Override
-    protected synchronized void onSizeChanged (int w, int h, int oldw, int oldh) {
+    protected void onSizeChanged (int w, int h, int oldw, int oldh) {
 
         // update pixel conversion values
         PixelUtils.init(getContext());
@@ -813,16 +825,22 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
             }
         }
 
-        // pingPong is only used in background rendering mode.
-        if(renderMode == RenderMode.USE_BACKGROUND_THREAD) {
-            pingPong.resize(h, w);
-        }
-
         RectF cRect = new RectF(0, 0, w, h);
         RectF mRect = boxModel.getMarginatedRect(cRect);
         RectF pRect = boxModel.getPaddedRect(mRect);
+        DisplayDimensions dims = new DisplayDimensions(cRect, mRect, pRect);
 
-        layout(new DisplayDimensions(cRect, mRect, pRect));
+        if(renderMode == RenderMode.USE_BACKGROUND_THREAD) {
+            // resize the buffers and apply the new layout atomically with respect to the render
+            // thread, taking the locks in the same order it does (pingPong, then this) so the
+            // two can never deadlock.
+            synchronized (pingPong) {
+                pingPong.resize(h, w);
+                layout(dims);
+            }
+        } else {
+            layout(dims);
+        }
         super.onSizeChanged(w, h, oldw, oldh);
         if(renderThread != null) {
             if (!renderThread.isAlive()) {
@@ -865,10 +883,8 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
      */
     protected synchronized void renderOnCanvas(@Nullable Canvas canvas) {
         if(canvas == null) {
-            // nothing to draw onto yet (eg. the view currently has a zero-sized dimension so no
-            // buffers exist); the render thread must still be marked idle or redraw() will
-            // never wake it once the view is given a real size.  (#120)
-            isIdle = true;
+            // nothing to draw onto yet, eg. the view currently has a zero-sized dimension so
+            // no buffers exist.  (#120)
             return;
         }
         try {
@@ -894,7 +910,6 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
                 Log.e(TAG, "Exception while rendering Plot.", e);
             }
 
-            isIdle = true;
             // any series interested in synchronizing with plot should
             // implement PlotListener.onAfterDraw(...) and do a read unlock from within that
             // invocation. This is the entry point for that invocation.

--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -175,7 +175,8 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
 
     private Thread renderThread;
     private boolean keepRunning = false;
-    private boolean isIdle = true;
+    // written by the render thread, read by redraw() on the UI thread
+    private volatile boolean isIdle = true;
 
     {
         listeners = new ArrayList<>();
@@ -823,8 +824,14 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
 
         layout(new DisplayDimensions(cRect, mRect, pRect));
         super.onSizeChanged(w, h, oldw, oldh);
-        if(renderThread != null && !renderThread.isAlive()) {
-            renderThread.start();
+        if(renderThread != null) {
+            if (!renderThread.isAlive()) {
+                renderThread.start();
+            } else {
+                // the render thread already drew at the previous size and the buffers were just
+                // replaced with blank ones, so render again at the new size.  (#120)
+                redraw();
+            }
         }
     }
 
@@ -858,6 +865,10 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
      */
     protected synchronized void renderOnCanvas(@Nullable Canvas canvas) {
         if(canvas == null) {
+            // nothing to draw onto yet (eg. the view currently has a zero-sized dimension so no
+            // buffers exist); the render thread must still be marked idle or redraw() will
+            // never wake it once the view is given a real size.  (#120)
+            isIdle = true;
             return;
         }
         try {

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -359,10 +359,43 @@ public class PlotTest extends AndroidplotTest {
         }
     }
 
+    /**
+     * A redraw() issued while the render thread is busy drawing must not be dropped: the
+     * thread has to render again afterwards so the latest data reaches the screen.
+     */
+    @Test
+    public void backgroundRender_redrawDuringRender_rendersAgain() throws Exception {
+        RenderCountingPlot plot = new RenderCountingPlot();
+        plot.holdFirstRender = true;
+        try {
+            plot.onSizeChanged(100, 100, 0, 0);
+            assertTrue(plot.firstRenderStarted.await(5, TimeUnit.SECONDS));
+
+            // render thread is now blocked inside its first render
+            plot.redraw();
+            plot.redraw();
+            plot.releaseFirstRender.countDown();
+
+            assertTrue("redraw() issued during a render was dropped",
+                    plot.renderedTwice.await(5, TimeUnit.SECONDS));
+            // several requests made during one render coalesce into a single extra pass
+            plot.awaitRenderThreadParked();
+            assertEquals(2, plot.rendersOnCanvas.get());
+        } finally {
+            plot.releaseFirstRender.countDown();
+            plot.onDetachedFromWindow();
+        }
+    }
+
     /** A background-mode plot that reports when it has rendered onto a real canvas. */
     static class RenderCountingPlot extends MockPlot {
         final CountDownLatch rendered = new CountDownLatch(1);
+        final CountDownLatch renderedTwice = new CountDownLatch(2);
         final AtomicInteger rendersOnCanvas = new AtomicInteger();
+
+        volatile boolean holdFirstRender = false;
+        final CountDownLatch firstRenderStarted = new CountDownLatch(1);
+        final CountDownLatch releaseFirstRender = new CountDownLatch(1);
 
         RenderCountingPlot() {
             super("RenderCountingPlot", RenderMode.USE_BACKGROUND_THREAD);
@@ -372,8 +405,17 @@ public class PlotTest extends AndroidplotTest {
         protected synchronized void renderOnCanvas(Canvas canvas) {
             super.renderOnCanvas(canvas);
             if (canvas != null) {
+                if (holdFirstRender && rendersOnCanvas.get() == 0) {
+                    firstRenderStarted.countDown();
+                    try {
+                        releaseFirstRender.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
                 rendersOnCanvas.incrementAndGet();
                 rendered.countDown();
+                renderedTwice.countDown();
             }
         }
 

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -28,6 +28,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 
 public class PlotTest extends AndroidplotTest {
 
@@ -366,15 +369,15 @@ public class PlotTest extends AndroidplotTest {
     @Test
     public void backgroundRender_redrawDuringRender_rendersAgain() throws Exception {
         RenderCountingPlot plot = new RenderCountingPlot();
-        plot.holdFirstRender = true;
+        plot.holdRenderIndex = 0;
         try {
             plot.onSizeChanged(100, 100, 0, 0);
-            assertTrue(plot.firstRenderStarted.await(5, TimeUnit.SECONDS));
+            assertTrue(plot.heldRenderStarted.await(5, TimeUnit.SECONDS));
 
             // render thread is now blocked inside its first render
             plot.redraw();
             plot.redraw();
-            plot.releaseFirstRender.countDown();
+            plot.releaseHeldRender.countDown();
 
             assertTrue("redraw() issued during a render was dropped",
                     plot.renderedTwice.await(5, TimeUnit.SECONDS));
@@ -382,7 +385,44 @@ public class PlotTest extends AndroidplotTest {
             plot.awaitRenderThreadParked();
             assertEquals(2, plot.rendersOnCanvas.get());
         } finally {
-            plot.releaseFirstRender.countDown();
+            plot.releaseHeldRender.countDown();
+            plot.onDetachedFromWindow();
+        }
+    }
+
+    /**
+     * Detaching and re-attaching a plot before its render thread has finished exiting (as a
+     * RecyclerView does when scrolling) must hand over cleanly: the replacement thread renders,
+     * and the exiting thread must not recycle the buffers out from under it.
+     */
+    @Test
+    public void backgroundRender_reattachWhileOldThreadExiting_keepsRendering() throws Exception {
+        RenderCountingPlot plot = new RenderCountingPlot();
+        try {
+            plot.onSizeChanged(100, 100, 0, 0);
+            plot.awaitRenders(1);
+            plot.awaitRenderThreadParked();
+
+            // park the old thread inside a render, then detach and re-attach while it's stuck
+            plot.holdRenderIndex = 1;
+            plot.redraw();
+            assertTrue(plot.heldRenderStarted.await(5, TimeUnit.SECONDS));
+            plot.onDetachedFromWindow();
+            plot.onAttachedToWindow();
+            plot.releaseHeldRender.countDown();
+
+            // the replacement thread renders on start, and again on request
+            plot.awaitRenders(3);
+            plot.awaitRenderThreadParked();
+            plot.redraw();
+            plot.awaitRenders(4);
+
+            // the buffers survived the old thread's exit: onDraw still has a bitmap to draw
+            Canvas canvas = spy(new Canvas());
+            plot.onDraw(canvas);
+            verify(canvas).drawBitmap(any(Bitmap.class), eq(0f), eq(0f), (Paint) isNull());
+        } finally {
+            plot.releaseHeldRender.countDown();
             plot.onDetachedFromWindow();
         }
     }
@@ -393,9 +433,10 @@ public class PlotTest extends AndroidplotTest {
         final CountDownLatch renderedTwice = new CountDownLatch(2);
         final AtomicInteger rendersOnCanvas = new AtomicInteger();
 
-        volatile boolean holdFirstRender = false;
-        final CountDownLatch firstRenderStarted = new CountDownLatch(1);
-        final CountDownLatch releaseFirstRender = new CountDownLatch(1);
+        /** zero-based index of the render to block inside until releaseHeldRender fires */
+        volatile int holdRenderIndex = -1;
+        final CountDownLatch heldRenderStarted = new CountDownLatch(1);
+        final CountDownLatch releaseHeldRender = new CountDownLatch(1);
 
         RenderCountingPlot() {
             super("RenderCountingPlot", RenderMode.USE_BACKGROUND_THREAD);
@@ -405,10 +446,10 @@ public class PlotTest extends AndroidplotTest {
         protected synchronized void renderOnCanvas(Canvas canvas) {
             super.renderOnCanvas(canvas);
             if (canvas != null) {
-                if (holdFirstRender && rendersOnCanvas.get() == 0) {
-                    firstRenderStarted.countDown();
+                if (rendersOnCanvas.get() == holdRenderIndex) {
+                    heldRenderStarted.countDown();
                     try {
-                        releaseFirstRender.await(5, TimeUnit.SECONDS);
+                        releaseHeldRender.await(5, TimeUnit.SECONDS);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                     }
@@ -419,6 +460,17 @@ public class PlotTest extends AndroidplotTest {
             }
         }
 
+        /** Blocks until at least n renders onto a real canvas have completed. */
+        void awaitRenders(int n) throws Exception {
+            long deadline = System.currentTimeMillis() + 5000;
+            while (rendersOnCanvas.get() < n) {
+                if (System.currentTimeMillis() > deadline) {
+                    fail("expected " + n + " renders, got " + rendersOnCanvas.get());
+                }
+                Thread.sleep(10);
+            }
+        }
+
         /**
          * Blocks until the render thread is waiting for a redraw request, so that a subsequent
          * notify cannot be lost by arriving before the thread has started waiting.
@@ -426,11 +478,18 @@ public class PlotTest extends AndroidplotTest {
         void awaitRenderThreadParked() throws Exception {
             long deadline = System.currentTimeMillis() + 5000;
             while (System.currentTimeMillis() < deadline) {
+                boolean anyLive = false;
+                boolean allParked = true;
                 for (Thread t : Thread.getAllStackTraces().keySet()) {
-                    if ("Androidplot renderThread".equals(t.getName())
-                            && t.getState() == Thread.State.WAITING) {
-                        return;
+                    if ("Androidplot renderThread".equals(t.getName())) {
+                        anyLive = true;
+                        if (t.getState() != Thread.State.WAITING) {
+                            allParked = false;
+                        }
                     }
+                }
+                if (anyLive && allParked) {
+                    return;
                 }
                 Thread.sleep(10);
             }

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -16,10 +16,14 @@ import org.robolectric.RuntimeEnvironment;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotSame;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -319,6 +323,79 @@ public class PlotTest extends AndroidplotTest {
         assertEquals(44f, plot.getPlotPaddingBottom());
     }
 
+    /**
+     * Regression tests for https://github.com/halfhp/androidplot/issues/120: a background-mode
+     * plot whose first layout pass gives it a zero-sized dimension used to leave its render thread
+     * permanently un-wakeable, so it never drew once it was given a real size.
+     */
+    @Test
+    public void backgroundRender_afterZeroSizedLayout_rendersOnResize() throws Exception {
+        RenderCountingPlot plot = new RenderCountingPlot();
+        try {
+            plot.onSizeChanged(100, 0, 0, 0);
+            plot.awaitRenderThreadParked();
+            assertEquals(0, plot.rendersOnCanvas.get());
+
+            plot.onSizeChanged(100, 100, 100, 0);
+            assertTrue("plot never rendered after being resized to a non-zero size",
+                    plot.rendered.await(5, TimeUnit.SECONDS));
+        } finally {
+            plot.onDetachedFromWindow();
+        }
+    }
+
+    @Test
+    public void backgroundRender_afterZeroSizedLayout_rendersOnRedraw() throws Exception {
+        RenderCountingPlot plot = new RenderCountingPlot();
+        try {
+            plot.onSizeChanged(100, 0, 0, 0);
+            plot.awaitRenderThreadParked();
+            plot.onSizeChanged(100, 100, 100, 0);
+            plot.redraw();
+            assertTrue("plot never rendered after redraw() following a resize",
+                    plot.rendered.await(5, TimeUnit.SECONDS));
+        } finally {
+            plot.onDetachedFromWindow();
+        }
+    }
+
+    /** A background-mode plot that reports when it has rendered onto a real canvas. */
+    static class RenderCountingPlot extends MockPlot {
+        final CountDownLatch rendered = new CountDownLatch(1);
+        final AtomicInteger rendersOnCanvas = new AtomicInteger();
+
+        RenderCountingPlot() {
+            super("RenderCountingPlot", RenderMode.USE_BACKGROUND_THREAD);
+        }
+
+        @Override
+        protected synchronized void renderOnCanvas(Canvas canvas) {
+            super.renderOnCanvas(canvas);
+            if (canvas != null) {
+                rendersOnCanvas.incrementAndGet();
+                rendered.countDown();
+            }
+        }
+
+        /**
+         * Blocks until the render thread is waiting for a redraw request, so that a subsequent
+         * notify cannot be lost by arriving before the thread has started waiting.
+         */
+        void awaitRenderThreadParked() throws Exception {
+            long deadline = System.currentTimeMillis() + 5000;
+            while (System.currentTimeMillis() < deadline) {
+                for (Thread t : Thread.getAllStackTraces().keySet()) {
+                    if ("Androidplot renderThread".equals(t.getName())
+                            && t.getState() == Thread.State.WAITING) {
+                        return;
+                    }
+                }
+                Thread.sleep(10);
+            }
+            fail("render thread never parked");
+        }
+    }
+
     static class MockPlotListener implements PlotListener {
 
         public void onBeforeDraw(Plot source, Canvas canvas) {
@@ -429,6 +506,10 @@ public class PlotTest extends AndroidplotTest {
     public static class MockPlot extends Plot<MockSeries, Formatter, SeriesRenderer, MockSeriesBundle, SeriesRegistry<MockSeriesBundle, MockSeries, Formatter>> {
         public MockPlot(String title) {
             super(RuntimeEnvironment.application, title);
+        }
+
+        public MockPlot(String title, RenderMode mode) {
+            super(RuntimeEnvironment.application, title, mode);
         }
 
         @Override

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,9 @@ For details on what to expect in general when updating to a new version of Andro
 [versioning doc](versioning.md).
 
 # 1.5.12
+* (#120) Fix background-thread plots never rendering when their first layout pass gives them a
+  zero-sized dimension.  The background render loop has been reworked while fixing this; see
+  **Behavior changes** below.
 * (#118) Fix pie chart segments larger than half the pie not responding to clicks over part of
   their area.
 * (#88) Fix crash when a formatter config or `androidPlot.` attribute references a color, dimension
@@ -12,6 +15,16 @@ For details on what to expect in general when updating to a new version of Andro
   [XML Configuration](xml_configuration.md) doc.
 * Compile and target SDK 37; build updated to AGP 9.4 / Gradle 9.7 / Kotlin 2.2.
 * Snapshot builds of unreleased changes are now published to the Central snapshots repository.
+
+**Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
+* `redraw()` requests are no longer dropped when the render thread is busy drawing.  Requests
+  made during a render are coalesced into one additional render pass, so the latest data is
+  always drawn.  Apps that issue `redraw()` faster than the plot can draw will see one extra
+  frame per burst compared to previous versions.
+* Plots now re-render automatically when resized; previously a resized plot was blank until the
+  next `redraw()` call.
+* Resizing a plot while it is rendering could previously deadlock; the locks involved are now
+  always taken in the same order.
 
 # 1.5.11
 * Update project to latest gradle / build tools

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -25,6 +25,9 @@ For details on what to expect in general when updating to a new version of Andro
   next `redraw()` call.
 * Resizing a plot while it is rendering could previously deadlock; the locks involved are now
   always taken in the same order.
+* Detaching and quickly re-attaching a plot (as happens when scrolling a RecyclerView) could
+  previously leave it without a render thread, or with recycled buffers, until its next resize.
+  Thread handover is now explicit and the replacement thread always renders.
 
 # 1.5.11
 * Update project to latest gradle / build tools


### PR DESCRIPTION
Fixes #120

## Cause

Exactly as @harbulot diagnosed. When a background-mode plot's first layout pass gives it a zero-sized dimension, `BufferedCanvas.resize` leaves the buffers null, the render thread's first pass gets a null canvas, and `renderOnCanvas` returned early without marking the thread idle. `redraw()` only notified an idle thread, so it could never be woken again and the plot stayed blank even after it was laid out at a real size.

## Fix

Rather than patching the idle flag, the background render loop is reworked so this class of bug can't recur. Four changes in `Plot`:

1. **Request flag instead of idle flag.** `redraw()` now always records a request and notifies. The render thread renders, then waits only while no request is pending. A request made while the thread is busy drawing is honored by one further pass instead of being dropped, a notify can no longer be lost in the window before `wait()`, and the null-canvas early return no longer matters because nothing depends on the thread flagging itself idle. Several requests during one render coalesce into a single extra pass.
2. **Re-render on resize.** `onSizeChanged` only ever started the thread; when it was already running, resize swapped in blank buffers and nothing drew until the app's next `redraw()`. A resize now requests a render.
3. **Consistent lock order.** `onSizeChanged` was `synchronized` on the plot and then took the buffer lock, while the render thread takes the buffer lock and then the plot lock inside `renderOnCanvas`. A resize landing mid-render could deadlock. `onSizeChanged` now takes the buffer lock first and applies the layout inside it, the same order as the render thread. `BufferedCanvas.recycle` is also synchronized so `onDraw` can't observe a recycled bitmap.
4. **Explicit thread ownership across detach/re-attach.** The loop moves into a `RenderThread` inner class that owns its own stop and request flags. Detaching stops the current thread; attaching replaces a stopped thread immediately rather than waiting for it to exit; and an exiting thread only clears the plot's reference and recycles the buffers if it is still the current thread. Previously a quick detach and re-attach (a RecyclerView scrolling) could either skip creating a new thread, or let the old thread recycle the buffers its replacement had just allocated, leaving the plot blank until its next resize. `onSizeChanged` also now starts the thread based on `Thread.State.NEW` rather than `!isAlive()`, which would have thrown for a finished thread.

## Behavior changes

Called out in the 1.5.12 release notes since they're observable by existing background-mode users:

- `redraw()` calls issued faster than the plot can draw used to be silently dropped, which acted as a crude frame limiter. They are now coalesced, so a burst produces one extra frame with the latest data.
- Resized plots re-render automatically instead of staying blank until the next `redraw()`.
- The resize/render deadlock is gone.
- A quick detach and re-attach no longer leaves the plot without a render thread or with recycled buffers.

## Verification

Four new `PlotTest` cases using a background-mode `MockPlot` subclass that reports renders through a latch (a Mockito spy can't be used, since the render thread captures the real instance):

- Lay out at 100x0, wait for the thread to park, lay out at 100x100, and expect a render from the resize alone.
- Same, but with an explicit `redraw()`: the reporter's scenario.
- Block the first render, issue two `redraw()` calls during it, release, and expect exactly one further render.
- Block a render, detach and re-attach while the old thread is stuck in it, release, and expect the replacement thread to render on start and on request, with `onDraw` still having a bitmap to draw afterwards.

Each test was checked to fail on the code before its corresponding change: the first two on the original code, the third on the minimal idle-flag fix, the fourth on the loop rework without ownership handling. All were rerun five times to check for flakiness.

Full suite: 215 tests, 0 failures. Lint, core release AAR and demoapp debug build pass.
