### PR TITLE
Draw grid lines and labels for inverted axes with INCREMENT_BY_VAL

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/xy/XYStepCalculator.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYStepCalculator.java
@@ -48,6 +48,14 @@ public class XYStepCalculator {
             case INCREMENT_BY_FIT:
                 stepVal = stepValue;
                 stepPix = stepValue / realBounds.ratio(pixelBounds).doubleValue();
+                if (stepPix < 0) {
+                    // the axis is inverted (min > max), so a positive value step runs against
+                    // the pixel direction.  Grid drawing walks the axis in pixel order, so keep
+                    // the pixel step positive and let the value step carry the sign, which is
+                    // how the other step modes already come out for inverted bounds.  (#125)
+                    stepPix = -stepPix;
+                    stepVal = -stepVal;
+                }
                 stepCount = pixelBounds.length().doubleValue() / stepPix;
                 break;
             case INCREMENT_BY_PIXELS:

--- a/androidplot-core/src/test/java/com/androidplot/xy/StepCalculatorTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/StepCalculatorTest.java
@@ -53,6 +53,32 @@ public class StepCalculatorTest {
         assertEquals(1.0, step.getStepPix());
     }
 
+    /**
+     * https://github.com/halfhp/androidplot/issues/125: with inverted bounds (min > max) the pixel
+     * step must stay positive so grid drawing can walk the axis, and the value step carries the
+     * sign, consistent with what the other step modes produce for inverted bounds.
+     */
+    @Test
+    public void testIncrementByVal_invertedBounds() throws Exception {
+        Region pixBounds = new Region(50, 150);
+        Region realBounds = new Region();
+        realBounds.setMin(200);
+        realBounds.setMax(100);
+        Step step = XYStepCalculator.getStep(StepMode.INCREMENT_BY_VAL, 1, realBounds, pixBounds);
+        assertEquals(1.0, step.getStepPix());
+        assertEquals(-1.0, step.getStepVal());
+        assertEquals(100.0, step.getStepCount());
+
+        // the other modes already behave this way:
+        step = XYStepCalculator.getStep(StepMode.INCREMENT_BY_PIXELS, 1, realBounds, pixBounds);
+        assertEquals(1.0, step.getStepPix());
+        assertEquals(-1.0, step.getStepVal());
+
+        step = XYStepCalculator.getStep(StepMode.SUBDIVIDE, 101, realBounds, pixBounds);
+        assertEquals(1.0, step.getStepPix());
+        assertEquals(-1.0, step.getStepVal());
+    }
+
     @Test
     public void testIncrementByPixels() throws Exception {
         Region pixBounds = new Region(50, 150);

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYGraphWidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYGraphWidgetTest.java
@@ -135,6 +135,52 @@ public class XYGraphWidgetTest extends AndroidplotTest {
         runDrawGridTest();
     }
 
+    /**
+     * https://github.com/halfhp/androidplot/issues/125: inverted boundaries (min > max) with
+     * INCREMENT_BY_VAL drew no grid lines or labels at all.
+     */
+    @Test
+    public void drawGrid_invertedBounds_drawsGrid() {
+        bounds = new RectRegion(0, 0, 0, 0);
+        bounds.setMinX(100);
+        bounds.setMaxX(0);
+        bounds.setMinY(100);
+        bounds.setMaxY(0);
+        when(xyPlot.getBounds()).thenReturn(bounds);
+        when(xyPlot.getDomainOrigin()).thenReturn(null);
+        when(xyPlot.getRangeOrigin()).thenReturn(null);
+
+        doNothing().when(graphWidget).
+                drawDomainLine(any(Canvas.class), anyFloat(), any(Number.class), any(Paint.class), anyBoolean(), anyBoolean());
+        doNothing().when(graphWidget).
+                drawRangeLine(any(Canvas.class), anyFloat(), any(Number.class), any(Paint.class), anyBoolean(), anyBoolean());
+
+        graphWidget.drawGrid(canvas);
+
+        ArgumentCaptor<Float> xPix = ArgumentCaptor.forClass(Float.class);
+        ArgumentCaptor<Number> xVal = ArgumentCaptor.forClass(Number.class);
+        verify(graphWidget, times(101)).drawDomainLine(
+                eq(canvas), xPix.capture(), xVal.capture(), any(Paint.class), anyBoolean(), anyBoolean());
+
+        // lines are laid out left to right and values run from max (100) at the left edge down
+        // to 0 at the right edge:
+        assertEquals(0f, xPix.getAllValues().get(0), 0.001f);
+        assertEquals(100.0, xVal.getAllValues().get(0).doubleValue(), 0.001);
+        assertEquals(10f, xPix.getAllValues().get(100), 0.001f);
+        assertEquals(0.0, xVal.getAllValues().get(100).doubleValue(), 0.001);
+
+        ArgumentCaptor<Float> yPix = ArgumentCaptor.forClass(Float.class);
+        ArgumentCaptor<Number> yVal = ArgumentCaptor.forClass(Number.class);
+        verify(graphWidget, times(101)).drawRangeLine(
+                eq(canvas), yPix.capture(), yVal.capture(), any(Paint.class), anyBoolean(), anyBoolean());
+
+        // the bottom of the grid carries the range minimum (100) and the top the maximum (0):
+        assertEquals(0f, yPix.getAllValues().get(0), 0.001f);
+        assertEquals(0.0, yVal.getAllValues().get(0).doubleValue(), 0.001);
+        assertEquals(100f, yPix.getAllValues().get(100), 0.001f);
+        assertEquals(100.0, yVal.getAllValues().get(100).doubleValue(), 0.001);
+    }
+
     @Test
     public void drawGrid_centeredOrigin_drawsGrid() {
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,8 @@ For details on what to expect in general when updating to a new version of Andro
 [versioning doc](versioning.md).
 
 # 1.5.12
+* (#125) Fix grid lines and labels not being drawn for an axis with inverted boundaries (min
+  greater than max) when using `StepMode.INCREMENT_BY_VAL` or `INCREMENT_BY_FIT`.
 * (#120) Fix background-thread plots never rendering when their first layout pass gives them a
   zero-sized dimension.  The background render loop has been reworked while fixing this; see
   **Behavior changes** below.


### PR DESCRIPTION
Fixes #125

## Cause

With inverted boundaries, e.g. `setDomainBoundaries(10, 0, FIXED)`, the axis region has min greater than max, so `Region.ratio` is negative. In `XYStepCalculator`, the `INCREMENT_BY_VAL` and `INCREMENT_BY_FIT` modes derive the pixel step by dividing the value step by that ratio, giving a negative pixel step. `XYGraphWidget.drawGrid` walks each axis in pixel order and computes its loop bounds from the pixel step, so with a negative step the bounds came out reversed and the loop never ran: no grid lines, no labels. The other modes derive the pixel step from pixel lengths, so they stayed positive and worked, which is why the reporter only saw it with `INCREMENT_BY_VAL`.

## Fix

In `XYStepCalculator`, when the computed pixel step is negative, negate both it and the value step. The pixel step is then always positive and the value step carries the axis direction, which is exactly what `INCREMENT_BY_PIXELS` and `SUBDIVIDE` already produce for inverted bounds. `drawGrid` needs no changes: it already computes each line's value as origin plus index times the signed value step.

This is a narrower change than the reporter's proposed swap of the loop endpoints inside `drawGrid`, and it fixes the inconsistency at its source so any other consumer of `Step` sees the same convention across modes.

## Verification

- `StepCalculatorTest`: new case with inverted real bounds asserts `INCREMENT_BY_VAL` yields pixel step +1 and value step -1, and that `INCREMENT_BY_PIXELS` and `SUBDIVIDE` produce the same signs. Fails on the old code with pixel step -1.
- `XYGraphWidgetTest`: new case sets inverted domain and range bounds with `INCREMENT_BY_VAL` and captures every grid line drawn. Asserts 101 lines per axis, that the leftmost domain line carries the value 100 and the rightmost 0, and that the top range line carries 0 and the bottom 100. Fails on the old code with zero lines drawn.
- Full suite: 218 tests, 0 failures. Lint, core release AAR and demoapp debug build pass.
- Release note added under 1.5.12.

