### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ ext {
     theCompileSdkVersion = 37
     theTargetSdkVersion = 37
     theMinSdkVersion = 5
-    theVersionName = '1.5.12'
+    theVersionName = '1.6.0'
     theVersionCode = 228
     gitUrl = 'https://github.com/halfhp/androidplot.git'
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.androidplot:androidplot-core:1.5.12-SNAPSHOT"
+    implementation "com.androidplot:androidplot-core:1.6.0-SNAPSHOT"
 }
 ```
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,7 +2,7 @@
 For details on what to expect in general when updating to a new version of Androiplot, check out the
 [versioning doc](versioning.md).
 
-# 1.5.12
+# 1.6.0
 * (#96) Background-mode plots are no longer forced onto a software layer, removing a full-size CPU
   copy of the view from every frame.  `Redrawer` now tolerates plots that have been garbage
   collected instead of crashing, and exits on its own once none remain.


### PR DESCRIPTION
Renames the pending 1.5.12 release to 1.6.0. The changes since 1.5.11 include a new compile/target SDK and toolchain, the Fig library folded into core, several bug fixes, and behavior changes to background-thread rendering, which is more than a patch release.

- `theVersionName` 1.5.12 → 1.6.0 (version code unchanged at 228, still above the 227 on Play)
- Release notes header 1.5.12 → 1.6.0
- Quickstart snapshot coordinates → `1.6.0-SNAPSHOT`

Merging publishes the first `1.6.0-SNAPSHOT`. Releasing is then a matter of pushing tag `v1.6.0`.