### PR TITLE
Composite background-mode plots with hardware acceleration; harden Redrawer

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -875,7 +875,12 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
         // disable hardware acceleration if it's not explicitly supported
         // by the current Plot implementation. this run only applies to
         // honeycomb and later environments.
-        if (Build.VERSION.SDK_INT >= 11) {
+        //
+        // In background rendering mode the plot is drawn onto an offscreen bitmap and onDraw
+        // only ever copies that bitmap onto the view canvas, which hardware acceleration handles
+        // natively, so forcing a software layer there would just add a full-size CPU copy of
+        // the view on every frame.  (#96)
+        if (Build.VERSION.SDK_INT >= 11 && renderMode != RenderMode.USE_BACKGROUND_THREAD) {
             if (!isHwAccelerationSupported() && isHardwareAccelerated()) {
                 setLayerType(View.LAYER_TYPE_SOFTWARE, null);
             }

--- a/androidplot-core/src/main/java/com/androidplot/util/Redrawer.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/Redrawer.java
@@ -9,6 +9,7 @@ import com.androidplot.Plot;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -25,10 +26,10 @@ public class Redrawer implements Runnable {
     private long sleepTime;
 
     // used to temporarily pause rendering without disposing of the run thread
-    private boolean keepRunning;
+    private volatile boolean keepRunning;
 
     // when set to false, run thread will be allowed to exit the main run loop
-    private boolean keepAlive;
+    private volatile boolean keepAlive;
 
     private Thread thread;
 
@@ -95,8 +96,11 @@ public class Redrawer implements Runnable {
                 // TODO: record start and end timestamps and
                 // TODO: calculate sleepTime from that, in order to more accurately
                 // TODO: meet desired refresh rate.
-                for(WeakReference<Plot> plotRef : plots) {
-                    plotRef.get().redraw();
+                if (!redrawAll(plots)) {
+                    // every plot has been garbage collected; there is nothing left to redraw
+                    // so let the thread exit rather than spin until finish() is called.
+                    keepAlive = false;
+                    break;
                 }
                 synchronized (this) {
                     wait(sleepTime);
@@ -120,6 +124,25 @@ public class Redrawer implements Runnable {
      * refresh rate could be slower.
      * @param refreshRate Refresh rate in Hz.
      */
+    /**
+     * Redraws every plot that is still reachable, dropping references to plots that have been
+     * garbage collected.
+     *
+     * @return false if no plots remain.
+     */
+    static boolean redrawAll(List<WeakReference<Plot>> plots) {
+        Iterator<WeakReference<Plot>> it = plots.iterator();
+        while (it.hasNext()) {
+            Plot plot = it.next().get();
+            if (plot == null) {
+                it.remove();
+            } else {
+                plot.redraw();
+            }
+        }
+        return !plots.isEmpty();
+    }
+
     public void setMaxRefreshRate(float refreshRate) {
         sleepTime = (long)(ONE_SECOND_MS / refreshRate);
         Log.d(TAG, "Set Redrawer refresh rate to " +

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -5,6 +5,7 @@ package com.androidplot;
 import android.content.res.TypedArray;
 import android.graphics.*;
 import android.util.*;
+import android.view.View;
 
 import com.androidplot.test.*;
 import com.androidplot.ui.*;
@@ -28,6 +29,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -425,6 +428,31 @@ public class PlotTest extends AndroidplotTest {
             plot.releaseHeldRender.countDown();
             plot.onDetachedFromWindow();
         }
+    }
+
+    /**
+     * https://github.com/halfhp/androidplot/issues/96: in background mode the view only ever
+     * draws a bitmap, so it must not be forced onto a software layer, which would add a
+     * full-size CPU copy of the view on every frame.
+     */
+    @Test
+    public void onSizeChanged_backgroundMode_doesNotForceSoftwareLayer() {
+        MockPlot plot = spy(new MockPlot("bg", Plot.RenderMode.USE_BACKGROUND_THREAD));
+        doReturn(true).when(plot).isHardwareAccelerated();
+        try {
+            plot.onSizeChanged(100, 100, 0, 0);
+            verify(plot, never()).setLayerType(eq(View.LAYER_TYPE_SOFTWARE), any());
+        } finally {
+            plot.onDetachedFromWindow();
+        }
+    }
+
+    @Test
+    public void onSizeChanged_mainThreadMode_forcesSoftwareLayer() {
+        MockPlot plot = spy(new MockPlot("main", Plot.RenderMode.USE_MAIN_THREAD));
+        doReturn(true).when(plot).isHardwareAccelerated();
+        plot.onSizeChanged(100, 100, 0, 0);
+        verify(plot).setLayerType(eq(View.LAYER_TYPE_SOFTWARE), any());
     }
 
     /** A background-mode plot that reports when it has rendered onto a real canvas. */

--- a/androidplot-core/src/test/java/com/androidplot/util/RedrawerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/RedrawerTest.java
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util;
+
+import com.androidplot.Plot;
+import com.androidplot.PlotTest;
+import com.androidplot.test.AndroidplotTest;
+
+import org.junit.Test;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+public class RedrawerTest extends AndroidplotTest {
+
+    /**
+     * https://github.com/halfhp/androidplot/issues/96: plots are held weakly, so one that has
+     * been garbage collected must be skipped rather than dereferenced.
+     */
+    @Test
+    public void redrawAll_skipsAndDropsCollectedPlots() {
+        Plot live = mock(Plot.class);
+        WeakReference<Plot> collected = new WeakReference<>(mock(Plot.class));
+        collected.clear();
+        List<WeakReference<Plot>> plots = new ArrayList<>();
+        plots.add(collected);
+        plots.add(new WeakReference<>(live));
+
+        assertTrue(Redrawer.redrawAll(plots));
+        verify(live).redraw();
+        assertEquals(1, plots.size());
+    }
+
+    @Test
+    public void redrawAll_reportsWhenNoPlotsRemain() {
+        WeakReference<Plot> collected = new WeakReference<>(mock(Plot.class));
+        collected.clear();
+        List<WeakReference<Plot>> plots = new ArrayList<>();
+        plots.add(collected);
+
+        assertFalse(Redrawer.redrawAll(plots));
+        assertTrue(plots.isEmpty());
+    }
+
+    @Test
+    public void run_redrawsPlotAtRefreshRate() throws Exception {
+        Plot plot = mock(Plot.class);
+        Redrawer redrawer = new Redrawer(Collections.singletonList(plot), 100, true);
+        try {
+            verify(plot, timeout(2000).atLeast(3)).redraw();
+        } finally {
+            redrawer.finish();
+        }
+    }
+
+    @Test
+    public void run_exitsCleanlyOnceAllPlotsAreCollected() throws Exception {
+        // an uncaught exception on the redrawer thread would crash a real app; capture it here
+        final List<Throwable> uncaught = Collections.synchronizedList(new ArrayList<Throwable>());
+        Thread.UncaughtExceptionHandler previous = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((t, e) -> uncaught.add(e));
+        try {
+            // a real plot rather than a mock: Mockito keeps strong references to its mocks,
+            // which would prevent collection.
+            Plot plot = new PlotTest.MockPlot("collectable");
+            new Redrawer(Collections.singletonList(plot), 100, true);
+            assertTrue(redrawerThreadAlive());
+
+            // simulate the plot being garbage collected while the redrawer keeps running
+            plot = null;
+            for (int i = 0; i < 20 && redrawerThreadAlive(); i++) {
+                System.gc();
+                Thread.sleep(100);
+            }
+            assertFalse("redrawer thread kept running with no plots left", redrawerThreadAlive());
+            assertTrue("redrawer thread died with " + uncaught, uncaught.isEmpty());
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previous);
+        }
+    }
+
+    private static boolean redrawerThreadAlive() {
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if ("Androidplot Redrawer".equals(t.getName()) && t.isAlive()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,9 @@ For details on what to expect in general when updating to a new version of Andro
 [versioning doc](versioning.md).
 
 # 1.5.12
+* (#96) Background-mode plots are no longer forced onto a software layer, removing a full-size CPU
+  copy of the view from every frame.  `Redrawer` now tolerates plots that have been garbage
+  collected instead of crashing, and exits on its own once none remain.
 * (#125) Fix grid lines and labels not being drawn for an axis with inverted boundaries (min
   greater than max) when using `StepMode.INCREMENT_BY_VAL` or `INCREMENT_BY_FIT`.
 * (#120) Fix background-thread plots never rendering when their first layout pass gives them a
@@ -19,6 +22,10 @@ For details on what to expect in general when updating to a new version of Andro
 * Snapshot builds of unreleased changes are now published to the Central snapshots repository.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
+* The plot view is now composited with hardware acceleration when the app has it enabled.  The
+  rendered content is unchanged since drawing still happens on an offscreen bitmap; only the copy
+  of that bitmap to the screen changes.  Rendering cost still scales with the plot's pixel area,
+  so keep plots that redraw at high rates as small as the design allows.
 * `redraw()` requests are no longer dropped when the render thread is busy drawing.  Requests
   made during a render are coalesced into one additional render pass, so the latest data is
   always drawn.  Apps that issue `redraw()` faster than the plot can draw will see one extra


### PR DESCRIPTION
Fixes #96

## The size/performance correlation

The reporter found that a background-mode plot's cost scaled with its on-screen size, to the point that shrinking the view doubled their app's frame rate. That's inherent to how background mode composites, but one third of it was avoidable.

Every frame does three full-size pixel passes: the render thread clears and draws into an ARGB bitmap the size of the view; the UI thread copies that bitmap into a software layer; and the framework uploads the layer as a texture. All scale with width times height, and two of the three run on the UI thread.

The middle pass exists because `Plot.isHwAccelerationSupported()` returns false for every plot type, so `onSizeChanged` forces `LAYER_TYPE_SOFTWARE`. That's needed in main-thread mode, where the renderers draw paths and clips straight onto the view canvas and older hardware canvases didn't support some of those operations. In background mode those operations already happen on the offscreen bitmap, and the view's `onDraw` does nothing but `drawBitmap`, which hardware acceleration handles natively. This PR only forces the software layer in main-thread mode, removing a full-size CPU copy from the UI thread on every background-mode frame. Rendered output is identical.

Cost still scales with plot area; the release note says so and advises keeping high-rate plots small.

## Redrawer crash

The crash in the issue comments is a library bug. `Redrawer` holds plots by weak reference so it doesn't keep them alive, but its loop called `plotRef.get().redraw()` unconditionally. When an activity is destroyed and the plot is collected before `finish()` is called, the thread dies with a NullPointerException, which on Android takes the process down. Now collected plots are skipped and dropped, the thread exits on its own once nothing remains, and the `keepRunning` / `keepAlive` flags are volatile since the thread reads them without synchronization.

## Verification

- `PlotTest`: with `isHardwareAccelerated()` stubbed true, a background-mode plot never calls `setLayerType(SOFTWARE)` and a main-thread plot still does. The background case fails on the old code.
- `RedrawerTest` (new): unit cases for the collected-plot handling; a thread case verifying redraws at the configured rate; and a case that constructs a real plot, drops the reference, forces GC, and asserts the thread exits without an uncaught exception. On the old loop that last case fails with the reporter's exact `NullPointerException`, captured via an uncaught-exception handler.
- Full suite: 224 tests, 0 failures. Lint, core release AAR and demoapp debug build pass. Threading tests rerun five times without flakes.

## Needs a device check

I can't measure the frame-rate change from here. The ECG demo in background mode, sized to fill the screen, is the closest thing to the reporter's setup; GPU profiling before and after should show the UI-thread draw time drop.
