### PR TITLE
Fix legend rendering, widget re-positioning and title XML attributes

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/ui/DynamicTableModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/DynamicTableModel.java
@@ -72,23 +72,57 @@ public class DynamicTableModel extends TableModel {
                                     Axis axis,
                                     int numElementsInTable) {
         int axisElements = 0;
-        
+
         float axisSizePix = 0;
         switch (axis) {
             case ROW:
-                axisElements = numRows;
+                axisElements = calculateNumRows(numElementsInTable);
                 axisSizePix = tableRect.height();
                 break;
             case COLUMN:
-                axisElements = numColumns;
+                axisElements = calculateNumColumns(numElementsInTable);
                 axisSizePix = tableRect.width();
                 break;
         }
-        if(axisElements != 0) {
-            return axisSizePix / axisElements;
+        return axisSizePix / Math.max(axisElements, 1);
+    }
+
+    /**
+     * @param totalElements Number of elements to be laid out in the table.
+     * @return The number of rows the table will actually use; the configured row count
+     * if there is one, otherwise the number of rows needed to fit totalElements into
+     * the configured number of columns (rounded up).
+     */
+    protected int calculateNumRows(int totalElements) {
+        if (numRows > 0) {
+            return numRows;
+        } else if (numColumns > 0) {
+            return ceilDiv(totalElements, numColumns);
         } else {
-            return axisSizePix / numElementsInTable;
+            // unlimited rows and columns (impossible) so default a single row with n columns:
+            return 1;
         }
+    }
+
+    /**
+     * @param totalElements Number of elements to be laid out in the table.
+     * @return The number of columns the table will actually use; the configured column count
+     * if there is one, otherwise the number of columns needed to fit totalElements into
+     * the configured number of rows (rounded up).
+     */
+    protected int calculateNumColumns(int totalElements) {
+        if (numColumns > 0) {
+            return numColumns;
+        } else if (numRows > 0) {
+            return ceilDiv(totalElements, numRows);
+        } else {
+            // unlimited rows and columns (impossible) so default a single row with n columns:
+            return totalElements;
+        }
+    }
+
+    private static int ceilDiv(int dividend, int divisor) {
+        return (dividend + divisor - 1) / divisor;
     }
 
 
@@ -130,23 +164,10 @@ public class DynamicTableModel extends TableModel {
             this.totalElements = totalElements;
             order = dynamicTableModel.getOrder();
 
-            // unlimited columns:
-            if(dynamicTableModel.getNumColumns() == 0 && dynamicTableModel.getNumRows() >= 1) {
-                calculatedRows = dynamicTableModel.getNumRows();
-
-                // round up:
-                calculatedColumns = Float.valueOf((totalElements / (float) calculatedRows) + 0.5f).intValue();
-            } else if(dynamicTableModel.getNumRows() == 0 && dynamicTableModel.getNumColumns() >= 1) {
-                calculatedColumns = dynamicTableModel.getNumColumns();
-                calculatedRows = Float.valueOf((totalElements / (float) calculatedColumns) + 0.5f).intValue();
-            // unlimited rows and columns (impossible) so default a single row with n columns:
-            }else if(dynamicTableModel.getNumColumns() == 0 && dynamicTableModel.getNumRows() == 0) {
-                calculatedRows = 1;
-                calculatedColumns = totalElements;
-            } else {
-                calculatedRows = dynamicTableModel.getNumRows();
-                calculatedColumns = dynamicTableModel.getNumColumns();
-            }
+            // use the same row / column counts that size the cells so that the
+            // table wraps where the cells run out:
+            calculatedRows = dynamicTableModel.calculateNumRows(totalElements);
+            calculatedColumns = dynamicTableModel.calculateNumColumns(totalElements);
             calculatedNumElements = calculatedRows * calculatedColumns;
             lastElementRect = dynamicTableModel.getCellRect(tableRect, totalElements);
         }
@@ -172,8 +193,8 @@ public class DynamicTableModel extends TableModel {
 
             switch (order) {
                 case ROW_MAJOR:
-                    if (dynamicTableModel.getNumColumns() > 0 && lastColumn >= (dynamicTableModel.getNumColumns() - 1)) {
-                        // move to the begining of the next row down:// move to the begining of the next row down:
+                    if (lastColumn >= (calculatedColumns - 1)) {
+                        // move to the begining of the next row down:
                         nextElementRect.offsetTo(tableRect.left, lastElementRect.bottom);
                         lastColumn = 0;
                         lastRow++;
@@ -184,7 +205,7 @@ public class DynamicTableModel extends TableModel {
                     }
                     break;
                 case COLUMN_MAJOR:
-                    if (dynamicTableModel.getNumRows() > 0 && lastRow >= (dynamicTableModel.getNumRows() - 1)) {
+                    if (lastRow >= (calculatedRows - 1)) {
                         // move to the top of the next column over:
                         nextElementRect.offsetTo(lastElementRect.right, tableRect.top);
                         lastRow = 0;

--- a/androidplot-core/src/main/java/com/androidplot/ui/FixedTableModel.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/FixedTableModel.java
@@ -62,11 +62,13 @@ public class FixedTableModel extends TableModel {
         }
 
         private boolean isColumnFinished() {
-            return lastRect.bottom + model.getCellHeight() > tableRect.height();
+            // lastRect is in the same coordinate space as tableRect, so compare
+            // against the table's bottom edge rather than its height:
+            return lastRect.bottom + model.getCellHeight() > tableRect.bottom;
             }
 
         private boolean isRowFinished() {
-            return lastRect.right + model.getCellWidth() > tableRect.width();
+            return lastRect.right + model.getCellWidth() > tableRect.right;
             }
 
         @Override

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendItem.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendItem.java
@@ -8,7 +8,7 @@ public interface LegendItem {
 
     /**
      *
-     * @return The user facing label for this item.
+     * @return The user facing label for this item, or null if it has none.
      */
     String getTitle();
 }

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendWidget.java
@@ -134,12 +134,18 @@ public abstract class LegendWidget<ItemT extends LegendItem> extends Widget {
             canvas.drawRect(iconRect, iconBorderPaint);
         }
 
+        final String title = legendItem.getTitle();
+        if (title == null) {
+            // nothing to draw for an untitled item (Canvas.drawText rejects null):
+            return;
+        }
+
         float centeredTextOriginY = getRectCenterY(cellRect) + (FontUtils.getFontHeight(textPaint)/2);
 
         if (textPaint.getTextAlign().equals(Paint.Align.RIGHT)) {
-            canvas.drawText(legendItem.getTitle(), iconRect.left - 2, centeredTextOriginY, textPaint);
+            canvas.drawText(title, iconRect.left - 2, centeredTextOriginY, textPaint);
         } else {
-            canvas.drawText(legendItem.getTitle(), iconRect.right + 2, centeredTextOriginY, textPaint);
+            canvas.drawText(title, iconRect.right + 2, centeredTextOriginY, textPaint);
         }
     }
 

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/LegendWidget.java
@@ -67,6 +67,10 @@ public abstract class LegendWidget<ItemT extends LegendItem> extends Widget {
         }
         final Iterator<RectF> cellRectIterator = tableModel.getIterator(widgetRect, items.size());
         for(ItemT item : items) {
+            if(!cellRectIterator.hasNext()) {
+                // the table is full; draw what fits rather than failing the whole frame:
+                break;
+            }
             final RectF cellRect = cellRectIterator.next();
             final RectF iconRect = getIconRect(cellRect);
             beginDrawingCell(canvas, iconRect);

--- a/androidplot-core/src/main/java/com/androidplot/ui/widget/Widget.java
+++ b/androidplot-core/src/main/java/com/androidplot/ui/widget/Widget.java
@@ -86,7 +86,12 @@ public abstract class Widget implements BoxModelable, Resizable {
     public void position(float x, HorizontalPositioning horizontalPositioning, float y,
                          VerticalPositioning verticalPositioning, Anchor anchor) {
         setPositionMetrics(new PositionMetrics(x, horizontalPositioning, y, verticalPositioning, anchor));
-        layoutManager.addToTop(this);
+
+        // only add on the first call; re-positioning an existing widget must not
+        // draw it a second time or alter its z-order:
+        if (!layoutManager.contains(this)) {
+            layoutManager.addToTop(this);
+        }
     }
 
     /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYGraphWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYGraphWidget.java
@@ -362,24 +362,6 @@ public class XYGraphWidget extends Widget {
                 R.styleable.xy_XYPlot_graphAnchor, R.styleable.xy_XYPlot_graphVisible
         );
 
-        // domainLabel size & position
-        AttrUtils.configureWidget(attrs, this,
-                R.styleable.xy_XYPlot_domainTitleHeightMode, R.styleable.xy_XYPlot_domainTitleHeight,
-                R.styleable.xy_XYPlot_domainTitleWidthMode, R.styleable.xy_XYPlot_domainTitleWidth,
-                R.styleable.xy_XYPlot_domainTitleHorizontalPositioning, R.styleable.xy_XYPlot_domainTitleHorizontalPosition,
-                R.styleable.xy_XYPlot_domainTitleVerticalPositioning, R.styleable.xy_XYPlot_domainTitleVerticalPosition,
-                R.styleable.xy_XYPlot_domainTitleAnchor, R.styleable.xy_XYPlot_domainTitleVisible
-        );
-
-        // rangeLabel size & position
-        AttrUtils.configureWidget(attrs, this,
-                R.styleable.xy_XYPlot_rangeTitleHeightMode, R.styleable.xy_XYPlot_rangeTitleHeight,
-                R.styleable.xy_XYPlot_rangeTitleWidthMode, R.styleable.xy_XYPlot_rangeTitleWidth,
-                R.styleable.xy_XYPlot_rangeTitleHorizontalPositioning, R.styleable.xy_XYPlot_rangeTitleHorizontalPosition,
-                R.styleable.xy_XYPlot_rangeTitleVerticalPositioning, R.styleable.xy_XYPlot_rangeTitleVerticalPosition,
-                R.styleable.xy_XYPlot_rangeTitleAnchor, R.styleable.xy_XYPlot_rangeTitleVisible
-        );
-
         // rotation
         AttrUtils.configureWidgetRotation(attrs, this, R.styleable.xy_XYPlot_graphRotation);
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYLegendItem.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYLegendItem.java
@@ -2,6 +2,7 @@
 package com.androidplot.xy;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.androidplot.ui.widget.LegendItem;
 
@@ -16,13 +17,14 @@ public class XYLegendItem implements LegendItem {
     public final Object item;
     private final String text;
 
-    public XYLegendItem(@NonNull Type cellType, @NonNull Object item, @NonNull String text) {
+    public XYLegendItem(@NonNull Type cellType, @NonNull Object item, @Nullable String text) {
         this.type = cellType;
         this.item = item;
         this.text = text;
     }
 
     @Override
+    @Nullable
     public String getTitle() {
         return this.text;
     }

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYLegendWidget.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYLegendWidget.java
@@ -13,8 +13,8 @@ import com.androidplot.ui.widget.LegendWidget;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 /**
@@ -36,7 +36,10 @@ public class XYLegendWidget extends LegendWidget<XYLegendItem> {
             @Override
             public int compare(XYLegendItem o1, XYLegendItem o2) {
                 if(o1.type == o2.type) {
-                    return o1.getTitle().compareTo(o2.getTitle());
+                    // series and regions may have no title; sort those as an empty string:
+                    final String t1 = o1.getTitle() != null ? o1.getTitle() : "";
+                    final String t2 = o2.getTitle() != null ? o2.getTitle() : "";
+                    return t1.compareTo(t2);
                 } else {
                     return(o1.type.compareTo(o2.type));
                 }
@@ -71,7 +74,7 @@ public class XYLegendWidget extends LegendWidget<XYLegendItem> {
         }
 
         for (XYSeriesRenderer renderer : plot.getRendererList()) {
-            Hashtable<XYRegionFormatter, String> urf = renderer.getUniqueRegionFormatters();
+            Map<XYRegionFormatter, String> urf = renderer.getUniqueRegionFormatters();
             for (Entry<XYRegionFormatter, String> entry : urf.entrySet()) {
                 items.add(new XYLegendItem(XYLegendItem.Type.REGION, entry.getKey(), entry.getValue()));
             }

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
@@ -314,6 +314,22 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
                 R.styleable.xy_XYPlot_legendVerticalPositioning, R.styleable.xy_XYPlot_legendVerticalPosition,
                 R.styleable.xy_XYPlot_legendAnchor, R.styleable.xy_XYPlot_legendVisible);
 
+        // domainTitle size & position
+        AttrUtils.configureWidget(attrs, getDomainTitle(),
+                R.styleable.xy_XYPlot_domainTitleHeightMode, R.styleable.xy_XYPlot_domainTitleHeight,
+                R.styleable.xy_XYPlot_domainTitleWidthMode, R.styleable.xy_XYPlot_domainTitleWidth,
+                R.styleable.xy_XYPlot_domainTitleHorizontalPositioning, R.styleable.xy_XYPlot_domainTitleHorizontalPosition,
+                R.styleable.xy_XYPlot_domainTitleVerticalPositioning, R.styleable.xy_XYPlot_domainTitleVerticalPosition,
+                R.styleable.xy_XYPlot_domainTitleAnchor, R.styleable.xy_XYPlot_domainTitleVisible);
+
+        // rangeTitle size & position
+        AttrUtils.configureWidget(attrs, getRangeTitle(),
+                R.styleable.xy_XYPlot_rangeTitleHeightMode, R.styleable.xy_XYPlot_rangeTitleHeight,
+                R.styleable.xy_XYPlot_rangeTitleWidthMode, R.styleable.xy_XYPlot_rangeTitleWidth,
+                R.styleable.xy_XYPlot_rangeTitleHorizontalPositioning, R.styleable.xy_XYPlot_rangeTitleHorizontalPosition,
+                R.styleable.xy_XYPlot_rangeTitleVerticalPositioning, R.styleable.xy_XYPlot_rangeTitleVerticalPosition,
+                R.styleable.xy_XYPlot_rangeTitleAnchor, R.styleable.xy_XYPlot_rangeTitleVisible);
+
         getGraph().processAttrs(attrs);
     }
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYSeriesRenderer.java
@@ -6,7 +6,8 @@ import com.androidplot.ui.SeriesBundle;
 import com.androidplot.ui.SeriesRenderer;
 import com.androidplot.util.Layerable;
 
-import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Base class for all Renderers that render XYSeries data.
@@ -21,11 +22,13 @@ public abstract class XYSeriesRenderer<SeriesType extends XYSeries, XYFormatterT
 
     /**
      * TODO: get rid of this method!
-     * @return Map of all unique XYRegionFormatters to region labels.
+     * @return Map of all unique XYRegionFormatters to region labels, in the order the regions
+     * were encountered.  A region without a label maps to null.
      */
-    public Hashtable<XYRegionFormatter, String> getUniqueRegionFormatters() {
+    public Map<XYRegionFormatter, String> getUniqueRegionFormatters() {
 
-        Hashtable<XYRegionFormatter, String> found = new Hashtable<>();
+        // a LinkedHashMap rather than a Hashtable; regions are not required to have a label:
+        Map<XYRegionFormatter, String> found = new LinkedHashMap<>();
         for(SeriesBundle<SeriesType, ? extends XYFormatterType> sfPair : getSeriesAndFormatterList()) {
             Layerable<RectRegion> regionIndexer = sfPair.getFormatter().getRegions();
             for (RectRegion region : regionIndexer.elements()) {

--- a/androidplot-core/src/test/java/com/androidplot/ui/DynamicTableModelTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/DynamicTableModelTest.java
@@ -40,6 +40,104 @@ public class DynamicTableModelTest {
         assertEquals(400f, cellRect.height());
     }
 
+    @Test
+    public void testGetCellRect_dynamicAxisSizedByComputedRowOrColumnCount() throws Exception {
+        RectF tableRect = new RectF(0, 0, 1000, 900);
+
+        // 2 fixed rows, 4 elements -> 2 columns of 500px:
+        DynamicTableModel model = new DynamicTableModel(0, 2);
+        RectF cellRect = model.getCellRect(tableRect, 4);
+        assertEquals(500f, cellRect.width());
+        assertEquals(450f, cellRect.height());
+
+        // 3 fixed rows, 4 elements -> 2 columns (round up), not 1:
+        model = new DynamicTableModel(0, 3);
+        cellRect = model.getCellRect(tableRect, 4);
+        assertEquals(500f, cellRect.width());
+        assertEquals(300f, cellRect.height());
+
+        // 3 fixed columns, 4 elements -> 2 rows of 450px:
+        model = new DynamicTableModel(3, 0);
+        cellRect = model.getCellRect(tableRect, 4);
+        assertEquals(1000f / 3, cellRect.width(), 0.001f);
+        assertEquals(450f, cellRect.height());
+    }
+
+    @Test
+    public void testIterator_roundsDynamicAxisUp() throws Exception {
+        // 3 fixed rows, 4 elements: needs 2 columns, so 6 cells of capacity:
+        TableModel model = new DynamicTableModel(0, 3);
+        RectF tableRect = new RectF(0, 0, 1000, 900);
+        Iterator<RectF> it = model.getIterator(tableRect, 4);
+        int iterations = 0;
+        while (it.hasNext()) {
+            it.next();
+            iterations++;
+        }
+        assertEquals(6, iterations);
+    }
+
+    @Test
+    public void testRowMajorIteration_dynamicColumns_wrapsAtComputedColumnCount() throws Exception {
+        // 3 fixed rows, 4 elements -> 2 columns x 3 rows on a 1000x900 table:
+        TableModel model = new DynamicTableModel(0, 3, TableOrder.ROW_MAJOR);
+        RectF tableRect = new RectF(0, 0, 1000, 900);
+        Iterator<RectF> it = model.getIterator(tableRect, 4);
+
+        // cell 0 (top-left)
+        RectF cellRect = it.next();
+        assertEquals(new RectF(0, 0, 500, 300), cellRect);
+
+        // cell 1 (top-right)
+        cellRect = it.next();
+        assertEquals(new RectF(500, 0, 1000, 300), cellRect);
+
+        // cell 2 (middle-left; wrapped to the next row)
+        cellRect = it.next();
+        assertEquals(new RectF(0, 300, 500, 600), cellRect);
+
+        // cell 3 (middle-right)
+        cellRect = it.next();
+        assertEquals(new RectF(500, 300, 1000, 600), cellRect);
+    }
+
+    @Test
+    public void testColumnMajorIteration_dynamicColumns_fillsTableWidth() throws Exception {
+        // 2 fixed rows, 4 elements -> 2 columns x 2 rows on a 1000x1000 table:
+        TableModel model = new DynamicTableModel(0, 2, TableOrder.COLUMN_MAJOR);
+        RectF tableRect = new RectF(0, 0, 1000, 1000);
+        Iterator<RectF> it = model.getIterator(tableRect, 4);
+
+        // cell 0 (top-left)
+        RectF cellRect = it.next();
+        assertEquals(new RectF(0, 0, 500, 500), cellRect);
+
+        // cell 1 (bottom-left)
+        cellRect = it.next();
+        assertEquals(new RectF(0, 500, 500, 1000), cellRect);
+
+        // cell 2 (top-right)
+        cellRect = it.next();
+        assertEquals(new RectF(500, 0, 1000, 500), cellRect);
+
+        // cell 3 (bottom-right)
+        cellRect = it.next();
+        assertEquals(new RectF(500, 500, 1000, 1000), cellRect);
+    }
+
+    @Test
+    public void testColumnMajorIteration_dynamicRows_wrapsAtComputedRowCount() throws Exception {
+        // 2 fixed columns, 4 elements -> 2 rows x 2 columns on a 1000x1000 table:
+        TableModel model = new DynamicTableModel(2, 0, TableOrder.COLUMN_MAJOR);
+        RectF tableRect = new RectF(0, 0, 1000, 1000);
+        Iterator<RectF> it = model.getIterator(tableRect, 4);
+
+        assertEquals(new RectF(0, 0, 500, 500), it.next());
+        assertEquals(new RectF(0, 500, 500, 1000), it.next());
+        assertEquals(new RectF(500, 0, 1000, 500), it.next());
+        assertEquals(new RectF(500, 500, 1000, 1000), it.next());
+    }
+
     @Test public void testIterator() throws Exception {
         TableModel model = new DynamicTableModel(2, 2);
 

--- a/androidplot-core/src/test/java/com/androidplot/ui/FixedTableModelTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/FixedTableModelTest.java
@@ -227,4 +227,64 @@ public class FixedTableModelTest extends AndroidplotTest {
         assertEquals(600f, cellRect.right);
         assertEquals(500f, cellRect.bottom);
     }
+
+    /**
+     * Same layout as {@link #testColumnMajor()} but with the table rect offset from the origin;
+     * cells should wrap at the table's right edge, not at its width.
+     */
+    @Test
+    public void testColumnMajor_offsetTableRect() throws Exception {
+        FixedTableModel model = new FixedTableModel(300, 500, TableOrder.COLUMN_MAJOR);
+
+        final float offsetX = 300;
+        final float offsetY = 400;
+        RectF tableRect = new RectF(offsetX, offsetY, offsetX + 1000, offsetY + 2000);
+
+        Iterator<RectF> it = model.getIterator(tableRect, 25);
+
+        // 3 columns x 4 rows fit in a 1000x2000 table with 300x500 cells:
+        for (int row = 0; row < 4; row++) {
+            for (int col = 0; col < 3; col++) {
+                assertTrue("row " + row + " col " + col, it.hasNext());
+                RectF cellRect = it.next();
+                assertEquals(offsetX + (col * 300f), cellRect.left);
+                assertEquals(offsetY + (row * 500f), cellRect.top);
+                assertEquals(offsetX + ((col + 1) * 300f), cellRect.right);
+                assertEquals(offsetY + ((row + 1) * 500f), cellRect.bottom);
+            }
+        }
+
+        // we've reached the limit
+        assertFalse(it.hasNext());
+    }
+
+    /**
+     * Same layout as {@link #testRowMajor()} but with the table rect offset from the origin;
+     * cells should wrap at the table's bottom edge, not at its height.
+     */
+    @Test
+    public void testRowMajor_offsetTableRect() throws Exception {
+        FixedTableModel model = new FixedTableModel(300, 500, TableOrder.ROW_MAJOR);
+
+        final float offsetX = 300;
+        final float offsetY = 400;
+        RectF tableRect = new RectF(offsetX, offsetY, offsetX + 1000, offsetY + 2000);
+
+        Iterator<RectF> it = model.getIterator(tableRect, 25);
+
+        // 4 rows x 3 columns fit in a 1000x2000 table with 300x500 cells:
+        for (int col = 0; col < 3; col++) {
+            for (int row = 0; row < 4; row++) {
+                assertTrue("row " + row + " col " + col, it.hasNext());
+                RectF cellRect = it.next();
+                assertEquals(offsetX + (col * 300f), cellRect.left);
+                assertEquals(offsetY + (row * 500f), cellRect.top);
+                assertEquals(offsetX + ((col + 1) * 300f), cellRect.right);
+                assertEquals(offsetY + ((row + 1) * 500f), cellRect.bottom);
+            }
+        }
+
+        // we've reached the limit
+        assertFalse(it.hasNext());
+    }
 }

--- a/androidplot-core/src/test/java/com/androidplot/ui/widget/WidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/widget/WidgetTest.java
@@ -90,6 +90,31 @@ public class WidgetTest extends AndroidplotTest {
     }
 
     @Test
+    public void position_calledRepeatedly_addsWidgetToLayoutManagerOnceAndKeepsZOrder() {
+        final LayoutManager realLayoutManager = new LayoutManager();
+        final Widget bottom = new TestWidget(realLayoutManager, size);
+        final Widget top = new TestWidget(realLayoutManager, size);
+
+        bottom.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        top.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        assertEquals(2, realLayoutManager.size());
+        assertEquals(0, realLayoutManager.indexOf(bottom));
+        assertEquals(1, realLayoutManager.indexOf(top));
+
+        // re-positioning an already added widget must neither add it again nor change its z-order:
+        bottom.position(10, HorizontalPositioning.ABSOLUTE_FROM_RIGHT,
+                10, VerticalPositioning.ABSOLUTE_FROM_BOTTOM, Anchor.RIGHT_BOTTOM);
+        assertEquals(2, realLayoutManager.size());
+        assertEquals(0, realLayoutManager.indexOf(bottom));
+        assertEquals(0, realLayoutManager.lastIndexOf(bottom));
+        assertEquals(1, realLayoutManager.indexOf(top));
+        assertEquals(10F, bottom.getPositionMetrics().getXPositionMetric().getValue());
+        assertEquals(Anchor.RIGHT_BOTTOM, bottom.getAnchor());
+    }
+
+    @Test
     public void draw_sizeChanged_invokesOnResizeBeforeDoOnDraw() {
         InOrder inOrder = Mockito.inOrder(widget);
 

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYLegendWidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYLegendWidgetTest.java
@@ -19,9 +19,12 @@ import org.mockito.Mockito;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -98,6 +101,59 @@ public class XYLegendWidgetTest extends AndroidplotTest {
         inOrder.verify(legendWidget).drawIcon(any(Canvas.class), any(RectF.class), eq(i2));
         inOrder.verify(legendWidget).drawIcon(any(Canvas.class), any(RectF.class), eq(i3));
         inOrder.verify(legendWidget).drawIcon(any(Canvas.class), any(RectF.class), eq(i1));
+    }
+
+    @Test
+    public void draw_nullSeriesTitles_sortsAndDrawsWithoutThrowing() throws Exception {
+        // CandlestickSeries et al. create series with a null title:
+        final XYSeries untitled1 = new SimpleXYSeries(null);
+        final XYSeries untitled2 = new SimpleXYSeries(null);
+        final XYSeries titled = new SimpleXYSeries("titled");
+        seriesRegistry.add(untitled1, new LineAndPointFormatter());
+        seriesRegistry.add(untitled2, new LineAndPointFormatter());
+        seriesRegistry.add(titled, new LineAndPointFormatter());
+
+        legendWidget.draw(canvas);
+
+        verify(legendWidget, times(3))
+                .drawIcon(any(Canvas.class), any(RectF.class), any(XYLegendItem.class));
+        verify(canvas, times(1)).drawText(eq("titled"), anyFloat(), anyFloat(), any(Paint.class));
+        verify(canvas, never()).drawText((String) isNull(), anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    @Test
+    public void draw_nullTitleWithoutComparator_drawsNoTextForThatItem() throws Exception {
+        legendWidget.setLegendItemComparator(null);
+        final XYLegendItem untitled = new XYLegendItem(XYLegendItem.Type.SERIES,
+                new LineAndPointFormatter(), null);
+        final XYLegendItem titled = new XYLegendItem(XYLegendItem.Type.SERIES,
+                new LineAndPointFormatter(), "titled");
+        doReturn(Lists.newArrayList(untitled, titled)).when(legendWidget).getLegendItems();
+
+        legendWidget.draw(canvas);
+
+        verify(legendWidget, times(2))
+                .drawIcon(any(Canvas.class), any(RectF.class), any(XYLegendItem.class));
+        verify(canvas, times(1)).drawText(eq("titled"), anyFloat(), anyFloat(), any(Paint.class));
+        verify(canvas, never()).drawText((String) isNull(), anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    @Test
+    public void draw_regionWithoutLabel_drawsRegionIconWithoutThrowing() throws Exception {
+        final XYSeries series = new SimpleXYSeries("series");
+        final XYSeriesFormatter formatter = new LineAndPointFormatter();
+
+        // the 4-arg RectRegion constructor leaves the label null:
+        formatter.addRegion(new RectRegion(0, 10, 0, 10), new XYRegionFormatter(0));
+        formatter.addRegion(new RectRegion(0, 20, 0, 20, "labelled"), new XYRegionFormatter(0));
+        seriesRegistry.add(series, formatter);
+
+        legendWidget.draw(canvas);
+
+        verify(legendWidget, times(2))
+                .drawRegionLegendIcon(any(Canvas.class), any(RectF.class), any(XYRegionFormatter.class));
+        verify(canvas, times(1)).drawText(eq("labelled"), anyFloat(), anyFloat(), any(Paint.class));
+        verify(canvas, never()).drawText((String) isNull(), anyFloat(), anyFloat(), any(Paint.class));
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYLegendWidgetTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYLegendWidgetTest.java
@@ -99,4 +99,21 @@ public class XYLegendWidgetTest extends AndroidplotTest {
         inOrder.verify(legendWidget).drawIcon(any(Canvas.class), any(RectF.class), eq(i3));
         inOrder.verify(legendWidget).drawIcon(any(Canvas.class), any(RectF.class), eq(i1));
     }
+
+    @Test
+    public void draw_moreItemsThanTableCells_drawsWhatFitsWithoutThrowing() throws Exception {
+        // a 2x2 table can only hold 4 of the 5 items:
+        legendWidget.setTableModel(new DynamicTableModel(2, 2));
+        final List<XYLegendItem> legendItems = Lists.newArrayList();
+        for (int i = 0; i < 5; i++) {
+            legendItems.add(new XYLegendItem(XYLegendItem.Type.SERIES,
+                    new LineAndPointFormatter(), "item " + i));
+        }
+        doReturn(legendItems).when(legendWidget).getLegendItems();
+
+        legendWidget.draw(canvas);
+
+        verify(legendWidget, times(4))
+                .drawIcon(any(Canvas.class), any(RectF.class), any(XYLegendItem.class));
+    }
 }

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
@@ -2,14 +2,21 @@
 
 package com.androidplot.xy;
 
+import android.content.res.TypedArray;
+import android.util.TypedValue;
 import android.graphics.*;
 import com.androidplot.Plot;
+import com.androidplot.R;
 import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.SizeMode;
 import com.androidplot.util.fig.*;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.robolectric.RuntimeEnvironment;
 
 import java.util.Arrays;
@@ -18,12 +25,22 @@ import java.util.Iterator;
 import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class XYPlotTest extends AndroidplotTest {
 
+    @Mock
+    TypedArray typedArray;
+
     XYPlot plot;  // testing
-    
+
     List<Integer> numList1;
     List<Integer> numList2;
     SimpleXYSeries series0To100;
@@ -703,5 +720,68 @@ public class XYPlotTest extends AndroidplotTest {
         plot.removeMarkers();
         assertEquals(0, plot.getXValueMarkers().size());
         assertEquals(0, plot.getYValueMarkers().size());
+    }
+
+    /**
+     * Makes the mock TypedArray behave like an empty attribute set: every
+     * boolean / int / float lookup returns the supplied default.
+     */
+    private void stubAttrsAsDefaults() {
+        final Answer<Object> returnDefault = new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                return invocation.getArgument(1);
+            }
+        };
+        when(typedArray.getBoolean(anyInt(), anyBoolean())).thenAnswer(returnDefault);
+        when(typedArray.getInt(anyInt(), anyInt())).thenAnswer(returnDefault);
+        when(typedArray.getFloat(anyInt(), anyFloat())).thenAnswer(returnDefault);
+    }
+
+    @Test
+    public void processAttrs_domainTitleVisibleFalse_hidesDomainTitleOnly() {
+        stubAttrsAsDefaults();
+        when(typedArray.getBoolean(eq(R.styleable.xy_XYPlot_domainTitleVisible), anyBoolean()))
+                .thenReturn(false);
+
+        plot.processAttrs(typedArray);
+
+        assertFalse(plot.getDomainTitle().isVisible());
+        assertTrue(plot.getRangeTitle().isVisible());
+        assertTrue(plot.getGraph().isVisible());
+        assertTrue(plot.getLegend().isVisible());
+    }
+
+    @Test
+    public void processAttrs_rangeTitleVisibleFalse_hidesRangeTitleOnly() {
+        stubAttrsAsDefaults();
+        when(typedArray.getBoolean(eq(R.styleable.xy_XYPlot_rangeTitleVisible), anyBoolean()))
+                .thenReturn(false);
+
+        plot.processAttrs(typedArray);
+
+        assertFalse(plot.getRangeTitle().isVisible());
+        assertTrue(plot.getDomainTitle().isVisible());
+        assertTrue(plot.getGraph().isVisible());
+        assertTrue(plot.getLegend().isVisible());
+    }
+
+    @Test
+    public void processAttrs_domainTitleHeight_resizesDomainTitleOnly() {
+        stubAttrsAsDefaults();
+        final float graphHeight = plot.getGraph().getSize().getHeight().getValue();
+        final SizeMode graphHeightMode = plot.getGraph().getSize().getHeight().getLayoutType();
+        final TypedValue dimension = new TypedValue();
+        dimension.type = TypedValue.TYPE_DIMENSION;
+        when(typedArray.hasValue(R.styleable.xy_XYPlot_domainTitleHeight)).thenReturn(true);
+        when(typedArray.peekValue(R.styleable.xy_XYPlot_domainTitleHeight)).thenReturn(dimension);
+        when(typedArray.getDimension(eq(R.styleable.xy_XYPlot_domainTitleHeight), anyFloat()))
+                .thenReturn(123f);
+
+        plot.processAttrs(typedArray);
+
+        assertEquals(123f, plot.getDomainTitle().getSize().getHeight().getValue());
+        assertEquals(graphHeight, plot.getGraph().getSize().getHeight().getValue());
+        assertEquals(graphHeightMode, plot.getGraph().getSize().getHeight().getLayoutType());
     }
 }

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -42,6 +42,21 @@ For details on what to expect in general when updating to a new version of Andro
   `[0, 1]` range when the wrapped series changes after construction.  Auto-calculated bounds are now
   refreshed before each draw (`NormedXYSeries` implements `PlotListener`) and can be refreshed
   manually via the new `normalize()` method.
+* Fix the legend (along with the plot title and border) disappearing, with an exception logged on
+  every frame, when a series has no title (e.g. candlestick plots), a region has no label, or there
+  are more legend items than the legend's `TableModel` can hold.  Untitled items now draw without
+  text, an over-full legend draws what fits, and `DynamicTableModel` rounds its dynamic axis up and
+  sizes cells by the computed row/column count so a table such as `DynamicTableModel(0, 2)` fills
+  its width.  `XYSeriesRenderer.getUniqueRegionFormatters()` now returns a `Map` (a
+  `LinkedHashMap`) instead of a `Hashtable`.
+* Fix `Widget.position(...)` re-adding the widget to the `LayoutManager` on every call, which drew
+  the widget again on top of everything positioned before it (e.g. the graph covering the legend
+  and titles after `plot.getGraph().position(...)`).
+* Fix `FixedTableModel` wrapping immediately (or laying out nothing) for any table whose rect does
+  not start at the plot origin.
+* Fix the `domainTitle*` and `rangeTitle*` size, position, anchor and visibility XML attributes
+  being applied to the graph widget instead of the domain and range title widgets, so e.g.
+  `ap:domainTitleVisible="false"` hid the entire graph.
 * The XML configuration engine (formerly the separate Fig library) is now part of androidplot-core;
   the library no longer has a dependency on `com.halfhp.fig:figlib`.  See the new
   [XML Configuration](xml_configuration.md) doc.


### PR DESCRIPTION
Fixes four bugs in legend rendering, widget positioning and XML attribute handling. Each fix has a regression test that was confirmed to fail on the unfixed code and pass after the change.

## 1. Legend crashes swallowed on every frame

`Plot.renderOnCanvas` catches exceptions from `layoutManager.draw`, so any exception in the legend path made the legend, plot title and border vanish and logged an exception on every frame. Three triggers:

### 1a. Null series titles
**Cause:** `XYLegendWidget`'s default comparator calls `o1.getTitle().compareTo(o2.getTitle())`; `CandlestickSeries` creates its four series with `new SimpleXYSeries(null)`, so any candlestick plot with a visible legend failed to sort. `LegendWidget.finishDrawingCell` also passed the null title to `Canvas.drawText`, which NPEs on a real canvas.
**Change:** the comparator treats a null title as `""`; `finishDrawingCell` skips the text draw for a null title. `XYLegendItem`'s title is now annotated `@Nullable`.
**Evidence:** `XYLegendWidgetTest.draw_nullSeriesTitles_sortsAndDrawsWithoutThrowing` failed with `NullPointerException: Cannot invoke "String.compareTo(String)" because the return value of "XYLegendItem.getTitle()" is null`; `draw_nullTitleWithoutComparator_drawsNoTextForThatItem` failed with `NeverWantedButInvoked: canvas.drawText(isNull(), ...)`. Both pass after the fix.

### 1b. Regions without a label
**Cause:** `XYSeriesRenderer.getUniqueRegionFormatters` stored `region.getLabel()` in a `Hashtable`, which rejects null values; the 4-arg `RectRegion` constructor leaves the label null.
**Change:** the method now returns a `Map` backed by a `LinkedHashMap` (insertion order, null-tolerant). Note this changes the public return type from `Hashtable` to `Map`; the only in-repo caller (`XYLegendWidget`) is updated. An unlabelled region draws its icon with no text.
**Evidence:** `XYLegendWidgetTest.draw_regionWithoutLabel_drawsRegionIconWithoutThrowing` failed with `NullPointerException` (from `Hashtable.put`), passes after.

### 1c. More legend items than the table can hold
**Cause:** `LegendWidget.doOnDraw` called `cellRectIterator.next()` for every item without `hasNext()`, and `DynamicTableModel`'s iterator throws `IndexOutOfBoundsException` past its capacity. The capacity itself was under-computed: "round up" was implemented as round-to-nearest (`(total / rows) + 0.5f`), so `DynamicTableModel(0, 3)` with 4 items yielded 1 column (3 cells). `getCellRect` also divided the dynamic axis by the item count while the iterator wrapped on the configured count, so `DynamicTableModel(0, 2)` with 4 items on a 1000px rect produced 250px cells that filled half the width (COLUMN_MAJOR) or never wrapped (ROW_MAJOR).
**Change:** `DynamicTableModel` derives row and column counts via ceiling division in two shared helpers (`calculateNumRows` / `calculateNumColumns`) used by both `getCellRect` and the iterator, and the iterator's wrap decisions use those computed counts. `LegendWidget.doOnDraw` breaks out of the loop when the iterator has no next cell, so an over-full legend draws what fits.
Behavior note: the default `DynamicTableModel(0, 1)` used by `XYPlot` and `PieChart` is unaffected. Tables with one fixed axis greater than 1 now wrap at the computed count and get larger cells on the dynamic axis; previously e.g. `(2, 0, COLUMN_MAJOR)` stacked every item in a single column.
**Evidence:** on the unfixed code, `XYLegendWidgetTest.draw_moreItemsThanTableCells_drawsWhatFitsWithoutThrowing` failed with `IndexOutOfBoundsException`, and the five new `DynamicTableModelTest` cases failed with `expected:<6> but was:<3>` (capacity), `expected:<500.0> but was:<250.0>` (cell width) and `expected:<RectF(0.0, 0.0, 500.0, 500.0)> but was:<RectF(0.0, 0.0, 250.0, 500.0)>` / `... 500.0, 250.0` (cell rects). All pass after; existing table model tests unchanged.

## 2. `Widget.position()` re-adds the widget on every call
**Cause:** `Widget.position(...)` unconditionally called `layoutManager.addToTop(this)`; `LayerListOrganizer.addToTop` is a plain list add. Following the docs' advice to call `plot.getGraph().position(...)` at runtime appended the graph again, drawing it (and every series) a second time on top of the legend and titles, and the list grew without bound.
**Change:** only add when `!layoutManager.contains(this)` (`LayoutManager` extends `LinkedList`; no Widget overrides `equals`, so this is identity). Z-order is left untouched on re-positioning.
**Evidence:** `WidgetTest.position_calledRepeatedly_addsWidgetToLayoutManagerOnceAndKeepsZOrder` failed with `expected:<2> but was:<3>`, passes after.

## 3. `FixedTableModel` wraps immediately for tables not at the origin
**Cause:** `isColumnFinished()` / `isRowFinished()` compared `lastRect.bottom + cellHeight` against `tableRect.height()` and `lastRect.right + cellWidth` against `tableRect.width()`, but `lastRect` is in plot coordinates starting at `tableRect.top/left`.
**Change:** compare against `tableRect.bottom` / `tableRect.right`. ROW_MAJOR / COLUMN_MAJOR semantics are unchanged (existing `FixedTableModelTest` passes as-is).
**Evidence:** `FixedTableModelTest.testColumnMajor_offsetTableRect` and `testRowMajor_offsetTableRect` (same 300x500 cells as the existing tests, table rect offset to `RectF(300, 400, 1300, 2400)`) failed with `expected:<900.0> but was:<300.0>` and `expected:<300.0> but was:<600.0>` (wrapping one cell early), pass after.

## 4. `domainTitle*` / `rangeTitle*` XML attributes applied to the graph widget
**Cause:** `XYGraphWidget.processAttrs` passed `this` (the graph) as the target of the two `AttrUtils.configureWidget` calls for the domain and range title attrs, so `ap:domainTitleVisible="false"` hid the whole graph and `ap:domainTitleHeight` resized it.
**Change:** the two calls are moved into `XYPlot.processAttrs` next to the legend's `configureWidget`, targeting `getDomainTitle()` / `getRangeTitle()`. `XYPlot` previously only set the title text and paint from attrs, so there is no double application.
**Evidence:** `XYPlotTest.processAttrs_domainTitleVisibleFalse_hidesDomainTitleOnly`, `processAttrs_rangeTitleVisibleFalse_hidesRangeTitleOnly` (`AssertionFailedError`: title still visible) and `processAttrs_domainTitleHeight_resizesDomainTitleOnly` (`expected:<123.0> but was:<10.0>`) failed on the unfixed code, pass after.

## Verification
`./gradlew testDebugUnitTest lint :androidplot-core:assembleRelease :demoapp:assembleDebug` succeeds. 239 unit tests, 1 skipped, 0 failures (baseline on master: 224). Release notes updated under `# 1.6.0` in `docs/release_notes.md`.
