### PR TITLE
Publish the demoapp to Play open testing on every merge to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # the demoapp version code is derived from the commit count
 
       - name: Set Up JDK 17
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
@@ -89,6 +91,32 @@ jobs:
           name: Core Library
           path: androidplot-core/build/outputs/aar/*.aar
           retention-days: 30
+
+      # Publishes the demoapp to the Play open testing (beta) track on every merge to master
+      # that touches the library or demoapp source.  Version codes rise with the commit count,
+      # so each upload is accepted; Play reviews each one before testers see it.
+      - name: Check for Demoapp Changes
+        id: demoapp
+        if: github.ref_name == 'master'
+        run: |
+          if git diff --quiet HEAD^ HEAD -- androidplot-core/src/main demoapp/src/main demoapp/build.gradle build.gradle; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish Demoapp to Google Play (beta)
+        if: github.ref_name == 'master' && steps.demoapp.outputs.changed == 'true'
+        env:
+          KEYSTORE: keystore.jks
+          KEY_ALIAS: Key0
+          KEYSTORE_PASSWORD: ${{ secrets.DEMOAPP_KEYSTORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
+          PUBLISHER_ACCT_JSON_FILE: publisher.json
+          PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
+        run: |
+          printf '%s' "$PLAY_JSON" > "${GITHUB_WORKSPACE}/demoapp/publisher.json"
+          ./gradlew :demoapp:publishReleaseApk --track beta
 
       - name: Upload Demoapp APK
         if: github.ref_name == 'master'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # the demoapp version code is derived from the commit count
 
       - name: Verify Tag Matches Project Version
         if: github.ref_type == 'tag'
@@ -59,7 +61,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.DEMOAPP_KEY_PASSWORD }}
         run: |
           printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
-          ./gradlew :demoapp:assembleRelease
+          ./gradlew :demoapp:assembleRelease -Prelease
 
       - name: Attach Artifacts to GitHub Release
         if: github.ref_type == 'tag'
@@ -98,7 +100,9 @@ jobs:
       # Uploads an APK rather than an app bundle. The demoapp's 2011 signing key
       # is 1024-bit RSA, which Play App Signing does not accept, and bundles
       # require Play App Signing. Play still accepts APKs for existing apps.
-      - name: Publish Demoapp to Google Play
+      # Betas are published continuously by the build workflow; a tagged release
+      # goes to production.
+      - name: Publish Demoapp to Google Play (production)
         if: github.event_name != 'workflow_dispatch' || inputs.publish_play
         env:
           KEYSTORE: keystore.jks
@@ -109,4 +113,4 @@ jobs:
           PLAY_JSON: ${{ secrets.PLAY_PUBLISHER_JSON }}
         run: |
           printf '%s' "$PLAY_JSON" > "${GITHUB_WORKSPACE}/demoapp/publisher.json"
-          ./gradlew :demoapp:publishReleaseApk
+          ./gradlew :demoapp:publishReleaseApk -Prelease --track production

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ ext {
     theTargetSdkVersion = 37
     theMinSdkVersion = 5
     theVersionName = '1.6.0'
+    // only used by the demoapp when the commit count cannot be determined; see demoapp/build.gradle
     theVersionCode = 228
     gitUrl = 'https://github.com/halfhp/androidplot.git'
 }

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -21,6 +21,29 @@ kotlin {
     jvmToolchain(17)
 }
 
+// Every merge to master publishes the demoapp to the Play beta track, so the version code is
+// derived from the commit count rather than maintained by hand: it rises with every commit and
+// is the same in every workflow.  A release build (-Prelease) gets a code one higher than the
+// beta of the same commit, so a tagged release can follow a beta built from the same commit.
+// Betas carry the commit count in their version name so builds can be told apart.
+def commitCount = {
+    try {
+        providers.exec {
+            commandLine 'git', 'rev-list', '--count', 'HEAD'
+        }.standardOutput.asText.get().trim().toInteger()
+    } catch (Exception e) {
+        logger.warn("demoapp: unable to determine commit count; falling back to theVersionCode")
+        null
+    }
+}()
+def isRelease = project.hasProperty('release')
+def demoVersionCode = commitCount != null
+        ? commitCount * 10 + (isRelease ? 1 : 0)
+        : rootProject.ext.theVersionCode
+def demoVersionName = isRelease
+        ? rootProject.ext.theVersionName
+        : "${rootProject.ext.theVersionName}-beta.${commitCount ?: 0}"
+
 android {
 
     compileOptions {
@@ -35,8 +58,8 @@ android {
     }
 
     defaultConfig {
-        versionCode rootProject.ext.theVersionCode
-        versionName rootProject.ext.theVersionName
+        versionCode demoVersionCode
+        versionName demoVersionName
         minSdk 23
         targetSdk rootProject.ext.theTargetSdkVersion
         applicationId "com.androidplot.demos"

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -23,9 +23,10 @@ kotlin {
 
 // Every merge to master publishes the demoapp to the Play beta track, so the version code is
 // derived from the commit count rather than maintained by hand: it rises with every commit and
-// is the same in every workflow.  A release build (-Prelease) gets a code one higher than the
-// beta of the same commit, so a tagged release can follow a beta built from the same commit.
-// Betas carry the commit count in their version name so builds can be told apart.
+// is the same in every workflow.  Betas get even codes (2 * count) and a release build
+// (-Prelease) of the same commit the odd code above it, so a tagged release can follow a beta
+// built from the same commit without colliding with either it or the next beta.  Betas carry
+// the commit count in their version name so builds can be told apart.
 def commitCount = {
     try {
         providers.exec {
@@ -38,7 +39,7 @@ def commitCount = {
 }()
 def isRelease = project.hasProperty('release')
 def demoVersionCode = commitCount != null
-        ? commitCount * 10 + (isRelease ? 1 : 0)
+        ? commitCount * 2 + (isRelease ? 1 : 0)
         : rootProject.ext.theVersionCode
 def demoVersionName = isRelease
         ? rootProject.ext.theVersionName

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,6 +25,22 @@ branch of Androidplot.  Please make sure that:
 
 Adding Unit Tests for new methods / functionality is highly encouraged.
 
+## What Happens on Merge
+Every merge to master runs the full test suite and then:
+
+* Publishes a `<version>-SNAPSHOT` of the library to the
+  [Central snapshots repository](https://central.sonatype.com/repository/maven-snapshots/).
+* If the change touched library or demo app source, publishes a new build of the demo app to
+  the Play Store's open testing (beta) track.  Beta builds are versioned `<version>-beta.<n>`
+  where `n` is the commit count, so no manual version bump is needed.
+
+## Releasing
+Releases are cut by pushing a tag of the form `v<version>` matching `theVersionName` in
+`build.gradle`.  The release workflow verifies the tag, runs the tests, publishes the library
+to Maven Central, publishes the demo app to the Play Store's production track, and creates a
+GitHub release with the artifacts attached.  Bump `theVersionName` and update the release notes
+before tagging.
+
 # Git Newcomers
 If you're new to Git, this section will show you the basics of checking out a local copy of the project and building it.
 


### PR DESCRIPTION
## Summary

Every merge to master that touches library or demoapp source now publishes a new demoapp build to the Play open testing (beta) track, the app-side equivalent of the library's snapshot publishing. Tagged releases go to production.

## Version scheme

Play requires every upload's version code to exceed all previous ones, so the hand-maintained `theVersionCode` is replaced by a value derived from the commit count in `demoapp/build.gradle`:

| Build | Version code | Version name |
|---|---|---|
| Beta (default) | `commitCount * 2` (even) | `1.6.0-beta.<commitCount>` |
| Release (`-Prelease`) | `commitCount * 2 + 1` (odd) | `1.6.0` |

The commit count rises with every commit and is identical across workflows, so betas always increase, a tagged release of the same commit lands one above its beta, and the next beta lands above the release. At the current 554 commits that's 1108, well above the 227 on Play today. If the count can't be determined (no git), it falls back to `theVersionCode`, which is kept for that purpose.

Verified locally: `assembleDebug` yields `1108 / 1.6.0-beta.554`; with `-Prelease`, `1109 / 1.6.0`.

## Workflows

- **build.yml**: after the signed build on master, a step checks whether the merge touched `androidplot-core/src/main`, `demoapp/src/main`, `demoapp/build.gradle` or `build.gradle`, and if so runs `publishReleaseApk --track beta`. Docs, workflow and test-only changes don't produce a beta.
- **release.yml**: builds and publishes with `-Prelease --track production`. Previously it targeted beta, which would now be redundant.
- Both workflows check out full history so the commit count is available.

## Docs

`docs/contributing.md` gains "What happens on merge" and "Releasing" sections describing snapshots, continuous betas, and the tag-driven release.

## Things to know

- Merging this PR itself touches `demoapp/build.gradle`, so it will publish the first continuous beta.
- Play reviews each testing-track upload before testers see it; a newer upload supersedes one still in review.
- Production promotion remains a deliberate act: push `v<version>`.

