### PR TITLE
Fix pan/zoom clamping and precision, pie donut/labels, series removal and clear()

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -744,11 +744,11 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
         List removedItems = getRegistry().remove(series, rendererClass);
 
         // if series implements PlotListener and is not assigned to any other renderers remove it as a listener:
-        if (removedItems.size() == 1 && series instanceof PlotListener) {
+        final boolean removed = !removedItems.isEmpty();
+        if (removed && series instanceof PlotListener && getSeries(series).isEmpty()) {
             removeListener((PlotListener) series);
-            return true;
         }
-        return false;
+        return removed;
     }
 
     /**
@@ -767,7 +767,7 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     /**
      * Remove all series from the plot.
      */
-    public void clear() {
+    public synchronized void clear() {
         for(SeriesType series : getRegistry().getSeriesList()) {
             if(series instanceof  PlotListener) {
                 removeListener((PlotListener) series);

--- a/androidplot-core/src/main/java/com/androidplot/SeriesRegistry.java
+++ b/androidplot-core/src/main/java/com/androidplot/SeriesRegistry.java
@@ -39,7 +39,7 @@ public abstract class SeriesRegistry
         return registry.isEmpty();
     }
 
-    public boolean add(SeriesType series, FormatterType formatter) {
+    public synchronized boolean add(SeriesType series, FormatterType formatter) {
         if(series == null || formatter == null) {
             throw new IllegalArgumentException("Neither series nor formatter param may be null.");
         }
@@ -94,12 +94,8 @@ public abstract class SeriesRegistry
     /**
      * Remove all series from the plot.
      */
-    public void clear() {
-        for(Iterator<BundleType> it
-            = registry.iterator(); it.hasNext();) {
-            it.next();
-            it.remove();
-        }
+    public synchronized void clear() {
+        registry.clear();
     }
 
     public List<SeriesBundle<SeriesType, FormatterType>> getLegendEnabledItems() {

--- a/androidplot-core/src/main/java/com/androidplot/pie/PieRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/pie/PieRenderer.java
@@ -18,6 +18,9 @@ public class PieRenderer extends SeriesRenderer<PieChart, Segment, SegmentFormat
     private static final float FULL_PIE_DEGS = 360f;
     private static final float HALF_PIE_DEGS = 180f;
 
+    // segments sweeping less than this are considered empty and are not labeled.
+    private static final float MIN_LABELED_SWEEP_DEGS = 0.0001f;
+
     // starting angle to use when drawing the first radial line of the first segment.
     private float startDegs = 0;
 
@@ -73,6 +76,9 @@ public class PieRenderer extends SeriesRenderer<PieChart, Segment, SegmentFormat
     protected void drawSegment(Canvas canvas, RectF bounds, Segment seg, SegmentFormatter f,
             float rad, float startAngle, float sweep) {
         canvas.save();
+
+        // a segment with no sweep (ex. a zero value) has nowhere to put its label:
+        final boolean hasSweep = Math.abs(sweep) > MIN_LABELED_SWEEP_DEGS;
         startAngle = startAngle + f.getRadialInset();
         sweep = sweep - (f.getRadialInset() * 2);
 
@@ -85,17 +91,7 @@ public class PieRenderer extends SeriesRenderer<PieChart, Segment, SegmentFormat
         final float cx = translated.x;
         final float cy = translated.y;
 
-        float donutSizePx;
-        switch (donutMode) {
-            case PERCENT:
-                donutSizePx = donutSize * rad;
-                break;
-            case PIXELS:
-                donutSizePx = (donutSize > 0) ? donutSize : (rad + donutSize);
-                break;
-            default:
-                throw new UnsupportedOperationException("Unsupported DonutMde: " + donutMode);
-        }
+        final float donutSizePx = getDonutSizePx(rad);
 
         final float outerRad = rad - f.getOuterInset();
         final float innerRad = donutSizePx == 0 ? 0 : donutSizePx + f.getInnerInset();
@@ -178,8 +174,25 @@ public class PieRenderer extends SeriesRenderer<PieChart, Segment, SegmentFormat
         // TODO: move segment labelling outside the segment drawing loop
         // TODO: so that the labels will not be clipped by the edge of the next
         // TODO: segment being drawn.
-        if (f.getLabelPaint() != null) {
+        if (hasSweep && f.getLabelPaint() != null) {
             drawSegmentLabel(canvas, labelOrigin, seg, f);
+        }
+    }
+
+    /**
+     * Calculates the size of the pie's empty inner space in pixels.
+     * @param rad The radius of the pie in pixels
+     * @return Size of the donut hole in pixels; 0 means no hole.
+     */
+    protected float getDonutSizePx(float rad) {
+        switch (donutMode) {
+            case PERCENT:
+                return donutSize * rad;
+            case PIXELS:
+                // 0 means no hole; negative values are an inset from the outer radius:
+                return (donutSize >= 0) ? donutSize : (rad + donutSize);
+            default:
+                throw new UnsupportedOperationException("Unsupported DonutMode: " + donutMode);
         }
     }
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
@@ -370,45 +370,49 @@ public class PanZoom implements View.OnTouchListener {
     }
 
     protected void calculatePan(final PointF oldFirstFinger, Region bounds, final boolean horizontal) {
-        final float offset;
+        // all value-space arithmetic is done in double; float has too little precision for
+        // large magnitude axes (ex. epoch millis) to register small finger movements.
+        final Region current = horizontal ? plot.getBounds().getxRegion() : plot.getBounds().getyRegion();
+        double min = current.getMin().doubleValue();
+        double max = current.getMax().doubleValue();
+        final double span = max - min;
+
         // multiply the absolute finger movement for a factor.
         // the factor is dependent on the calculated min and max
+        final double offset;
         if (horizontal) {
-            bounds.setMinMax(plot.getBounds().getxRegion());
-            offset = (oldFirstFinger.x - firstFingerPos.x) *
-                    ((bounds.getMax().floatValue() - bounds.getMin().floatValue()) / plot.getWidth());
+            offset = (oldFirstFinger.x - firstFingerPos.x) * (span / plot.getWidth());
         } else {
-            bounds.setMinMax(plot.getBounds().getyRegion());
-            offset = -(oldFirstFinger.y - firstFingerPos.y) *
-                    ((bounds.getMax().floatValue() - bounds.getMin().floatValue()) / plot.getHeight());
+            offset = -(oldFirstFinger.y - firstFingerPos.y) * (span / plot.getHeight());
         }
-        // move the calculated offset
-        bounds.setMin(bounds.getMin().floatValue() + offset);
-        bounds.setMax(bounds.getMax().floatValue() + offset);
 
-        //get the distance between max and min
-        final float diff = bounds.length().floatValue();
+        // move the calculated offset
+        min += offset;
+        max += offset;
 
         //run if we reached the limit of panning
-        if (horizontal && plot.getOuterLimits().getxRegion().isDefined()) {
-            if (bounds.getMin().floatValue() < plot.getOuterLimits().getMinX().floatValue()) {
-                bounds.setMin(plot.getOuterLimits().getMinX());
-                bounds.setMax(bounds.getMin().floatValue() + diff);
+        final RectRegion limits = plot.getOuterLimits();
+        if (horizontal && limits.getxRegion().isDefined()) {
+            if (min < limits.getMinX().doubleValue()) {
+                min = limits.getMinX().doubleValue();
+                max = min + span;
             }
-            if (bounds.getMax().floatValue() > plot.getOuterLimits().getMaxX().floatValue()) {
-                bounds.setMax(plot.getOuterLimits().getMaxX());
-                bounds.setMin(bounds.getMax().floatValue() - diff);
+            if (max > limits.getMaxX().doubleValue()) {
+                max = limits.getMaxX().doubleValue();
+                min = max - span;
             }
-        } else if(plot.getOuterLimits().getyRegion().isDefined()) {
-            if (bounds.getMin().floatValue() < plot.getOuterLimits().getMinY().floatValue()) {
-                bounds.setMin(plot.getOuterLimits().getMinY());
-                bounds.setMax(bounds.getMin().floatValue() + diff);
+        } else if (!horizontal && limits.getyRegion().isDefined()) {
+            if (min < limits.getMinY().doubleValue()) {
+                min = limits.getMinY().doubleValue();
+                max = min + span;
             }
-            if (bounds.getMax().floatValue() > plot.getOuterLimits().getMaxY().floatValue()) {
-                bounds.setMax(plot.getOuterLimits().getMaxY());
-                bounds.setMin(bounds.getMax().floatValue() - diff);
+            if (max > limits.getMaxY().doubleValue()) {
+                max = limits.getMaxY().doubleValue();
+                min = max - span;
             }
         }
+        bounds.setMin(min);
+        bounds.setMax(max);
     }
 
     protected boolean isValidScale(float scale) {
@@ -428,7 +432,7 @@ public class PanZoom implements View.OnTouchListener {
             // zooming gesture has not happened yet so skip:
             return;
         }
-        RectF newRect = new RectF();
+        RectRegion newRect = new RectRegion(0, 0, 0, 0);
 
         float scaleX = 1;
         float scaleY = 1;
@@ -469,38 +473,63 @@ public class PanZoom implements View.OnTouchListener {
                 Zoom.STRETCH_BOTH,
                 Zoom.SCALE).contains(zoom)) {
             calculateZoom(newRect, scaleX, true);
-            adjustDomainBoundary(newRect.left, newRect.right, BoundaryMode.FIXED);
+            adjustDomainBoundary(newRect.getMinX().doubleValue(),
+                    newRect.getMaxX().doubleValue(), BoundaryMode.FIXED);
         }
         if (EnumSet.of(
                 Zoom.STRETCH_VERTICAL,
                 Zoom.STRETCH_BOTH,
                 Zoom.SCALE).contains(zoom)) {
             calculateZoom(newRect, scaleY, false);
-            adjustRangeBoundary(newRect.top, newRect.bottom, BoundaryMode.FIXED);
+            adjustRangeBoundary(newRect.getMinY().doubleValue(),
+                    newRect.getMaxY().doubleValue(), BoundaryMode.FIXED);
         }
         plot.redraw();
     }
 
     /**
-     *
+     * @deprecated Use {@link #calculateZoom(RectRegion, float, boolean)}; float cannot represent
+     * the bounds of large magnitude axes accurately.
      * @param newRect RectF into which zoom calculation results should be placed.
      * @param scale
      * @param isHorizontal
      */
+    @Deprecated
     protected void calculateZoom(RectF newRect, float scale, boolean isHorizontal) {
-        final float calcMax;
-        final float span;
+        RectRegion result = new RectRegion(newRect.left, newRect.right, newRect.top, newRect.bottom);
+        calculateZoom(result, scale, isHorizontal);
+        if (isHorizontal) {
+            newRect.left = result.getMinX().floatValue();
+            newRect.right = result.getMaxX().floatValue();
+        } else {
+            newRect.top = result.getMinY().floatValue();
+            newRect.bottom = result.getMaxY().floatValue();
+        }
+    }
+
+    /**
+     * Calculates the new bounds of a single axis after zooming by scale around the current midpoint.
+     * All value-space arithmetic is done in double; float has too little precision for large
+     * magnitude axes (ex. epoch millis).
+     * @param newRect RectRegion into which zoom calculation results should be placed.  Only the
+     *                axis selected by isHorizontal is modified.
+     * @param scale
+     * @param isHorizontal
+     */
+    protected void calculateZoom(RectRegion newRect, float scale, boolean isHorizontal) {
+        final double calcMax;
+        final double span;
         final RectRegion bounds = plot.getBounds();
         if (isHorizontal) {
-            calcMax = bounds.getMaxX().floatValue();
-            span = calcMax - bounds.getMinX().floatValue();
+            calcMax = bounds.getMaxX().doubleValue();
+            span = calcMax - bounds.getMinX().doubleValue();
         } else {
-            calcMax = bounds.getMaxY().floatValue();
-            span = calcMax - bounds.getMinY().floatValue();
+            calcMax = bounds.getMaxY().doubleValue();
+            span = calcMax - bounds.getMinY().doubleValue();
         }
 
-        final float midPoint = calcMax - (span / 2.0f);
-        float offset = span * scale / 2.0f;
+        final double midPoint = calcMax - (span / 2.0);
+        double offset = span * scale / 2.0;
         final RectRegion limits = plot.getOuterLimits();
 
         if (isHorizontal ) {
@@ -508,39 +537,43 @@ public class PanZoom implements View.OnTouchListener {
             if (zoomLimit == ZoomLimit.MIN_TICKS) {
                 // make sure we do not zoom in too far (there should be at least one grid line visible)
                 if (plot.getDomainStepValue() > (scale*span)) {
-                    offset = (float)(plot.getDomainStepValue() / 2.0f);
+                    offset = plot.getDomainStepValue() / 2.0;
                 }
             }
 
-            newRect.left = midPoint - offset;
-            newRect.right = midPoint + offset;
+            double left = midPoint - offset;
+            double right = midPoint + offset;
             if(limits.isFullyDefined()) {
-                if (newRect.left < limits.getMinX().floatValue()) {
-                    newRect.left =  limits.getMinX().floatValue();
+                if (left < limits.getMinX().doubleValue()) {
+                    left = limits.getMinX().doubleValue();
                 }
-                if (newRect.right >  limits.getMaxX().floatValue()) {
-                    newRect.right =  limits.getMaxX().floatValue();
+                if (right > limits.getMaxX().doubleValue()) {
+                    right = limits.getMaxX().doubleValue();
                 }
             }
+            newRect.setMinX(left);
+            newRect.setMaxX(right);
         } else {
             // zoom limited and increment by value StepMode?
             if (zoomLimit == ZoomLimit.MIN_TICKS) {
                 // make sure we do not zoom in too far (there should be at least one grid line visible)
                 if (plot.getRangeStepValue() > (scale*span)) {
-                    offset = (float)(plot.getRangeStepValue() / 2.0f);
+                    offset = plot.getRangeStepValue() / 2.0;
                 }
             }
 
-            newRect.top = midPoint - offset;
-            newRect.bottom = midPoint + offset;
+            double top = midPoint - offset;
+            double bottom = midPoint + offset;
             if(limits.isFullyDefined()) {
-                if (newRect.top < limits.getMinY().floatValue()) {
-                    newRect.top = limits.getMinY().floatValue();
+                if (top < limits.getMinY().doubleValue()) {
+                    top = limits.getMinY().doubleValue();
                 }
-                if (newRect.bottom > limits.getMaxY().floatValue()) {
-                    newRect.bottom = limits.getMaxY().floatValue();
+                if (bottom > limits.getMaxY().doubleValue()) {
+                    bottom = limits.getMaxY().doubleValue();
                 }
             }
+            newRect.setMinY(top);
+            newRect.setMaxY(bottom);
         }
     }
 

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -10,10 +10,15 @@ import android.view.View;
 import com.androidplot.test.*;
 import com.androidplot.ui.*;
 import com.androidplot.util.fig.*;
+import com.androidplot.xy.LineAndPointFormatter;
+import com.androidplot.xy.LineAndPointRenderer;
+import com.androidplot.xy.XYPlot;
+import com.androidplot.xy.XYSeries;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.robolectric.Robolectric;
 import org.robolectric.RuntimeEnvironment;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -152,6 +157,71 @@ public class PlotTest extends AndroidplotTest {
         plot.removeSeries(m3);
     }
 
+
+    @Test
+    public void removeSeries_byRenderer_returnsWhetherAnythingWasRemoved() {
+        XYPlot plot = new XYPlot(getContext(), "XYPlot");
+
+        // a plain series that is not a PlotListener:
+        XYSeries s1 = new XYSeries() {
+            @Override
+            public int size() {
+                return 0;
+            }
+
+            @Override
+            public Number getX(int index) {
+                return null;
+            }
+
+            @Override
+            public Number getY(int index) {
+                return null;
+            }
+
+            @Override
+            public String getTitle() {
+                return "s1";
+            }
+        };
+        assertFalse(s1 instanceof PlotListener);
+        plot.addSeries(s1, new LineAndPointFormatter());
+
+        assertTrue(plot.removeSeries(s1, LineAndPointRenderer.class));
+        assertEquals(0, plot.getRegistry().size());
+
+        // nothing left to remove:
+        assertFalse(plot.removeSeries(s1, LineAndPointRenderer.class));
+    }
+
+    @Test
+    public void removeSeries_byRenderer_keepsListenerWhileSeriesIsStillRegistered() {
+        Plot plot = new MockPlot("MockPlot");
+
+        // a PlotListener series registered with two renderers:
+        MockSeries m1 = new MockSeries();
+        plot.addSeries(m1, new MockFormatter1());
+        plot.addSeries(m1, new MockFormatter2());
+        assertTrue(plot.getListeners().contains(m1));
+
+        // still registered with MockRenderer2, so it must remain a listener:
+        assertTrue(plot.removeSeries(m1, MockRenderer1.class));
+        assertTrue(plot.getListeners().contains(m1));
+
+        // now gone from the plot entirely:
+        assertTrue(plot.removeSeries(m1, MockRenderer2.class));
+        assertFalse(plot.getListeners().contains(m1));
+        assertEquals(0, plot.getRegistry().size());
+    }
+
+    @Test
+    public void clear_isSynchronizedWithRendering() throws Exception {
+        // clear() mutates the registry that renderOnCanvas iterates, so it must hold the same
+        // monitor as renderOnCanvas / addSeries / removeSeries:
+        assertTrue(Modifier.isSynchronized(Plot.class.getMethod("clear").getModifiers()));
+        assertTrue(Modifier.isSynchronized(
+                Plot.class.getDeclaredMethod("renderOnCanvas", Canvas.class).getModifiers()));
+    }
 
     @Test
     public void testGetFormatter() {

--- a/androidplot-core/src/test/java/com/androidplot/SeriesRegistryTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/SeriesRegistryTest.java
@@ -13,6 +13,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Modifier;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -37,6 +39,16 @@ public class SeriesRegistryTest extends AndroidplotTest {
         assertEquals(0, seriesRegistry.size());
         seriesRegistry.add(new SimpleXYSeries("s1"), new LineAndPointFormatter());
         assertEquals(1, seriesRegistry.size());
+    }
+
+    @Test
+    public void add_and_clear_areSynchronizedLikeRemove() throws Exception {
+        // the render thread iterates the registry, so every mutator must hold the same monitor:
+        assertTrue(Modifier.isSynchronized(
+                SeriesRegistry.class.getMethod("add", Series.class, Formatter.class).getModifiers()));
+        assertTrue(Modifier.isSynchronized(SeriesRegistry.class.getMethod("clear").getModifiers()));
+        assertTrue(Modifier.isSynchronized(
+                SeriesRegistry.class.getMethod("remove", Series.class).getModifiers()));
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/pie/PieRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/pie/PieRendererTest.java
@@ -235,6 +235,57 @@ public class PieRendererTest extends AndroidplotTest {
     }
 
     @Test
+    public void getDonutSizePx_pixelsMode_zeroMeansNoHole() throws Exception {
+        PieRenderer renderer = new PieRenderer(pieChart);
+
+        renderer.setDonutSize(0, PieRenderer.DonutMode.PIXELS);
+        assertEquals(0f, renderer.getDonutSizePx(100));
+
+        renderer.setDonutSize(10, PieRenderer.DonutMode.PIXELS);
+        assertEquals(10f, renderer.getDonutSizePx(100));
+
+        // negative values are an inset from the outer radius:
+        renderer.setDonutSize(-10, PieRenderer.DonutMode.PIXELS);
+        assertEquals(90f, renderer.getDonutSizePx(100));
+
+        renderer.setDonutSize(0.25f, PieRenderer.DonutMode.PERCENT);
+        assertEquals(25f, renderer.getDonutSizePx(100));
+    }
+
+    @Test
+    public void drawSegment_zeroPixelDonut_drawsFullWedge() throws Exception {
+        PieRenderer renderer = new PieRenderer(pieChart);
+        renderer.setDonutSize(0, PieRenderer.DonutMode.PIXELS);
+        SegmentFormatter formatter = new SegmentFormatter(Color.GREEN);
+
+        renderer.drawSegment(canvas, plotArea, new Segment("s1", 10), formatter, 50, 0, 90);
+
+        // the inner edge of the wedge should be at the center of the pie, not at its outer radius:
+        verify(canvas).drawCircle(anyFloat(), anyFloat(), eq(0f), eq(formatter.getInnerEdgePaint()));
+        verify(canvas).drawCircle(anyFloat(), anyFloat(), eq(50f), eq(formatter.getOuterEdgePaint()));
+    }
+
+    @Test
+    public void onRender_doesNotLabelZeroValueSegments() throws Exception {
+        Segment s1 = new Segment("s1", 8);
+        Segment s2 = new Segment("s2", 0);
+        Segment s3 = new Segment("s3", 2);
+        SegmentFormatter formatter = new SegmentFormatter(Color.GREEN, Color.GREEN, Color.GREEN, Color.GREEN);
+        PieRenderer renderer = spy(formatter.getRendererInstance(pieChart));
+
+        pieChart.addSegment(s1, formatter);
+        pieChart.addSegment(s2, formatter);
+        pieChart.addSegment(s3, formatter);
+
+        renderer.onRender(canvas, plotArea, s1, formatter, renderStack);
+
+        verify(renderer).drawSegmentLabel(eq(canvas), any(PointF.class), eq(s1), eq(formatter));
+        verify(renderer, never()).drawSegmentLabel(eq(canvas), any(PointF.class), eq(s2), eq(formatter));
+        verify(renderer).drawSegmentLabel(eq(canvas), any(PointF.class), eq(s3), eq(formatter));
+        verify(canvas, times(2)).drawText(anyString(), anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    @Test
     public void testSetDonutSize() throws Exception {
 
         Segment segment1 = spy(new Segment("s1", 25));

--- a/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
@@ -139,26 +139,26 @@ public class PanZoomTest extends AndroidplotTest {
 
         // should result in a 2x zoom on domain centerpoint:
         panZoom.zoom(TestUtils.newPointerDownEvent(0, 0, 40, 40));
-        inOrder.verify(xyPlot).setDomainBoundaries(25f, 75f, BoundaryMode.FIXED);
-        inOrder.verify(xyPlot).setRangeBoundaries(25f, 75f, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setDomainBoundaries(25.0, 75.0, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setRangeBoundaries(25.0, 75.0, BoundaryMode.FIXED);
         inOrder.verify(xyPlot).redraw();
 
         // should result in another 2x zoom on domain centerpoint:
         panZoom.zoom(TestUtils.newPointerDownEvent(0, 0, 80, 80));
-        inOrder.verify(xyPlot).setDomainBoundaries(37.5f, 62.5f, BoundaryMode.FIXED);
-        inOrder.verify(xyPlot).setRangeBoundaries(37.5f, 62.5f, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setDomainBoundaries(37.5, 62.5, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setRangeBoundaries(37.5, 62.5, BoundaryMode.FIXED);
         inOrder.verify(xyPlot).redraw();
 
         // should zoom out and take us back to the original bounds:
         panZoom.zoom(TestUtils.newPointerDownEvent(0, 0, 20, 20));
-        inOrder.verify(xyPlot).setDomainBoundaries(0f, 100f, BoundaryMode.FIXED);
-        inOrder.verify(xyPlot).setRangeBoundaries(0f, 100f, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setDomainBoundaries(0.0, 100.0, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setRangeBoundaries(0.0, 100.0, BoundaryMode.FIXED);
         inOrder.verify(xyPlot).redraw();
 
         // zooming out past capped bounds should not result in any change:
         panZoom.zoom(TestUtils.newPointerDownEvent(0, 0, 1, 1));
-        inOrder.verify(xyPlot).setDomainBoundaries(0f, 100f, BoundaryMode.FIXED);
-        inOrder.verify(xyPlot).setRangeBoundaries(0f, 100f, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setDomainBoundaries(0.0, 100.0, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setRangeBoundaries(0.0, 100.0, BoundaryMode.FIXED);
         // TODO: if nothing changed, then why bother redrawing??
         inOrder.verify(xyPlot).redraw();
 
@@ -195,8 +195,8 @@ public class PanZoomTest extends AndroidplotTest {
         // should NOT result in a 2x zoom on domain centerpoint, but in a zoom to
         // the minimum spacing 10 and 20 respectively
         panZoom.zoom(TestUtils.newPointerDownEvent(0, 0, 40, 40));
-        inOrder.verify(xyPlot).setDomainBoundaries(5f, 15f, BoundaryMode.FIXED);
-        inOrder.verify(xyPlot).setRangeBoundaries(5f, 25f, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setDomainBoundaries(5.0, 15.0, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setRangeBoundaries(5.0, 25.0, BoundaryMode.FIXED);
         inOrder.verify(xyPlot).redraw();
 
         // to zoom in beyond min limits
@@ -204,8 +204,8 @@ public class PanZoomTest extends AndroidplotTest {
 
         // should result in another 2x zoom on domain centerpoint:
         panZoom.zoom(TestUtils.newPointerDownEvent(0, 0, 80, 80));
-        inOrder.verify(xyPlot).setDomainBoundaries(7.5f, 12.5f, BoundaryMode.FIXED);
-        inOrder.verify(xyPlot).setRangeBoundaries(10f, 20f, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setDomainBoundaries(7.5, 12.5, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setRangeBoundaries(10.0, 20.0, BoundaryMode.FIXED);
         inOrder.verify(xyPlot).redraw();
 
         // back to limited zoom
@@ -213,8 +213,8 @@ public class PanZoomTest extends AndroidplotTest {
 
         // try to zoom in further, should snap back to min limit:
         panZoom.zoom(TestUtils.newPointerDownEvent(0, 0, 90, 90));
-        inOrder.verify(xyPlot).setDomainBoundaries(5f, 15f, BoundaryMode.FIXED);
-        inOrder.verify(xyPlot).setRangeBoundaries(5f, 25f, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setDomainBoundaries(5.0, 15.0, BoundaryMode.FIXED);
+        inOrder.verify(xyPlot).setRangeBoundaries(5.0, 25.0, BoundaryMode.FIXED);
         inOrder.verify(xyPlot).redraw();
 
         // redraw should not be called again
@@ -223,6 +223,62 @@ public class PanZoomTest extends AndroidplotTest {
         // make sure no panning took place during these zoom ops:
         verify(panZoom, never()).pan(any(MotionEvent.class));
 
+    }
+
+    /**
+     * A 1000px wide plot showing 60 seconds of epoch milliseconds.  Dragging one finger 10px to the
+     * left must shift the domain window right by exactly 600ms; float arithmetic cannot represent
+     * that offset at this magnitude (the float ulp of 1.7e12 is 131072).
+     */
+    @Test
+    public void testPan_keepsPrecisionOnLargeMagnitudeDomain() {
+        final double minX = 1.7e12;
+        final double maxX = minX + 60000;
+        xyPlot = spy(new InstrumentedXYPlot(getContext()));
+        doReturn(1000).when(xyPlot).getWidth();
+        doReturn(500).when(xyPlot).getHeight();
+        xyPlot.setDomainBoundaries(minX, maxX, BoundaryMode.FIXED);
+        xyPlot.setRangeBoundaries(0, 100, BoundaryMode.FIXED);
+        xyPlot.redraw();
+
+        PanZoom panZoom = new PanZoom(xyPlot, PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+        panZoom.onTouch(xyPlot, MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 100, 50, 0));
+        panZoom.onTouch(xyPlot, MotionEvent.obtain(0, 0, MotionEvent.ACTION_MOVE, 90, 50, 0));
+
+        ArgumentCaptor<Number> lower = ArgumentCaptor.forClass(Number.class);
+        ArgumentCaptor<Number> upper = ArgumentCaptor.forClass(Number.class);
+        verify(xyPlot, times(2)).setDomainBoundaries(
+                lower.capture(), upper.capture(), eq(BoundaryMode.FIXED));
+        assertEquals(minX + 600, lower.getValue().doubleValue(), 1);
+        assertEquals(maxX + 600, upper.getValue().doubleValue(), 1);
+    }
+
+    /**
+     * Outer limits defining only a range (y) constraint must not clamp a horizontal pan.
+     */
+    @Test
+    public void testPan_horizontalIgnoresRangeOnlyOuterLimits() {
+        xyPlot = spy(new InstrumentedXYPlot(getContext()));
+        doReturn(1000).when(xyPlot).getWidth();
+        doReturn(500).when(xyPlot).getHeight();
+        xyPlot.setDomainBoundaries(1000, 1100, BoundaryMode.FIXED);
+        xyPlot.setRangeBoundaries(0, 100, BoundaryMode.FIXED);
+        xyPlot.redraw();
+
+        // only y limits are defined; the domain window lies entirely outside of them:
+        xyPlot.getOuterLimits().setMinY(0);
+        xyPlot.getOuterLimits().setMaxY(100);
+
+        PanZoom panZoom = new PanZoom(xyPlot, PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+        panZoom.onTouch(xyPlot, MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 100, 50, 0));
+        panZoom.onTouch(xyPlot, MotionEvent.obtain(0, 0, MotionEvent.ACTION_MOVE, 90, 50, 0));
+
+        ArgumentCaptor<Number> lower = ArgumentCaptor.forClass(Number.class);
+        ArgumentCaptor<Number> upper = ArgumentCaptor.forClass(Number.class);
+        verify(xyPlot, times(2)).setDomainBoundaries(
+                lower.capture(), upper.capture(), eq(BoundaryMode.FIXED));
+        assertEquals(1001d, lower.getValue().doubleValue(), 0.0001);
+        assertEquals(1101d, upper.getValue().doubleValue(), 0.0001);
     }
 
     @Test

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -57,6 +57,13 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix `PieRenderer.setDonutSize(0, DonutMode.PIXELS)` making the pie invisible; a donut size of 0
   pixels now means no hole.
 * Fix pie segments with a zero value drawing their label on top of the neighbouring segment.
+* Fix `Plot.removeSeries(series, rendererClass)` returning false when a series that is not a
+  `PlotListener` was removed, and unregistering a `PlotListener` series (ex. `SimpleXYSeries`,
+  which relies on it for draw-time locking) while the series was still registered with another
+  renderer.
+* Fix `Plot.clear()` and `SeriesRegistry.add()`/`clear()` mutating the series registry without
+  synchronizing against the render thread, which could throw a `ConcurrentModificationException`
+  mid-render.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -54,6 +54,9 @@ For details on what to expect in general when updating to a new version of Andro
   small drags did not move the window and zoom quantized.  The value-space math is now done in
   double.  `PanZoom.calculateZoom(RectF, float, boolean)` is deprecated in favor of a `RectRegion`
   overload.
+* Fix `PieRenderer.setDonutSize(0, DonutMode.PIXELS)` making the pie invisible; a donut size of 0
+  pixels now means no hole.
+* Fix pie segments with a zero value drawing their label on top of the neighbouring segment.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -48,6 +48,12 @@ For details on what to expect in general when updating to a new version of Andro
   `IndexOutOfBoundsException`) and `moveAbove(...)` silently moving it to the bottom when the
   reference element is not in the list; both now throw `IllegalArgumentException` and leave the
   list unchanged.
+* Fix `PanZoom` clamping a horizontal pan to the range (y) outer limits when only `minY`/`maxY`
+  outer limits are set, which snapped the data away on the first drag.
+* Fix `PanZoom` pan and zoom losing precision on large-magnitude axes such as epoch milliseconds;
+  small drags did not move the window and zoom quantized.  The value-space math is now done in
+  double.  `PanZoom.calculateZoom(RectF, float, boolean)` is deprecated in favor of a `RectRegion`
+  overload.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The


### PR DESCRIPTION
Six confirmed bug fixes, each with a regression test that was run against the unfixed code first (TDD order: test written, run and confirmed failing, then the fix applied and the test re-run) and a `* Fix ...` entry under `# 1.6.0` in `docs/release_notes.md`.

## 1. Horizontal pan clamped to the Y outer limits (`PanZoom.calculatePan`)

**Cause:** `if (horizontal && xRegion.isDefined()) {...} else if (yRegion.isDefined()) {...}` fell into the Y branch for a horizontal pan whenever only `minY`/`maxY` outer limits were set, clamping the domain window to the range limits so the data snapped away on the first drag.

**Change:** the second branch now requires `!horizontal`.

**Evidence:** `PanZoomTest.testPan_horizontalIgnoresRangeOnlyOuterLimits` (domain `[1000, 1100]`, outer limits `minY=0, maxY=100` only, 10 px horizontal drag).
- Before: `expected:<1001.0> but was:<0.0>` (domain clamped to the y limits)
- After: passes

## 2. Pan/zoom math in float lost precision on large-magnitude axes (`PanZoom`)

**Cause:** offsets and bounds went through `floatValue()` and `RectF`. With x values around epoch milliseconds (~1.7e12, float ulp 131072) small drags did not move the window and zoom quantized.

**Change:** `calculatePan` and `calculateZoom` now do all value-space arithmetic in `double` (`Number.doubleValue()`, `Region`/`RectRegion`); pixel-space math (finger positions, `fingersRect`, scale ratios) stays `float`. `zoom()` uses a `RectRegion` result instead of a `RectF`. Public API signatures are unchanged; `calculatePan(PointF, Region, boolean)` keeps its signature. The protected `calculateZoom(RectF, float, boolean)` is kept as a `@Deprecated` shim delegating to a new `calculateZoom(RectRegion, float, boolean)` overload. Note for subclassers: `zoom()` now calls the `RectRegion` overload, so an override of the `RectF` version is no longer invoked by the default gesture path.

Because the boundaries passed to `setDomainBoundaries`/`setRangeBoundaries` are now `Double`s rather than `Float`s, the literal expectations in the existing `testZoom`/`testLimitZoom` were updated from e.g. `25f, 75f` to `25.0, 75.0` (`Float.equals(Double)` is false in Mockito matching); the arithmetic still lands on exactly the same values.

**Evidence:** `PanZoomTest.testPan_keepsPrecisionOnLargeMagnitudeDomain` (domain `[1.7e12, 1.7e12 + 60000]`, 1000 px wide plot, 10 px horizontal drag; asserts the window moved by 600 ms within 1 ms).
- Before: `expected:<1.7000000006E12> but was:<1.700000038912E12>` (float rounding of the origin, offset lost entirely)
- After: passes

## 3. Pie: donut size of 0 pixels made the pie invisible (`PieRenderer`)

**Cause:** `donutSizePx = (donutSize > 0) ? donutSize : (rad + donutSize)` treated 0 like a negative inset, giving `innerRad == rad` so every segment collapsed.

**Change:** donut-size computation extracted into `protected float getDonutSizePx(float rad)`; in `PIXELS` mode 0 now means no hole (`donutSize >= 0 ? donutSize : rad + donutSize`). Negative values still mean an inset from the outer radius.

**Evidence:**
- `PieRendererTest.drawSegment_zeroPixelDonut_drawsFullWedge` (fails on unmodified master): verifies the inner edge circle is drawn with radius `0f` and the outer with `50f`. Before: `Argument(s) are different! Wanted: canvas.drawCircle(<any float>, <any float>, 0.0f, ...)`. After: passes.
- `PieRendererTest.getDonutSizePx_pixelsMode_zeroMeansNoHole` (0 -> 0, 10 -> 10, -10 -> rad-10, 25% -> 25). This method did not exist on master, so its fail-before was measured against the pure extraction with the old semantics: `expected:<0.0> but was:<100.0>`. After: passes.

## 4. Pie: zero-value segments still drew their label over neighbours (`PieRenderer.drawSegment`)

**Cause:** the label was drawn unconditionally whenever `labelPaint != null`.

**Change:** the label is skipped when the segment's incoming sweep (before radial insets) is below `MIN_LABELED_SWEEP_DEGS` (0.0001 degrees).

**Evidence:** `PieRendererTest.onRender_doesNotLabelZeroValueSegments` (values 8, 0, 2).
- Before: `NeverWantedButInvoked: pieRenderer.drawSegmentLabel(..., Segment s2, ...)` (three labels drawn)
- After: passes; `drawSegmentLabel` is invoked for s1 and s3 only and `canvas.drawText` exactly twice

## 5. `Plot.removeSeries(series, rendererClass)`: wrong return value and premature listener removal

**Cause:** it returned `false` for any series that is not a `PlotListener` even when a bundle was removed (javadoc says true if anything was removed), and it removed a `PlotListener` series (e.g. `SimpleXYSeries`, which uses `onBeforeDraw`/`onAfterDraw` for its read lock) from the listeners even when the series was still registered with another renderer.

**Change:** returns `!removedItems.isEmpty()`; the listener is only removed when something was removed and `getSeries(series)` is now empty (the series is gone from the registry entirely). No new registry method was needed. The method has no side effect when it returns `false`.

**Evidence:**
- `PlotTest.removeSeries_byRenderer_returnsWhetherAnythingWasRemoved` (plain non-listener `XYSeries` on an `XYPlot`): before `AssertionError` (returned false), after passes; a second removal returns false.
- `PlotTest.removeSeries_byRenderer_keepsListenerWhileSeriesIsStillRegistered` (listener series added with two formatters): before `AssertionError` (listener gone after removing the first), after passes; still a listener after one removal, removed after both.

## 6. `Plot.clear()` and `SeriesRegistry.add()/clear()` unsynchronized against the render thread

**Cause:** `renderOnCanvas` is `synchronized` on the plot and iterates the registry; `clear()` from the UI thread mutated it concurrently, throwing `ConcurrentModificationException` on the render thread (a dropped frame every time). `SeriesRegistry.remove()` was already `synchronized` but `add()`/`clear()` were not.

**Change:** `Plot.clear()` is now `synchronized` (same monitor as `renderOnCanvas`/`addSeries`/`removeSeries`; lock order plot -> registry is unchanged, so no deadlock). `SeriesRegistry.add()` and `clear()` are now `synchronized` consistently with `remove()`; `clear()` simply calls `registry.clear()`.

**Evidence:**
- `PlotTest.clear_isSynchronizedWithRendering` (reflection on `Modifier.SYNCHRONIZED` for `clear()` and `renderOnCanvas`): before `AssertionError`, after passes.
- `SeriesRegistryTest.add_and_clear_areSynchronizedLikeRemove`: before `AssertionError`, after passes.
- Existing `clear_unregistersAllPlotListeners` and `clear_clearsRegistry` continue to cover the behaviour.

## Verification

`./gradlew testDebugUnitTest lint :androidplot-core:assembleRelease :demoapp:assembleDebug` succeeds.

- Unit tests: **233 tests, 0 failures, 0 errors** (baseline on master was 224; 9 new regression tests: 2 in `PanZoomTest`, 3 in `PieRendererTest`, 3 in `PlotTest`, 1 in `SeriesRegistryTest`).
- Lint passes; `androidplot-core-release.aar` and `demoapp-debug.apk` build.
- CRLF line endings preserved in `PlotTest.java`; all other touched files are LF.
- `PanZoom.State`/`getState`/`setState`, `Plot`'s listener list and `XYPlot`'s marker lists were not touched.
