### PR TITLE
README: show the feature list in two columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,27 @@ If you enjoy the lib, please [rate us on codix.io](http://codix.io/gh/repo/halfh
 
 **Features:**
 
-* Line Charts
-* Scatter Charts
-* Bar Charts
-* Pie Charts
-* Step Charts
-* Candlestick Charts
-* Bubble Charts
-* Dynamic plots
-* Pan & Zoom
+<table>
+<tr>
+<td valign="top">
+<ul>
+<li>Line Charts</li>
+<li>Scatter Charts</li>
+<li>Bar Charts</li>
+<li>Pie Charts</li>
+<li>Step Charts</li>
+</ul>
+</td>
+<td valign="top">
+<ul>
+<li>Candlestick Charts</li>
+<li>Bubble Charts</li>
+<li>Dynamic plots</li>
+<li>Pan &amp; Zoom</li>
+</ul>
+</td>
+</tr>
+</table>
 
 # Usage
 


### PR DESCRIPTION
Splits the nine-item feature list into a two-column HTML table so it no longer runs as one long column. GitHub-flavored markdown has no column syntax, but it renders inline HTML tables with lists inside cells.

Preview: https://github.com/halfhp/androidplot/blob/readme-feature-columns/README.md