### PR TITLE
Fix series and renderer math: empty/short series, auto bounds, fills, stacked bars, bubbles

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/Region.java
+++ b/androidplot-core/src/main/java/com/androidplot/Region.java
@@ -110,6 +110,12 @@ public class Region {
         double range = length().doubleValue();
         final double r2 = max - min;
 
+        // a zero-length region cannot be scaled (the result would be NaN or infinite);
+        // map everything onto the center of the target range instead:
+        if (range == 0) {
+            return min + (r2 / 2);
+        }
+
         // TODO: refactor to use ratio here
         final double scale = r2 / range;
         if(!flip) {

--- a/androidplot-core/src/main/java/com/androidplot/util/SeriesUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/SeriesUtils.java
@@ -117,9 +117,13 @@ public class SeriesUtils {
      * in strict ascending order; behavior is undefined otherwise.
      * @param series
      * @param visibleBounds The visible constraints of the plot
-     * @return
+     * @return The min/max iVals to draw.  An empty series yields [0, 0]; callers should check
+     * {@link XYSeries#size()} before iterating.
      */
     public static Region iBounds(XYSeries series, RectRegion visibleBounds) {
+        if (series.size() == 0) {
+            return new Region(0, 0);
+        }
         final float step = series.size() >= 200 ? 50 : 1;
         final int iBoundsMin = iBoundsMin(series, visibleBounds.getMinX().doubleValue(), step);
         final int iBoundsMax = iBoundsMax(series, visibleBounds.getMaxX().doubleValue(), step);

--- a/androidplot-core/src/main/java/com/androidplot/xy/BarFormatter.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BarFormatter.java
@@ -7,24 +7,26 @@ import com.androidplot.ui.SeriesRenderer;
 
 public class BarFormatter extends LineAndPointFormatter {
 
+    /**
+     * @return The fill paint, or null if none has been set.  Unlike
+     * {@link LineAndPointFormatter#getFillPaint()} no default is instantiated.
+     */
+    @Override
     public Paint getFillPaint() {
         return fillPaint;
     }
 
-    public void setFillPaint(Paint fillPaint) {
-        this.fillPaint = fillPaint;
-    }
-
+    /**
+     * @return The border paint, or null if none has been set.  Bar borders are stored as the
+     * inherited line paint, so {@link #hasLinePaint()} reports whether a border will be drawn.
+     */
     public Paint getBorderPaint() {
-        return borderPaint;
+        return linePaint;
     }
 
     public void setBorderPaint(Paint borderPaint) {
-        this.borderPaint = borderPaint;
+        this.linePaint = borderPaint;
     }
-
-    private Paint fillPaint;
-    private Paint borderPaint;
 
     private float marginTop;
     private float marginBottom;
@@ -38,15 +40,15 @@ public class BarFormatter extends LineAndPointFormatter {
         fillPaint = new Paint();
         fillPaint.setStyle(Paint.Style.FILL);
         fillPaint.setAlpha(100);
-        borderPaint = new Paint();
-        borderPaint.setStyle(Paint.Style.STROKE);
-        borderPaint.setAlpha(100);
+        linePaint = new Paint();
+        linePaint.setStyle(Paint.Style.STROKE);
+        linePaint.setAlpha(100);
     }
 
     public BarFormatter(int fillColor, int borderColor) {
         this();
         fillPaint.setColor(fillColor);
-        borderPaint.setColor(borderColor);
+        linePaint.setColor(borderColor);
     }
 
     public BarFormatter(Context context, int xmlCfgId) {

--- a/androidplot-core/src/main/java/com/androidplot/xy/BarRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BarRenderer.java
@@ -102,7 +102,9 @@ public class BarRenderer<FormatterType extends BarFormatter> extends GroupRender
         if (formatter.hasFillPaint()) {
             canvas.drawRect(rect, formatter.getFillPaint());
         }
-        canvas.drawRect(rect, formatter.getBorderPaint());
+        if (formatter.hasLinePaint()) {
+            canvas.drawRect(rect, formatter.getBorderPaint());
+        }
     }
 
     /**
@@ -203,17 +205,30 @@ public class BarRenderer<FormatterType extends BarFormatter> extends GroupRender
                     }
                     break;
                 case STACKED:
-                    float bottom = (int) barGroup.plotArea.bottom;
+                    // each bar's height is the screen distance between its value and the
+                    // range origin.  Positive values stack upward from the origin while
+                    // negative values stack downward from it:
+                    float positiveBottom = rangeOriginPx;
+                    float negativeTop = rangeOriginPx;
                     Collections.sort(barGroup.bars, comparator);
                     for (Bar bar : barGroup.bars) {
                         // TODO: handling sub range-origin values for the purpose of labeling
-                        final float height = (int) bar.barGroup.plotArea.bottom - bar.yPix;
-                        final float top = bottom - height;
+                        final float height = bar.getY() != null ? rangeOriginPx - bar.yPix : 0;
+                        final float top;
+                        final float bottom;
+                        if (height >= 0) {
+                            bottom = positiveBottom;
+                            top = bottom - height;
+                            positiveBottom = top;
+                        } else {
+                            top = negativeTop;
+                            bottom = top - height;
+                            negativeTop = bottom;
+                        }
                         drawBar(canvas, bar, createBarRect(
                                 bar.barGroup.leftPix, top,
                                 bar.barGroup.rightPix, bottom,
                                 bar.formatter));
-                        bottom = top;
                     }
                     break;
                 default:

--- a/androidplot-core/src/main/java/com/androidplot/xy/BubbleRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/BubbleRenderer.java
@@ -48,22 +48,40 @@ public class BubbleRenderer<FormatterType extends BubbleFormatter> extends XYSer
             FormatterType formatter, RenderStack stack) {
 
         Region magnitudeBounds = calculateBounds();
+        if (magnitudeBounds == null) {
+            // no positive z-vals; nothing to render
+            return;
+        }
         for(int i = 0; i < series.size(); i++) {
 
             // only render non-null values greater than zero:
-            if(series.getY(i) != null && series.getZ(i).doubleValue() > 0) {
+            if(series.getX(i) != null && series.getY(i) != null && series.getZ(i) != null
+                    && series.getZ(i).doubleValue() > 0) {
 
                 final PointF centerPoint = getPlot().getBounds().
                         transform(series.getX(i), series.getY(i), plotArea, false, true);
 
-                // calculate bubble radius:
-                float bubbleRadius = magnitudeBounds.
-                        transform(bubbleScaleMode == BubbleScaleMode.SQUARE_ROOT ?
-                                  Math.sqrt(series.getZ(i).doubleValue()) :
-                                  series.getZ(i).doubleValue(), bubbleBounds).floatValue();
-                drawBubble(canvas, formatter, series, i, centerPoint, bubbleRadius);
+                drawBubble(canvas, formatter, series, i, centerPoint,
+                        calculateRadius(magnitudeBounds, series.getZ(i).doubleValue()));
             }
         }
+    }
+
+    /**
+     * @param magnitudeBounds the min/max magnitude of all rendered z-vals, as calculated by
+     * {@link #calculateBounds()}.
+     * @param z
+     * @return The radius to draw a bubble of magnitude z with.  Always a finite value within
+     * the configured min/max bubble radius.
+     */
+    protected float calculateRadius(Region magnitudeBounds, double z) {
+        if (magnitudeBounds.length().doubleValue() == 0) {
+            // all bubbles have the same magnitude so there is nothing to scale against:
+            return bubbleBounds.getMax().floatValue();
+        }
+        final double magnitude = bubbleScaleMode == BubbleScaleMode.SQUARE_ROOT ?
+                Math.sqrt(z) : z;
+        return magnitudeBounds.transform(magnitude, bubbleBounds).floatValue();
     }
 
     /**
@@ -145,7 +163,7 @@ public class BubbleRenderer<FormatterType extends BubbleFormatter> extends XYSer
             }
         } else {
             // if the smallest value is negative, use zero instead since those vals arent visible:
-            bounds.setMax(0);
+            bounds.setMin(0);
         }
         return bounds;
     }

--- a/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointRenderer.java
@@ -121,6 +121,11 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
         path.reset();
         final List<PointF> points = getPointsCache(series);
 
+        // nothing to draw (and nothing to compute visible index bounds from):
+        if (series.size() == 0) {
+            return;
+        }
+
         int iStart = 0;
         int iEnd = series.size();
         if(SeriesUtils.getXYOrder(series) == OrderedXYSeries.XOrder.ASCENDING) {
@@ -134,6 +139,12 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
                 iEnd++;
             }
         }
+
+        // interpolation requires at least 3 non-null vertices; fall back to straight
+        // line segments when the series cannot be interpolated:
+        final boolean interpolate = formatter.getInterpolationParams() != null
+                && isInterpolatable(series);
+
         for (int i = iStart; i < iEnd; i++) {
             final Number y = series.getY(i);
             final Number x = series.getX(i);
@@ -153,7 +164,7 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
             }
 
             // don't need to do any of this if the line isnt going to be drawn:
-            if(formatter.hasLinePaint() && formatter.getInterpolationParams() == null) {
+            if(formatter.hasLinePaint() && !interpolate) {
                 if (thisPoint != null) {
 
                     // record the first point of the new Path
@@ -181,7 +192,7 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
         }
 
         if(formatter.hasLinePaint()) {
-            if(formatter.getInterpolationParams() != null) {
+            if(interpolate) {
                 List<XYCoords> interpolatedPoints = getInterpolator(
                         formatter.getInterpolationParams()).interpolate(series,
                         formatter.getInterpolationParams());
@@ -200,6 +211,34 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
             }
         }
         renderPoints(canvas, plotArea, series, iStart, iEnd, points, formatter);
+    }
+
+    /**
+     * @param series
+     * @return True if series can be passed to an {@link Interpolator}: it must contain at least
+     * 3 vertices, none of which may have a null x or y value.
+     */
+    protected boolean isInterpolatable(XYSeries series) {
+        final int size = series.size();
+        if (size < 3) {
+            return false;
+        }
+        for (int i = 0; i < size; i++) {
+            if (series.getX(i) == null || series.getY(i) == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param plotArea
+     * @return The screen y-coordinate of the plot's range origin.
+     */
+    protected float getRangeOriginPix(RectF plotArea) {
+        return (float) getPlot().getBounds().getyRegion()
+                .transform(getPlot().getRangeOrigin().doubleValue(),
+                        plotArea.top, plotArea.bottom, true);
     }
 
     /**
@@ -265,9 +304,7 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
                 path.close();
                 break;
             case RANGE_ORIGIN:
-                float originPix = (float) getPlot().getBounds().getxRegion()
-                        .transform(getPlot().getRangeOrigin()
-                                .doubleValue(), plotArea.top, plotArea.bottom, true);
+                float originPix = getRangeOriginPix(plotArea);
                 path.lineTo(lastPoint.x, originPix);
                 path.lineTo(firstPoint.x, originPix);
                 path.close();

--- a/androidplot-core/src/main/java/com/androidplot/xy/NormedXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/NormedXYSeries.java
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
+import android.graphics.Canvas;
+
+import com.androidplot.Plot;
+import com.androidplot.PlotListener;
 import com.androidplot.Region;
 import com.androidplot.util.SeriesUtils;
 
@@ -8,10 +12,17 @@ import com.androidplot.util.SeriesUtils;
  * Wrapper implementation of {@link XYSeries} that wraps another XYSeries, normalizing values in the range of 0 to 1.
  * Note that it's possible to push normed values outside of the standard 0, 1 range by applying
  * a sufficiently large offset.
+ *
+ * Auto-calculated min/max bounds are refreshed before each draw of the plot this series is
+ * attached to, so the wrapped series may continue to change after being wrapped.  Call
+ * {@link #normalize()} to refresh them manually.
  */
-public class NormedXYSeries implements XYSeries {
+public class NormedXYSeries implements XYSeries, PlotListener {
 
     private XYSeries rawData;
+
+    private Norm normX;
+    private Norm normY;
 
     private Region minMaxX;
     private Region minMaxY;
@@ -68,7 +79,18 @@ public class NormedXYSeries implements XYSeries {
      */
     public NormedXYSeries(XYSeries rawData, Norm x, Norm y) {
         this.rawData = rawData;
-        normalize(x, y);
+        this.normX = x;
+        this.normY = y;
+        normalize();
+    }
+
+    /**
+     * Recalculates the normalization bounds from the current contents of the wrapped series.
+     * Only auto-calculated bounds (a {@link Norm} created with a null minMax) are affected.
+     * Invoked automatically before each draw when attached to a {@link Plot}.
+     */
+    public void normalize() {
+        normalize(normX, normY);
     }
 
     protected void normalize(Norm x, Norm y) {
@@ -80,6 +102,21 @@ public class NormedXYSeries implements XYSeries {
         if( y != null) {
             this.minMaxY = y.minMax != null ? y.minMax : SeriesUtils.minMaxY(rawData);
             this.transformY = calculateTransform(y);
+        }
+    }
+
+    @Override
+    public void onBeforeDraw(Plot source, Canvas canvas) {
+        if (rawData instanceof PlotListener) {
+            ((PlotListener) rawData).onBeforeDraw(source, canvas);
+        }
+        normalize();
+    }
+
+    @Override
+    public void onAfterDraw(Plot source, Canvas canvas) {
+        if (rawData instanceof PlotListener) {
+            ((PlotListener) rawData).onAfterDraw(source, canvas);
         }
     }
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYConstraints.java
@@ -42,7 +42,7 @@ public class XYConstraints {
     }
 
     public boolean contains(@NonNull RectRegion rectRegion) {
-        return contains(rectRegion.getMinY(), rectRegion.getMinY())
+        return contains(rectRegion.getMinX(), rectRegion.getMinY())
                 && contains(rectRegion.getMaxX(), rectRegion.getMaxY());
     }
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
@@ -13,6 +13,7 @@ import android.util.AttributeSet;
 
 import com.androidplot.Plot;
 import com.androidplot.R;
+import com.androidplot.Region;
 import com.androidplot.ui.Anchor;
 import com.androidplot.ui.DynamicTableModel;
 import com.androidplot.ui.HorizontalPositioning;
@@ -483,12 +484,15 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
                 updateDomainMinMaxForOriginModel();
                 break;
             case EDGE:
+                // when no value could be calculated (ex: no series data yet) pass null rather
+                // than the placeholder default so that it is never latched by GROW/SHRINK:
                 bounds.setMaxX(applyUserMinMax(getCalculatedUpperBoundary(
-                        constraints.getDomainUpperBoundaryMode(), prevMaxX, bounds.getMaxX()),
+                        constraints.getDomainUpperBoundaryMode(), prevMaxX,
+                        bounds.isMaxXSet() ? bounds.getMaxX() : null),
                         innerLimits.getMaxX(), outerLimits.getMaxX()));
                 bounds.setMinX(applyUserMinMax(getCalculatedLowerBoundary(
                         constraints.getDomainLowerBoundaryMode(),
-                        prevMinX, bounds.getMinX()),
+                        prevMinX, bounds.isMinXSet() ? bounds.getMinX() : null),
                         outerLimits.getMinX(), innerLimits.getMinX()));
                 break;
             default:
@@ -504,16 +508,21 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
             	if (getRegistry().size() > 0) {
                     bounds.setMaxY(applyUserMinMax(getCalculatedUpperBoundary(
                             constraints.getRangeUpperBoundaryMode(),
-                            prevMaxY, bounds.getMaxY()), innerLimits.getMaxY(), outerLimits.getMaxY()));
+                            prevMaxY, bounds.isMaxYSet() ? bounds.getMaxY() : null),
+                            innerLimits.getMaxY(), outerLimits.getMaxY()));
                     bounds.setMinY(applyUserMinMax(getCalculatedLowerBoundary(
                             constraints.getRangeLowerBoundaryMode(),
-                            prevMinY, bounds.getMinY()), outerLimits.getMinY(), innerLimits.getMinY()));
+                            prevMinY, bounds.isMinYSet() ? bounds.getMinY() : null),
+                            outerLimits.getMinY(), innerLimits.getMinY()));
             	}
                 break;
             default:
                 throw new UnsupportedOperationException(
                         "Range Framing Model not yet supported: " + constraints.getRangeFramingModel());
         }
+
+        padZeroLengthBounds(bounds.getxRegion(), constraints.getMinX(), constraints.getMaxX());
+        padZeroLengthBounds(bounds.getyRegion(), constraints.getMinY(), constraints.getMaxY());
 
 
         calculatedOrigin.x = userDomainOrigin != null ?
@@ -523,6 +532,39 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
                 userRangeOrigin : bounds.getMinY();
     }
 
+    /**
+     * Ensures that an axis derived from series data never ends up with min == max, which
+     * cannot be scaled onto the screen.  A flat axis is padded symmetrically so the data
+     * is centered with a visible grid; user-fixed edges are left untouched.
+     *
+     * @param region the axis bounds to pad
+     * @param userMin the user-set lower boundary, or null if it was calculated
+     * @param userMax the user-set upper boundary, or null if it was calculated
+     */
+    protected static void padZeroLengthBounds(Region region, Number userMin, Number userMax) {
+        if (!region.isMinSet() || !region.isMaxSet()) {
+            return;
+        }
+        final double min = region.getMin().doubleValue();
+        final double max = region.getMax().doubleValue();
+        if (min != max || (userMin != null && userMax != null)) {
+            return;
+        }
+        final double pad = min == 0 ? 1 : Math.abs(min) * 0.1;
+        if (userMin == null) {
+            region.setMin(min - pad);
+        }
+        if (userMax == null) {
+            region.setMax(max + pad);
+        }
+    }
+
+    /**
+     * @param mode
+     * @param previousMax
+     * @param calculatedMax the max derived from series data; null if there was no data.
+     * @return
+     */
     protected Number getCalculatedUpperBoundary(BoundaryMode mode, Number previousMax, Number calculatedMax) {
         switch (mode) {
             case FIXED:
@@ -530,12 +572,14 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
             case AUTO:
                 break;
             case GROW:
-                if (!(previousMax == null || calculatedMax.doubleValue() > previousMax.doubleValue())) {
+                if (calculatedMax == null || !(previousMax == null
+                        || calculatedMax.doubleValue() > previousMax.doubleValue())) {
                     calculatedMax = previousMax;
                 }
                 break;
             case SHRINK:
-                if (!(previousMax == null || calculatedMax.doubleValue() < previousMax.doubleValue())) {
+                if (calculatedMax == null || !(previousMax == null
+                        || calculatedMax.doubleValue() < previousMax.doubleValue())) {
                     calculatedMax = previousMax;
                 }
                 break;
@@ -545,6 +589,12 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
         return calculatedMax;
     }
 
+    /**
+     * @param mode
+     * @param previousMin
+     * @param calculatedMin the min derived from series data; null if there was no data.
+     * @return
+     */
     protected Number getCalculatedLowerBoundary(BoundaryMode mode, Number previousMin, Number calculatedMin) {
         switch (mode) {
             case FIXED:
@@ -552,12 +602,14 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
             case AUTO:
                 break;
             case GROW:
-                if (!(previousMin == null || calculatedMin.doubleValue() < previousMin.doubleValue())) {
+                if (calculatedMin == null || !(previousMin == null
+                        || calculatedMin.doubleValue() < previousMin.doubleValue())) {
                     return previousMin;
                 }
                 break;
             case SHRINK:
-                if (!(previousMin == null || calculatedMin.doubleValue() > previousMin.doubleValue())) {
+                if (calculatedMin == null || !(previousMin == null
+                        || calculatedMin.doubleValue() > previousMin.doubleValue())) {
                     return previousMin;
                 }
                 break;

--- a/androidplot-core/src/test/java/com/androidplot/RegionTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/RegionTest.java
@@ -85,6 +85,21 @@ public class RegionTest {
     }
 
     @Test
+    public void transform_zeroLengthRegion_returnsCenterOfTargetRange() {
+        Region flat = new Region(5, 5);
+
+        // previously scale = (100 - 0) / 0 = Infinity and Infinity * 0 = NaN:
+        assertEquals(50, flat.transform(5, 0, 100, false), 0);
+        assertEquals(50, flat.transform(5, 0, 100, true), 0);
+        assertEquals(30, flat.transform(5, new Region(20, 40)).doubleValue(), 0);
+
+        // non-degenerate regions are unaffected:
+        Region r = new Region(0, 10);
+        assertEquals(25, r.transform(2.5, 0, 100, false), 0);
+        assertEquals(75, r.transform(2.5, 0, 100, true), 0);
+    }
+
+    @Test
     public void testIntersects() throws Exception {
         Region line1 = new Region(1, 10);
         Region line2 = new Region(11, 20);

--- a/androidplot-core/src/test/java/com/androidplot/util/SeriesUtilsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/SeriesUtilsTest.java
@@ -294,4 +294,15 @@ public class SeriesUtilsTest {
         assertEquals(0, result.getMin().intValue());
         assertEquals(4, result.getMax().intValue());
     }
+
+    @Test
+    public void iBounds_emptySeries_returnsNonNegativeBounds() {
+        SimpleXYSeries series = new SimpleXYSeries("empty");
+        series.setXOrder(OrderedXYSeries.XOrder.ASCENDING);
+
+        // previously yielded [-1, 0], causing series.getY(-1) to be invoked by renderers:
+        Region result = SeriesUtils.iBounds(series, new RectRegion(0, 1, 0, 1));
+        assertEquals(0, result.getMin().intValue());
+        assertEquals(0, result.getMax().intValue());
+    }
 }

--- a/androidplot-core/src/test/java/com/androidplot/xy/BarRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/BarRendererTest.java
@@ -19,10 +19,15 @@ import org.mockito.Mock;
 import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -102,6 +107,83 @@ public class BarRendererTest extends AndroidplotTest {
 
         // s2[2]
         verifyBarHeight(0, 30, barFormatter, 1);
+    }
+
+    @Test
+    public void onRender_stacked_measuresBarsFromRangeOrigin() {
+        XYSeries s1 = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 3);
+        XYSeries s2 = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s2", 4);
+
+        BarRenderer renderer = setupRendererForTesting(s1, s2);
+        renderer.setBarOrientation(BarRenderer.BarOrientation.STACKED);
+
+        // range 2..12 over 100px => 10px per unit; origin (y = 0) is at 120px:
+        xyPlot.setRangeBoundaries(2, 12, BoundaryMode.FIXED);
+        xyPlot.setUserRangeOrigin(0);
+        xyPlot.calculateMinMaxVals();
+        renderer.onRender(canvas, plotArea, s1, barFormatter, renderStack);
+
+        verify(renderer, times(2)).
+                drawBar(eq(canvas), any(BarRenderer.Bar.class), any(RectF.class));
+
+        // s1[0]: y = 3 spans the origin (120) to the pixel for y = 3 (90):
+        verifyBarHeight(90, 120, barFormatter, 1);
+
+        // s2[0]: y = 4 stacks on top, ending at the pixel for y = 7 (50).
+        // Previously heights were measured from the plot bottom, giving a top of 70:
+        verifyBarHeight(50, 90, barFormatter, 1);
+    }
+
+    @Test
+    public void onRender_stacked_negativeValuesStackDownwardFromRangeOrigin() {
+        XYSeries s1 = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", -2);
+        XYSeries s2 = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s2", -3);
+
+        BarRenderer renderer = setupRendererForTesting(s1, s2);
+        renderer.setBarOrientation(BarRenderer.BarOrientation.STACKED);
+
+        // range -10..10 over 100px => 5px per unit; origin (y = 0) is at 50px:
+        xyPlot.setRangeBoundaries(-10, 10, BoundaryMode.FIXED);
+        xyPlot.setUserRangeOrigin(0);
+        xyPlot.calculateMinMaxVals();
+        renderer.onRender(canvas, plotArea, s1, barFormatter, renderStack);
+
+        // s1[0]: y = -2 hangs from the origin down to 60:
+        verifyBarHeight(50, 60, barFormatter, 1);
+
+        // s2[0]: y = -3 continues down to the pixel for y = -5 (75):
+        verifyBarHeight(60, 75, barFormatter, 1);
+    }
+
+    @Test
+    public void setFillPaint_null_disablesFill() {
+        BarFormatter formatter = new BarFormatter(Color.RED, Color.RED);
+        formatter.setFillPaint(null);
+
+        // previously BarFormatter shadowed the inherited fillPaint field so this stayed true:
+        assertFalse(formatter.hasFillPaint());
+        assertNull(formatter.getFillPaint());
+        assertTrue(formatter.hasLinePaint());
+
+        formatter.setBorderPaint(null);
+        assertFalse(formatter.hasLinePaint());
+        assertNull(formatter.getBorderPaint());
+    }
+
+    @Test
+    public void onRender_withNullFillAndBorderPaint_drawsNothingWithNullPaint() {
+        XYSeries s1 = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 2, 5, 7);
+        BarRenderer renderer = setupRendererForTesting(s1);
+        barFormatter.setFillPaint(null);
+        barFormatter.setBorderPaint(null);
+
+        xyPlot.setRangeBoundaries(0, 10, BoundaryMode.FIXED);
+        xyPlot.calculateMinMaxVals();
+        renderer.onRender(canvas, plotArea, s1, barFormatter, renderStack);
+        renderer.doDrawLegendIcon(canvas, new RectF(0, 0, 10, 10), barFormatter);
+
+        verify(canvas, never()).drawRect(anyFloat(), anyFloat(), anyFloat(), anyFloat(), isNull());
+        verify(canvas, never()).drawRect(any(RectF.class), isNull());
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/xy/BubbleRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/BubbleRendererTest.java
@@ -10,6 +10,8 @@ import com.androidplot.ui.*;
 import org.junit.*;
 import org.mockito.*;
 
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 /**
@@ -67,5 +69,59 @@ public class BubbleRendererTest extends AndroidplotTest {
 
         // verify the z-val is the one labeled:
         verify(canvas).drawText(eq("22"), anyFloat(), anyFloat(), eq(plf.getTextPaint()));
+    }
+
+    @Test
+    public void onRender_withZeroZVal_drawsFiniteRadiiWithinConfiguredBounds() {
+        BubbleFormatter formatter = spy(new BubbleFormatter());
+        BubbleRenderer renderer = setupRenderer(formatter);
+
+        // z = 0, 4, 9; only the two bubbles with z > 0 are drawn:
+        BubbleSeries bs = new BubbleSeries(0, 0, 0, 1, 1, 4, 2, 2, 9);
+        xyPlot.addSeries(bs, formatter);
+        xyPlot.calculateMinMaxVals();
+
+        renderer.onRender(canvas, plotArea, bs, formatter, renderStack);
+
+        // each bubble is drawn twice (fill + stroke).  Previously the magnitude region
+        // collapsed to [0, 0] producing infinite radii:
+        ArgumentCaptor<Float> radius = ArgumentCaptor.forClass(Float.class);
+        verify(canvas, times(4)).drawCircle(anyFloat(), anyFloat(), radius.capture(), any(Paint.class));
+        for (float r : radius.getAllValues()) {
+            assertTrue("radius should be finite: " + r, Float.isFinite(r));
+            assertTrue(r >= renderer.getMinBubbleRadius());
+            assertTrue(r <= renderer.getMaxBubbleRadius());
+        }
+
+        // z = 9 is the largest value so it gets the largest radius:
+        assertEquals(renderer.getMaxBubbleRadius(), radius.getAllValues().get(2), 0.0001f);
+        assertTrue(radius.getAllValues().get(0) < radius.getAllValues().get(2));
+    }
+
+    @Test
+    public void onRender_singleBubble_drawsFiniteRadius() {
+        BubbleFormatter formatter = spy(new BubbleFormatter());
+        BubbleRenderer renderer = setupRenderer(formatter);
+
+        BubbleSeries bs = new BubbleSeries(1, 1, 9);
+        xyPlot.addSeries(bs, formatter);
+        xyPlot.calculateMinMaxVals();
+
+        renderer.onRender(canvas, plotArea, bs, formatter, renderStack);
+
+        // previously the zero-length magnitude region produced a NaN radius:
+        ArgumentCaptor<Float> radius = ArgumentCaptor.forClass(Float.class);
+        verify(canvas, times(2)).drawCircle(anyFloat(), anyFloat(), radius.capture(), any(Paint.class));
+        for (float r : radius.getAllValues()) {
+            assertTrue("radius should be finite: " + r, Float.isFinite(r));
+            assertEquals(renderer.getMaxBubbleRadius(), r, 0.0001f);
+        }
+    }
+
+    private BubbleRenderer setupRenderer(BubbleFormatter formatter) {
+        BubbleRenderer renderer = spy(formatter.getRendererInstance(xyPlot));
+        doReturn(renderer.getClass()).when(formatter).getRendererClass();
+        doReturn(renderer).when(formatter).getRendererInstance(any(XYPlot.class));
+        return renderer;
     }
 }

--- a/androidplot-core/src/test/java/com/androidplot/xy/LineAndPointRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/LineAndPointRendererTest.java
@@ -257,6 +257,84 @@ public class LineAndPointRendererTest extends AndroidplotTest {
     }
 
     @Test
+    public void drawSeries_emptyAscendingSeries_drawsNothing() {
+        LineAndPointFormatter formatter = new LineAndPointFormatter(Color.RED, Color.RED, Color.RED, null);
+        SimpleXYSeries series = new SimpleXYSeries("empty");
+        series.setXOrder(OrderedXYSeries.XOrder.ASCENDING);
+
+        xyPlot.addSeries(series, formatter);
+        LineAndPointRenderer renderer = xyPlot.getRenderer(LineAndPointRenderer.class);
+        xyPlot.calculateMinMaxVals();
+
+        // must not throw (previously IndexOutOfBoundsException from series.getY(-1)):
+        renderer.drawSeries(canvas, plotArea, series, formatter);
+
+        verify(canvas, never()).drawPath(any(Path.class), any(Paint.class));
+        verify(canvas, never()).drawPoint(anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    @Test
+    public void drawSeries_withInterpolation_fewerThanThreePoints_drawsStraightLine() {
+        LineAndPointFormatter formatter = new LineAndPointFormatter(Color.RED, Color.RED, null, null);
+        formatter.setInterpolationParams(
+                new CatmullRomInterpolator.Params(10, CatmullRomInterpolator.Type.Centripetal));
+        SimpleXYSeries series = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 1, 2);
+
+        xyPlot.addSeries(series, formatter);
+        LineAndPointRenderer renderer = xyPlot.getRenderer(LineAndPointRenderer.class);
+        xyPlot.calculateMinMaxVals();
+
+        // must not throw (previously IllegalArgumentException from the interpolator):
+        renderer.drawSeries(canvas, plotArea, series, formatter);
+
+        // the two points are still connected by a line:
+        verify(canvas, times(1)).drawPath(any(Path.class), eq(formatter.getLinePaint()));
+    }
+
+    @Test
+    public void drawSeries_withInterpolation_nullPoint_drawsStraightSegments() {
+        LineAndPointFormatter formatter = new LineAndPointFormatter(Color.RED, Color.RED, null, null);
+        formatter.setInterpolationParams(
+                new CatmullRomInterpolator.Params(10, CatmullRomInterpolator.Type.Centripetal));
+        SimpleXYSeries series = new SimpleXYSeries(
+                SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 1, 2, 3, null, 5, 6, 7);
+
+        xyPlot.addSeries(series, formatter);
+        LineAndPointRenderer renderer = xyPlot.getRenderer(LineAndPointRenderer.class);
+        xyPlot.calculateMinMaxVals();
+
+        // must not throw (previously NullPointerException from the interpolator):
+        renderer.drawSeries(canvas, plotArea, series, formatter);
+
+        // one segment on each side of the null:
+        verify(canvas, times(2)).drawPath(any(Path.class), eq(formatter.getLinePaint()));
+    }
+
+    @Test
+    public void renderPath_rangeOriginFill_closesPathAtRangeOrigin() {
+        LineAndPointFormatter formatter = new LineAndPointFormatter(
+                Color.RED, Color.RED, Color.RED, null, FillDirection.RANGE_ORIGIN);
+        SimpleXYSeries series = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 1, 2, 3);
+        xyPlot.addSeries(series, formatter);
+        LineAndPointRenderer renderer = xyPlot.getRenderer(LineAndPointRenderer.class);
+
+        // domain 0..10, range -1..1, origin at 0 => origin is the vertical center of the plot:
+        xyPlot.setDomainBoundaries(0, 10, BoundaryMode.FIXED);
+        xyPlot.setRangeBoundaries(-1, 1, BoundaryMode.FIXED);
+        xyPlot.setUserRangeOrigin(0);
+        xyPlot.calculateMinMaxVals();
+
+        Path path = spy(new Path());
+        PointF firstPoint = new PointF(10, 20);
+        PointF lastPoint = new PointF(90, 20);
+        renderer.renderPath(canvas, plotArea, path, firstPoint, lastPoint, formatter);
+
+        // (previously the origin was transformed through the domain region, yielding 100):
+        verify(path).lineTo(lastPoint.x, 50f);
+        verify(path).lineTo(firstPoint.x, 50f);
+    }
+
+    @Test
     public void drawSeries_withPointLabelFormatter_drawsPointLabels() {
         LineAndPointFormatter formatter =
                 new LineAndPointFormatter(0, 0, 0, null);

--- a/androidplot-core/src/test/java/com/androidplot/xy/NormedXYSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/NormedXYSeriesTest.java
@@ -8,6 +8,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 
 /**
@@ -84,5 +85,48 @@ public class NormedXYSeriesTest extends AndroidplotTest {
         assertEquals(0.5d, normedData.getY(0).doubleValue(), DELTA);
         assertEquals(0.7d, normedData.getY(1).doubleValue(), DELTA);
         assertEquals(1.5d, normedData.getY(5).doubleValue(), DELTA);
+    }
+
+    @Test
+    public void getY_singlePoint_returnsFiniteValue() {
+        XYSeries rawData = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 7);
+        NormedXYSeries normedData = new NormedXYSeries(rawData);
+
+        // min == max; previously the transform produced NaN.  A flat series maps
+        // onto the center of the normalized range:
+        final double y = normedData.getY(0).doubleValue();
+        assertTrue("expected a finite value but got " + y, !Double.isNaN(y) && !Double.isInfinite(y));
+        assertEquals(0.5d, y, DELTA);
+    }
+
+    @Test
+    public void onBeforeDraw_renormalizesAgainstUpdatedRawData() {
+        SimpleXYSeries rawData = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 0, 2, 4);
+        NormedXYSeries normedData = new NormedXYSeries(rawData);
+        assertEquals(1.0d, normedData.getY(2).doubleValue(), DELTA);
+
+        // the wrapped series grows beyond the bounds captured at construction time:
+        rawData.addLast(null, 8);
+        assertEquals(2.0d, normedData.getY(3).doubleValue(), DELTA);
+
+        // the plot notifies the series before drawing, which refreshes the normalization:
+        normedData.onBeforeDraw(null, null);
+        assertEquals(0.5d, normedData.getY(2).doubleValue(), DELTA);
+        assertEquals(1.0d, normedData.getY(3).doubleValue(), DELTA);
+        normedData.onAfterDraw(null, null);
+    }
+
+    @Test
+    public void onBeforeDraw_doesNotAlterUserSpecifiedBounds() {
+        SimpleXYSeries rawData = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s1", 0, 2, 4);
+        NormedXYSeries normedData = new NormedXYSeries(rawData, null,
+                new NormedXYSeries.Norm(new com.androidplot.Region(0, 8)));
+        assertEquals(0.5d, normedData.getY(2).doubleValue(), DELTA);
+
+        rawData.addLast(null, 16);
+        normedData.onBeforeDraw(null, null);
+        assertEquals(0.5d, normedData.getY(2).doubleValue(), DELTA);
+        assertEquals(2.0d, normedData.getY(3).doubleValue(), DELTA);
+        normedData.onAfterDraw(null, null);
     }
 }

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYConstraintsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYConstraintsTest.java
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package com.androidplot.xy;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class XYConstraintsTest {
+
+    @Test
+    public void contains_rectRegion_checksMinXAgainstDomain() {
+        // domain fixed to [0, 50], range unconstrained:
+        XYConstraints constraints = new XYConstraints(0, 50, null, null);
+
+        // region extends to x = -50, outside of the domain.  Previously minY was passed
+        // as the x coordinate so this region was reported as contained:
+        assertFalse(constraints.contains(new RectRegion(-50, 50, 0, 10)));
+
+        // region fully within the domain:
+        assertTrue(constraints.contains(new RectRegion(10, 40, 0, 10)));
+
+        // region extends beyond the upper domain boundary:
+        assertFalse(constraints.contains(new RectRegion(10, 60, 0, 10)));
+    }
+
+    @Test
+    public void contains_rectRegion_checksRangeEdges() {
+        XYConstraints constraints = new XYConstraints(null, null, 0, 50);
+
+        assertTrue(constraints.contains(new RectRegion(-100, 100, 10, 40)));
+        assertFalse(constraints.contains(new RectRegion(-100, 100, -10, 40)));
+        assertFalse(constraints.contains(new RectRegion(-100, 100, 10, 60)));
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
@@ -302,6 +302,78 @@ public class XYPlotTest extends AndroidplotTest {
     }
     
     @Test
+    public void calculateMinMaxVals_grow_ignoresPlaceholderBoundsWhenFirstFrameHasNoData() {
+        SimpleXYSeries series = new SimpleXYSeries("live");
+        plot.addSeries(series, new LineAndPointFormatter());
+        plot.setRangeBoundaries(null, null, BoundaryMode.GROW);
+
+        // first frame: no data at all
+        plot.calculateMinMaxVals();
+
+        for (int y = 50; y <= 100; y += 10) {
+            series.addLast(y - 50, y);
+        }
+        plot.calculateMinMaxVals();
+
+        // previously the placeholder -1 lower bound was latched forever:
+        assertEquals(50, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(100, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void calculateMinMaxVals_shrink_ignoresPlaceholderBoundsWhenFirstFrameHasNoData() {
+        SimpleXYSeries series = new SimpleXYSeries("live");
+        plot.addSeries(series, new LineAndPointFormatter());
+        plot.setRangeBoundaries(null, null, BoundaryMode.SHRINK);
+
+        // first frame: no data at all
+        plot.calculateMinMaxVals();
+
+        for (int y = 50; y <= 100; y += 10) {
+            series.addLast(y - 50, y);
+        }
+        plot.calculateMinMaxVals();
+
+        // previously produced the inverted axis [50, 1]:
+        assertEquals(50, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(100, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void calculateMinMaxVals_singlePoint_padsBoundsToNonZeroLength() {
+        SimpleXYSeries series = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "single", 5);
+        plot.addSeries(series, new LineAndPointFormatter());
+        plot.calculateMinMaxVals();
+
+        final double minX = plot.getBounds().getMinX().doubleValue();
+        final double maxX = plot.getBounds().getMaxX().doubleValue();
+        final double minY = plot.getBounds().getMinY().doubleValue();
+        final double maxY = plot.getBounds().getMaxY().doubleValue();
+
+        // x == 0 so it is padded by one unit; y == 5 so it is padded by 10%:
+        assertEquals(-1, minX, 0);
+        assertEquals(1, maxX, 0);
+        assertEquals(4.5, minY, 0.0001);
+        assertEquals(5.5, maxY, 0.0001);
+
+        // and the single point transforms to the center of the plot rather than NaN:
+        PointF p = plot.getBounds().transformScreen(0, 5, new RectF(0, 0, 100, 100));
+        assertEquals(50f, p.x, 0.0001f);
+        assertEquals(50f, p.y, 0.0001f);
+    }
+
+    @Test
+    public void calculateMinMaxVals_flatSeriesWithFixedLowerBound_padsOnlyTheCalculatedEdge() {
+        SimpleXYSeries series = new SimpleXYSeries(SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "flat", 5, 5, 5);
+        plot.addSeries(series, new LineAndPointFormatter());
+        plot.setRangeBoundaries(5, BoundaryMode.FIXED, null, BoundaryMode.AUTO);
+        plot.calculateMinMaxVals();
+
+        assertEquals(5, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(5.5, plot.getBounds().getMaxY().doubleValue(), 0.0001);
+    }
+
+    @Test
     public void setRangeBoundaries_calculatesCorrectMinMaxVals() throws Exception {
         plot.addSeries(series0To100, new LineAndPointFormatter());
         plot.calculateMinMaxVals();

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -15,6 +15,33 @@ For details on what to expect in general when updating to a new version of Andro
   their area.
 * (#88) Fix crash when a formatter config or `androidPlot.` attribute references a color, dimension
   or integer resource.  Negative integer values are now accepted as well.
+* Fix `LineAndPointRenderer` throwing `IndexOutOfBoundsException` on every frame for an empty
+  series with `XOrder.ASCENDING`; `SeriesUtils.iBounds` no longer yields a negative index for an
+  empty series.
+* Fix `LineAndPointRenderer` throwing on every frame when interpolation is enabled on a series with
+  fewer than 3 points or a null value; such series now fall back to straight line segments.
+* Fix `GROW` / `SHRINK` boundary modes latching the placeholder `[-1, 1]` bounds when the first
+  frame is drawn before any series data exists, which left `GROW` stuck at -1 and gave `SHRINK` an
+  inverted axis.
+* Fix `XYConstraints.contains(RectRegion)` comparing the region's minimum y value against the domain
+  instead of its minimum x value.
+* Fix `FillDirection.RANGE_ORIGIN` fills being closed at the wrong screen coordinate; the range
+  origin was transformed through the domain region instead of the range region.
+* Fix `BarOrientation.STACKED` bars being measured from the bottom of the plot instead of from the
+  range origin, which produced incorrect stacks whenever the range lower boundary was not the origin.
+  Negative values now stack downward from the origin.
+* Fix `BubbleRenderer` producing infinite radii when any z-val is zero or negative, and NaN radii (no
+  bubble drawn) when all z-vals are equal or the series has a single bubble.
+* Fix a plot whose data spans a single point or a flat line rendering blank: `Region.transform` now
+  maps a zero-length region onto the center of the target range, and `XYPlot` pads a calculated axis
+  whose min equals max so the data is centered with a visible grid.
+* Fix `BarFormatter.setFillPaint(null)` / `setBorderPaint(null)` not disabling the fill / border;
+  the formatter shadowed the inherited paint fields so `hasFillPaint()` / `hasLinePaint()` kept
+  returning true and `BarRenderer` drew with a null `Paint`.
+* Fix `NormedXYSeries` returning NaN for a flat or single-point series, and drifting outside of the
+  `[0, 1]` range when the wrapped series changes after construction.  Auto-calculated bounds are now
+  refreshed before each draw (`NormedXYSeries` implements `PlotListener`) and can be refreshed
+  manually via the new `normalize()` method.
 * The XML configuration engine (formerly the separate Fig library) is now part of androidplot-core;
   the library no longer has a dependency on `com.halfhp.fig:figlib`.  See the new
   [XML Configuration](xml_configuration.md) doc.


### PR DESCRIPTION
Fixes ten confirmed bugs in the XY series/renderer math. Each fix has a regression test that was run against the unfixed code (main-source changes stashed, tests kept) and confirmed to fail before the fix and pass after. Fail-before messages below are quoted from that run.

## Fixes

### 1. Empty ordered series indexes at -1
**Cause:** `SeriesUtils.iBoundsMax` returns `size() - 1 = -1` for an empty series; `new Region(0, -1)` normalises to `[-1, 0]` and `LineAndPointRenderer.drawSeries` then calls `series.getY(-1)` on every frame until the first point arrives (the exception is caught and aborts the frame).
**Change:** `drawSeries` returns early for an empty series; `SeriesUtils.iBounds` returns `[0, 0]` for an empty series (documented; callers are responsible for the size check).
**Tests:** `LineAndPointRendererTest.drawSeries_emptyAscendingSeries_drawsNothing` (before: `IndexOutOfBoundsException: Index: -1, Size: 0`), `SeriesUtilsTest.iBounds_emptySeries_returnsNonNegativeBounds` (before: `expected:<0> but was:<-1>`).

### 2. Interpolation with fewer than 3 points or a null value throws every frame
**Cause:** the interpolator was invoked whenever `getInterpolationParams() != null`; `CatmullRomInterpolator` throws `IllegalArgumentException` for `size() < 3` and NPEs on null x/y.
**Change:** new `LineAndPointRenderer.isInterpolatable(series)` (>= 3 vertices, no null x/y). When it is false the renderer falls back to the plain straight-segment path.
**Tests:** `drawSeries_withInterpolation_fewerThanThreePoints_drawsStraightLine` (before: `IllegalArgumentException: Cannot interpolate a series with fewer than 3 vertices.`), `drawSeries_withInterpolation_nullPoint_drawsStraightSegments` (before: `NullPointerException ... XYSeries.getY(int) is null`).

### 3. GROW/SHRINK latch the placeholder [-1, 1] bounds when the first frame has no data
**Cause:** in `XYPlot.calculateMinMaxVals`, when `SeriesUtils.minMax` finds no data, `bounds.getMinY()` falls through to the `-1` default and that default is passed to `getCalculatedLowerBoundary` and stored via `setMinY`. On the next frame it is the "previous" value, so GROW keeps -1 forever and SHRINK produces an inverted axis like `[50, 1]`.
**Change:** the calculated value is passed as `null` when `bounds.isMin/MaxX/YSet()` is false; `getCalculatedUpper/LowerBoundary` return the previous value (which is itself null on the first frame) for a null calculated value, so nothing is stored until real data exists. `prevMin*/prevMax*` were already null-guarded via `is*Set()`.
**Tests:** `XYPlotTest.calculateMinMaxVals_grow_ignoresPlaceholderBoundsWhenFirstFrameHasNoData` (before: `expected:<50.0> but was:<-1.0>`), `calculateMinMaxVals_shrink_ignoresPlaceholderBoundsWhenFirstFrameHasNoData` (before: `expected:<100.0> but was:<1.0>`).

### 4. Typo in `XYConstraints.contains(RectRegion)`
**Cause:** `contains(rectRegion.getMinY(), rectRegion.getMinY())` passed the minimum y as the x coordinate.
**Change:** pass `getMinX()`.
**Tests:** new `XYConstraintsTest.contains_rectRegion_checksMinXAgainstDomain` (before: `AssertionError`, region with x in [-50, 50] reported as contained by domain [0, 50]). `contains_rectRegion_checksRangeEdges` is a companion test that passes on the old code by design.

### 5. RANGE_ORIGIN fill uses the domain region
**Cause:** `LineAndPointRenderer.renderPath` transformed the range origin through `getxRegion()`.
**Change:** new `getRangeOriginPix(plotArea)` helper using `getyRegion()` (matches `BarRenderer`).
**Tests:** `renderPath_rangeOriginFill_closesPathAtRangeOrigin` with domain 0..10, range -1..1, origin 0, plot area 0..100px: fill closes at y = 50 (before: `Wanted: path.lineTo(90.0f, 50.0f)` but the path was closed at 100).

### 6. Stacked bars measure from the plot bottom
**Cause:** `BarOrientation.STACKED` used `bottom = plotArea.bottom` and `height = plotArea.bottom - yPix`, so each bar's height was `(y - minY)` in pixels.
**Change:** each bar's height is `rangeOriginPx - yPix`; positive values stack upward from the origin pixel and negative values stack downward from it (separate cursors, so no negative heights). Null y-vals contribute zero height instead of shifting the stack.
**Tests:** `BarRendererTest.onRender_stacked_measuresBarsFromRangeOrigin` with FIXED range [2, 12], range origin 0 and stacked y = 3 and y = 4: the stack tops out at the pixel for y = 7 (before: `Wanted but not invoked: drawRect(<any>, 90.0f, <any>, 120.0f, ...)`; the old top was at the pixel for y = 5), `onRender_stacked_negativeValuesStackDownwardFromRangeOrigin`.
**Caveat:** the range origin defaults to the range minimum when no origin has been set (`calculatedOrigin.y = userRangeOrigin != null ? userRangeOrigin : bounds.getMinY()`), so with no origin set the rendered output is unchanged from before; true value-sum stacks on a range that does not start at 0 require `setUserRangeOrigin(0)`. This mirrors how OVERLAID / SIDE_BY_SIDE already base bars on the origin.
**Not addressed:** auto-ranging does not sum stacked series, so a STACKED plot with AUTO range boundaries can still clip the top of the stack. That is a separate limitation.

### 7. Bubble sizing
**Cause:** `calculateBounds` clamped the wrong end of the magnitude region (`setMax(0)` instead of `setMin(0)`) whenever the smallest z-val was <= 0, producing a `[0, 0]`/`[-1, 0]` region and infinite radii. A single bubble or all-equal z-vals gave a zero-length region and NaN radii through `Region.transform`, so nothing was drawn.
**Change:** clamp the min; new `calculateRadius` returns the configured maximum bubble radius when the magnitude region has zero length (the single value *is* the maximum; chosen over the midpoint). Null x/y/z values are skipped, and `onRender` returns early when `calculateBounds` yields null.
**Tests:** `BubbleRendererTest.onRender_withZeroZVal_drawsFiniteRadiiWithinConfiguredBounds` (before: `radius should be finite: Infinity`), `onRender_singleBubble_drawsFiniteRadius` (before: `radius should be finite: NaN`).

### 8. Zero-length bounds produce NaN everywhere
**Cause:** `Region.transform` computes `scale = r2 / range`; with `range == 0` that is infinite and `Infinity * 0` is NaN, so a single-point or flat series rendered blank (grid loop never runs, all points NaN).
**Change:** (a) `Region.transform` returns the center of the target range when this region has zero length; (b) `XYPlot.padZeroLengthBounds` pads a calculated axis whose min equals max: by 1 unit when the value is 0, otherwise by 10% of |value|. Both edges are padded symmetrically when both are calculated; when one edge is user-fixed only the calculated edge is padded; fully fixed axes are left alone.
**Tests:** `RegionTest.transform_zeroLengthRegion_returnsCenterOfTargetRange` (before: `expected:<50.0> but was:<NaN>`), `XYPlotTest.calculateMinMaxVals_singlePoint_padsBoundsToNonZeroLength` (before: `expected:<-1.0> but was:<0.0>`), `calculateMinMaxVals_flatSeriesWithFixedLowerBound_padsOnlyTheCalculatedEdge` (before: `expected:<5.5> but was:<5.0>`).

### 9. `BarFormatter` shadows `fillPaint`
**Cause:** `BarFormatter` declared its own private `fillPaint` and `borderPaint` while the inherited `hasFillPaint()` / `hasLinePaint()` tested the parent's fields (which the implicit `LineAndPointFormatter()` constructor always populates), so `setFillPaint(null)` left `hasFillPaint()` true and `BarRenderer.drawBar` called `canvas.drawRect(..., null)` every frame. Same for the border, and `doDrawLegendIcon` drew the border unconditionally.
**Change:** the shadowing fields are removed; `getFillPaint()` returns the inherited field without instantiating a default, `get/setBorderPaint` map onto the inherited `linePaint`, and the legend icon draws the border only when `hasLinePaint()`. The `getBorderPaint`/`setBorderPaint` accessors are kept so XML `borderPaint.*` configuration is unaffected.
**Tests:** `BarRendererTest.setFillPaint_null_disablesFill` (before: `AssertionFailedError`, `hasFillPaint()` stayed true), `onRender_withNullFillAndBorderPaint_drawsNothingWithNullPaint` (before: `NullPointerException` from `drawRect` with a null paint).

### 10. `NormedXYSeries`
**Cause:** (a) `min == max` made every value NaN via `Region.transform`; (b) min/max were computed once in the constructor, so wrapping a live series drifted outside [0, 1].
**Change:** (a) is covered by fix 8a and now yields the center of the normalized range. (b) `NormedXYSeries` keeps its `Norm` settings, implements `PlotListener` (auto-registered by `Plot.attachSeries`) and recalculates auto bounds in `onBeforeDraw`; user-specified `Norm.minMax` regions are unaffected. A public `normalize()` allows a manual refresh. The listener callbacks are forwarded to the wrapped series when it is itself a `PlotListener`, so a wrapped `SimpleXYSeries` still gets its read lock during the draw.
**Tests:** `NormedXYSeriesTest.getY_singlePoint_returnsFiniteValue` (before: `expected a finite value but got NaN`), `onBeforeDraw_renormalizesAgainstUpdatedRawData`, `onBeforeDraw_doesNotAlterUserSpecifiedBounds`. The two `onBeforeDraw` tests cannot compile against the old code (the class did not implement `PlotListener`); for the fail-before run they were temporarily changed to cast to `PlotListener`, which failed with `ClassCastException`.

## Verification

- Baseline on `master` before any change: `./gradlew testDebugUnitTest` 224 tests, 0 failures.
- Fail-before run (main-source changes stashed, tests kept): 245 tests, 20 failures, all in the new tests listed above.
- After: `./gradlew testDebugUnitTest lint :androidplot-core:assembleRelease :demoapp:assembleDebug` exits 0; 245 tests, 0 failures, 0 errors; lint clean; `androidplot-core-release.aar` and `demoapp-debug.apk` produced.
- CRLF line endings preserved in `LineAndPointRenderer`, `XYPlot`, `BarRenderer`, `BarFormatter` and `XYPlotTest`.
- `Plot.java`, `XYPlot.updateRangeMinMaxForOriginModel`, `Region.intersects`, `SampledXYSeries` and `PanZoom` are untouched.
- One `Fix ...` bullet per fix added under `# 1.6.0` in `docs/release_notes.md`.
