### PR TITLE
Fix crashes in pan/zoom state, sampled series, listeners, markers and origin modes

### DIFF
--- a/androidplot-core/src/main/java/com/androidplot/Plot.java
+++ b/androidplot-core/src/main/java/com/androidplot/Plot.java
@@ -41,6 +41,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Base class for all Plot implementations.
@@ -171,7 +172,9 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     private HashMap<Class<? extends RendererType>, RendererType> renderers;
 
     private RegistryType registry;
-    private final ArrayList<PlotListener> listeners;
+    // listeners may add / remove themselves (or a series) from within a draw callback, so this
+    // must be safe to mutate while notifyListenersBeforeDraw / AfterDraw iterate over it:
+    private final List<PlotListener> listeners;
 
     // the current render thread, if any.  Replaced under renderSync; read without the lock
     // where only a best-effort check is needed.
@@ -260,7 +263,7 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
     }
 
     {
-        listeners = new ArrayList<>();
+        listeners = new CopyOnWriteArrayList<>();
         registry = getRegistryInstance();
         renderers = new HashMap<>();
 
@@ -643,7 +646,7 @@ public abstract class Plot<SeriesType extends Series, FormatterType extends Form
         return listeners.remove(listener);
     }
 
-    protected ArrayList<PlotListener> getListeners() {
+    protected List<PlotListener> getListeners() {
         return listeners;
     }
 

--- a/androidplot-core/src/main/java/com/androidplot/Region.java
+++ b/androidplot-core/src/main/java/com/androidplot/Region.java
@@ -26,13 +26,20 @@ public class Region {
         return r;
     }
 
+    /**
+     * @param v1
+     * @param v2
+     * Values are ordered so that min is the smaller of the two.  A null value represents infinity
+     * relative to its position (null v1 = negative infinity, null v2 = positive infinity) and
+     * is never reordered.
+     */
     public Region(Number v1, Number v2) {
-        if (v1 != null && v2 != null && v1.doubleValue() < v2.doubleValue()) {
-            this.setMin(v1);
-            this.setMax(v2);
-        } else {
+        if (v1 != null && v2 != null && v1.doubleValue() > v2.doubleValue()) {
             this.setMin(v2);
             this.setMax(v1);
+        } else {
+            this.setMin(v1);
+            this.setMax(v2);
         }
     }
 
@@ -170,18 +177,24 @@ public class Region {
     }
 
      /**
-     * Tests whether this segment intersects another
+     * Tests whether this segment intersects another.  A null min represents negative infinity
+     * and a null max represents positive infinity, both for the params and for this region's
+     * own min / max.
      * @param line2Min
      * @param line2Max
      * @return
      */
     public  boolean intersects(Number line2Min, Number line2Max) {
+        final double min1 = getMin() == null ? Double.NEGATIVE_INFINITY : getMin().doubleValue();
+        final double max1 = getMax() == null ? Double.POSITIVE_INFINITY : getMax().doubleValue();
+        final double min2 = line2Min == null ? Double.NEGATIVE_INFINITY : line2Min.doubleValue();
+        final double max2 = line2Max == null ? Double.POSITIVE_INFINITY : line2Max.doubleValue();
 
         // is this line completely within line2?
-        if(line2Min.doubleValue() <= getMin().doubleValue() && line2Max.doubleValue() >= getMax().doubleValue()) {
+        if(min2 <= min1 && max2 >= max1) {
             return true;
         // is line1 partially within line2
-        } else return contains(line2Min) || contains(line2Max);
+        } else return (min2 >= min1 && min2 <= max1) || (max2 >= min1 && max2 <= max1);
     }
 
     public boolean isMinSet() {

--- a/androidplot-core/src/main/java/com/androidplot/util/LayerListOrganizer.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/LayerListOrganizer.java
@@ -29,11 +29,18 @@ public class LayerListOrganizer<ElementType> implements Layerable<ElementType> {
             }
     }
 
+    /**
+     * @param objectToMove
+     * @param reference
+     * @return
+     * @throws IllegalArgumentException if reference is not an element of this list, or is the
+     * same as objectToMove.  The list is left unchanged.
+     */
     public boolean moveAbove(ElementType objectToMove, ElementType reference) {
         if(objectToMove == reference) {
             throw new IllegalArgumentException("Illegal argument to moveAbove(A, B); A cannot be equal to B.");
         }
-
+        checkReference(reference, "moveAbove");
 
         list.remove(objectToMove);
         int refIndex = list.indexOf(reference);
@@ -41,16 +48,31 @@ public class LayerListOrganizer<ElementType> implements Layerable<ElementType> {
         return true;
     }
 
+    /**
+     * @param objectToMove
+     * @param reference
+     * @return
+     * @throws IllegalArgumentException if reference is not an element of this list, or is the
+     * same as objectToMove.  The list is left unchanged.
+     */
     public boolean moveBeneath(ElementType objectToMove, ElementType reference) {
         if (objectToMove == reference) {
             throw new IllegalArgumentException("Illegal argument to moveBeaneath(A, B); A cannot be equal to B.");
         }
+        checkReference(reference, "moveBeneath");
 
         list.remove(objectToMove);
         int refIndex = list.indexOf(reference);
         list.add(refIndex, objectToMove);
         return true;
 
+    }
+
+    private void checkReference(ElementType reference, String operation) {
+        if (!list.contains(reference)) {
+            throw new IllegalArgumentException(
+                    "Illegal argument to " + operation + "(A, B); B must be an element of the list.");
+        }
     }
 
     public boolean moveToBottom(ElementType key) {

--- a/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointRenderer.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/LineAndPointRenderer.java
@@ -288,9 +288,9 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
         for (RectRegion thisRegion : bounds.intersects(formatter.getRegions().elements())) {
             XYRegionFormatter regionFormatter = formatter.getRegionFormatter(thisRegion);
             RectRegion thisRegionTransformed = bounds
-                    .transform(thisRegion, plotRegion, false, true);
+                    .transform(clipToBounds(thisRegion, bounds), plotRegion, false, true);
             thisRegionTransformed.intersect(plotRegion);
-            if(thisRegion.isFullyDefined()) {
+            if(thisRegionTransformed.isFullyDefined()) {
                 RectF thisRegionRectF = thisRegionTransformed.asRectF();
                 if (thisRegionRectF != null) {
                     try {
@@ -310,5 +310,25 @@ public class LineAndPointRenderer<FormatterType extends LineAndPointFormatter> e
         }
 
         path.rewind();
+    }
+
+    /**
+     * A null edge on a region represents infinity (see {@link RectRegion#intersects(Number, Number, Number, Number)}).
+     * Nothing beyond the visible bounds can be drawn anyway, so such an edge is replaced by the
+     * corresponding edge of bounds, producing a region that can be transformed into screen space.
+     * @param region
+     * @param bounds The plot's visible bounds; must be fully defined.
+     * @return region itself if it is fully defined, otherwise a fully defined copy.
+     */
+    protected static RectRegion clipToBounds(RectRegion region, RectRegion bounds) {
+        if (region.isFullyDefined()) {
+            return region;
+        }
+        return new RectRegion(
+                region.getMinX() != null ? region.getMinX() : bounds.getMinX(),
+                region.getMaxX() != null ? region.getMaxX() : bounds.getMaxX(),
+                region.getMinY() != null ? region.getMinY() : bounds.getMinY(),
+                region.getMaxY() != null ? region.getMaxY() : bounds.getMaxY(),
+                region.getLabel());
     }
 }

--- a/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
@@ -38,7 +38,6 @@ public class PanZoom implements View.OnTouchListener {
     // rectangle created by the space between two fingers
     protected RectF fingersRect;
     private View.OnTouchListener delegate;
-    private State state = new State();
 
     // Definition of the touch states
     protected enum DragState {
@@ -99,33 +98,75 @@ public class PanZoom implements View.OnTouchListener {
         MIN_TICKS
     }
 
+    /**
+     * A snapshot of an {@link XYPlot}'s domain and range boundaries, as captured by
+     * {@link PanZoom#getState()} and restored by {@link PanZoom#setState(State)}.  Each boundary
+     * edge is stored independently; an edge whose mode is null is left untouched when the state
+     * is applied.
+     */
     // TODO: consider making this immutable / threadsafe
     public static class State implements Serializable {
         private Number domainLowerBoundary;
         private Number domainUpperBoundary;
         private Number rangeLowerBoundary;
         private Number rangeUpperBoundary;
-        private BoundaryMode domainBoundaryMode;
-        private BoundaryMode rangeBoundaryMode;
+        private BoundaryMode domainLowerBoundaryMode;
+        private BoundaryMode domainUpperBoundaryMode;
+        private BoundaryMode rangeLowerBoundaryMode;
+        private BoundaryMode rangeUpperBoundaryMode;
 
         public void setDomainBoundaries(Number lowerBoundary, Number upperBoundary, BoundaryMode mode) {
+            setDomainBoundaries(lowerBoundary, mode, upperBoundary, mode);
+        }
+
+        public void setDomainBoundaries(Number lowerBoundary, BoundaryMode lowerBoundaryMode,
+                                        Number upperBoundary, BoundaryMode upperBoundaryMode) {
             this.domainLowerBoundary = lowerBoundary;
+            this.domainLowerBoundaryMode = lowerBoundaryMode;
             this.domainUpperBoundary = upperBoundary;
-            this.domainBoundaryMode = mode;
+            this.domainUpperBoundaryMode = upperBoundaryMode;
         }
 
         public void setRangeBoundaries(Number lowerBoundary, Number upperBoundary, BoundaryMode mode) {
+            setRangeBoundaries(lowerBoundary, mode, upperBoundary, mode);
+        }
+
+        public void setRangeBoundaries(Number lowerBoundary, BoundaryMode lowerBoundaryMode,
+                                       Number upperBoundary, BoundaryMode upperBoundaryMode) {
             this.rangeLowerBoundary = lowerBoundary;
+            this.rangeLowerBoundaryMode = lowerBoundaryMode;
             this.rangeUpperBoundary = upperBoundary;
-            this.rangeBoundaryMode = mode;
+            this.rangeUpperBoundaryMode = upperBoundaryMode;
         }
 
+        /**
+         * Applies the captured domain boundaries to plot.  An edge whose mode is null (this state
+         * was never populated for that edge) is skipped, since a null mode would crash the plot's
+         * next render pass.
+         * @param plot
+         */
         public void applyDomainBoundaries(@NonNull XYPlot plot) {
-            plot.setDomainBoundaries(domainLowerBoundary, domainUpperBoundary, domainBoundaryMode);
+            if (domainLowerBoundaryMode != null) {
+                plot.setDomainLowerBoundary(domainLowerBoundary, domainLowerBoundaryMode);
+            }
+            if (domainUpperBoundaryMode != null) {
+                plot.setDomainUpperBoundary(domainUpperBoundary, domainUpperBoundaryMode);
+            }
         }
 
+        /**
+         * Applies the captured range boundaries to plot.  An edge whose mode is null (this state
+         * was never populated for that edge) is skipped, since a null mode would crash the plot's
+         * next render pass.
+         * @param plot
+         */
         public void applyRangeBoundaries(@NonNull XYPlot plot) {
-            plot.setRangeBoundaries(rangeLowerBoundary, rangeUpperBoundary, rangeBoundaryMode);
+            if (rangeLowerBoundaryMode != null) {
+                plot.setRangeLowerBoundary(rangeLowerBoundary, rangeLowerBoundaryMode);
+            }
+            if (rangeUpperBoundaryMode != null) {
+                plot.setRangeUpperBoundary(rangeUpperBoundary, rangeUpperBoundaryMode);
+            }
         }
 
         public void apply(@NonNull XYPlot plot) {
@@ -149,23 +190,36 @@ public class PanZoom implements View.OnTouchListener {
         this.zoomLimit = limit;
     }
 
+    /**
+     * @return A snapshot of the plot's current domain and range boundaries, reflecting any
+     * panning / zooming that has taken place.  Suitable for persisting (eg. in an Activity's
+     * saved instance state) and later restoring via {@link #setState(State)}.
+     */
     public State getState() {
-        return this.state;
+        final State state = new State();
+        state.setDomainBoundaries(
+                plot.getUserMinX(), plot.getDomainLowerBoundaryMode(),
+                plot.getUserMaxX(), plot.getDomainUpperBoundaryMode());
+        state.setRangeBoundaries(
+                plot.getUserMinY(), plot.getRangeLowerBoundaryMode(),
+                plot.getUserMaxY(), plot.getRangeUpperBoundaryMode());
+        return state;
     }
 
+    /**
+     * Applies a previously captured state to the plot.  Note that the plot is not redrawn.
+     * @param state
+     */
     public void setState(@NonNull State state) {
-        this.state = state;
         state.apply(plot);
     }
 
     protected void adjustRangeBoundary(Number lower, Number upper,  BoundaryMode mode) {
-        state.setRangeBoundaries(lower, upper, mode);
-        state.applyRangeBoundaries(plot);
+        plot.setRangeBoundaries(lower, upper, mode);
     }
 
     protected void adjustDomainBoundary(Number lower, Number upper, BoundaryMode mode) {
-        state.setDomainBoundaries(lower, upper, mode);
-        state.applyDomainBoundaries(plot);
+        plot.setDomainBoundaries(lower, upper, mode);
     }
 
     /**

--- a/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/PanZoom.java
@@ -106,6 +106,15 @@ public class PanZoom implements View.OnTouchListener {
      */
     // TODO: consider making this immutable / threadsafe
     public static class State implements Serializable {
+
+        /**
+         * The JVM-computed UID of this class as it existed before per-edge boundary modes were
+         * added.  It must never change: a State serialized by an older version of the library
+         * (eg. one held in an Activity's saved instance state across an app update) must still
+         * deserialize, with any fields it lacks left null so that {@link #apply(XYPlot)} skips them.
+         */
+        private static final long serialVersionUID = -4221152827129598653L;
+
         private Number domainLowerBoundary;
         private Number domainUpperBoundary;
         private Number rangeLowerBoundary;

--- a/androidplot-core/src/main/java/com/androidplot/xy/SampledXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/SampledXYSeries.java
@@ -70,6 +70,9 @@ public class SampledXYSeries implements FastXYSeries, OrderedXYSeries {
 
     public void resample() {
         bounds = null;
+
+        // until a zoom factor is applied, the series is the raw data (1x zoom):
+        activeSeries = rawData;
         zoomLevels = new ArrayList<>();
         int t = (int) Math.ceil(rawData.size() / getRatio());
         List<Thread> threads = new ArrayList<>(zoomLevels.size());
@@ -108,6 +111,11 @@ public class SampledXYSeries implements FastXYSeries, OrderedXYSeries {
             throw new RuntimeException("Exception encountered during resampling", lastResamplingException);
         }
 
+        // no zoom levels were generated (rawData.size / ratio is already below threshold) so
+        // the sampler never ran; compute bounds directly from the raw data instead:
+        if (bounds == null) {
+            bounds = SeriesUtils.minMax(rawData);
+        }
     }
 
     protected List<EditableXYSeries> getZoomLevels() {
@@ -186,6 +194,10 @@ public class SampledXYSeries implements FastXYSeries, OrderedXYSeries {
         this.threshold = threshold;
     }
 
+    /**
+     * @return The min/max bounds of the raw data.  Never null after construction unless
+     * explicitly set to null via {@link #setBounds(RectRegion)}.
+     */
     public RectRegion getBounds() {
         return bounds;
     }

--- a/androidplot-core/src/main/java/com/androidplot/xy/SimpleXYSeries.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/SimpleXYSeries.java
@@ -126,8 +126,10 @@ public class SimpleXYSeries implements EditableXYSeries, OrderedXYSeries, PlotLi
 
         lock.writeLock().lock();
         try {
-            // empty the current values:
-            xVals.clear();
+            // empty the current values (xVals is null when implicit x-vals are in use):
+            if (xVals != null) {
+                xVals.clear();
+            }
             yVals.clear();
 
             // make sure the new model has data:
@@ -140,8 +142,10 @@ public class SimpleXYSeries implements EditableXYSeries, OrderedXYSeries, PlotLi
                 // array containing only y-vals. assume x = index:
                 case Y_VALS_ONLY:
                     yVals.addAll(model);
-                    for(int i = 0; i < yVals.size(); i++) {
-                        xVals.add(i);
+                    if (xVals != null) {
+                        for (int i = 0; i < yVals.size(); i++) {
+                            xVals.add(i);
+                        }
                     }
                     break;
 
@@ -172,10 +176,16 @@ public class SimpleXYSeries implements EditableXYSeries, OrderedXYSeries, PlotLi
      * Sets individual x value based on index
      * @param value
      * @param index
+     * @throws IllegalStateException if this series uses implicit x-vals.
+     * See {@link #useImplicitXVals()}.
      */
     public void setX(Number value, int index) {
         lock.writeLock().lock();
         try {
+            if (xVals == null) {
+                throw new IllegalStateException(
+                        "Cannot set an x value on a series that uses implicit x-vals.");
+            }
             xVals.set(index, value);
         } finally {
             lock.writeLock().unlock();
@@ -200,14 +210,18 @@ public class SimpleXYSeries implements EditableXYSeries, OrderedXYSeries, PlotLi
     public void resize(int size) {
         try {
             lock.writeLock().lock();
-            if (xVals.size() < size) {
-                for (int i = xVals.size(); i < size; i++) {
-                    xVals.add(null);
+            if (yVals.size() < size) {
+                for (int i = yVals.size(); i < size; i++) {
+                    if (xVals != null) {
+                        xVals.add(null);
+                    }
                     yVals.add(null);
                 }
-            } else if(xVals.size() > size) {
-                for(int i = xVals.size(); i > size; i--) {
-                    xVals.removeLast();
+            } else if(yVals.size() > size) {
+                for(int i = yVals.size(); i > size; i--) {
+                    if (xVals != null) {
+                        xVals.removeLast();
+                    }
                     yVals.removeLast();
                 }
             }
@@ -217,7 +231,8 @@ public class SimpleXYSeries implements EditableXYSeries, OrderedXYSeries, PlotLi
     }
 
     /**
-     * Sets xy values based on index
+     * Sets xy values based on index.  If this series uses implicit x-vals
+     * (see {@link #useImplicitXVals()}) only the y value is set; xVal is ignored.
      * @param xVal
      * @param yVal
      * @param index
@@ -226,7 +241,9 @@ public class SimpleXYSeries implements EditableXYSeries, OrderedXYSeries, PlotLi
         lock.writeLock().lock();
         try {
             yVals.set(index, yVal);
-            xVals.set(index, xVal);
+            if (xVals != null) {
+                xVals.set(index, xVal);
+            }
         } finally {lock.writeLock().unlock();}
     }
 

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
@@ -728,22 +728,48 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
     }
 
     public void updateRangeMinMaxForOriginModel() {
+        double origin = userRangeOrigin.doubleValue();
+        double maxDelta = distance(bounds.getMaxY().doubleValue(), origin);
+        double minDelta = distance(bounds.getMinY().doubleValue(), origin);
+        double delta = maxDelta > minDelta ? maxDelta : minDelta;
+        double lowerBoundary = origin - delta;
+        double upperBoundary = origin + delta;
         switch (rangeOriginBoundaryMode) {
             case AUTO:
-                double origin = userRangeOrigin.doubleValue();
-                double maxDelta = distance(bounds.getMaxY().doubleValue(), origin);
-                double minDelta = distance(bounds.getMinY().doubleValue(), origin);
-                if (maxDelta > minDelta) {
-                    bounds.setMinY(origin - maxDelta);
-                    bounds.setMaxY(origin + maxDelta);
+                bounds.setMinY(lowerBoundary);
+                bounds.setMaxY(upperBoundary);
+                break;
+            // if fixed, then the value already exists within "user" vals.
+            case FIXED:
+                break;
+            case GROW: {
+
+                if (prevMinY == null || lowerBoundary < prevMinY.doubleValue()) {
+                    bounds.setMinY(lowerBoundary);
                 } else {
-                    bounds.setMinY(origin - minDelta);
-                    bounds.setMaxY(origin + minDelta);
+                    bounds.setMinY(prevMinY);
+                }
+
+                if (prevMaxY == null || upperBoundary > prevMaxY.doubleValue()) {
+                    bounds.setMaxY(upperBoundary);
+                } else {
+                    bounds.setMaxY(prevMaxY);
+                }
+            }
+            break;
+            case SHRINK:
+                if (prevMinY == null || lowerBoundary > prevMinY.doubleValue()) {
+                    bounds.setMinY(lowerBoundary);
+                } else {
+                    bounds.setMinY(prevMinY);
+                }
+
+                if (prevMaxY == null || upperBoundary < prevMaxY.doubleValue()) {
+                    bounds.setMaxY(upperBoundary);
+                } else {
+                    bounds.setMaxY(prevMaxY);
                 }
                 break;
-            case FIXED:
-            case GROW:
-            case SHRINK:
             default:
                 throw new UnsupportedOperationException(
                         "Range Origin Boundary Mode not yet supported: " + rangeOriginBoundaryMode);

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
@@ -1002,6 +1002,54 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
         setRangeFramingModel(XYFramingModel.EDGE);
     }
 
+    public BoundaryMode getDomainLowerBoundaryMode() {
+        return constraints.getDomainLowerBoundaryMode();
+    }
+
+    public BoundaryMode getDomainUpperBoundaryMode() {
+        return constraints.getDomainUpperBoundaryMode();
+    }
+
+    public BoundaryMode getRangeLowerBoundaryMode() {
+        return constraints.getRangeLowerBoundaryMode();
+    }
+
+    public BoundaryMode getRangeUpperBoundaryMode() {
+        return constraints.getRangeUpperBoundaryMode();
+    }
+
+    /**
+     * @return The user specified lower domain boundary, or null if the lower domain boundary
+     * mode is not {@link BoundaryMode#FIXED}.
+     */
+    protected Number getUserMinX() {
+        return constraints.getMinX();
+    }
+
+    /**
+     * @return The user specified upper domain boundary, or null if the upper domain boundary
+     * mode is not {@link BoundaryMode#FIXED}.
+     */
+    protected Number getUserMaxX() {
+        return constraints.getMaxX();
+    }
+
+    /**
+     * @return The user specified lower range boundary, or null if the lower range boundary
+     * mode is not {@link BoundaryMode#FIXED}.
+     */
+    protected Number getUserMinY() {
+        return constraints.getMinY();
+    }
+
+    /**
+     * @return The user specified upper range boundary, or null if the upper range boundary
+     * mode is not {@link BoundaryMode#FIXED}.
+     */
+    protected Number getUserMaxY() {
+        return constraints.getMaxY();
+    }
+
     public XYCoords getOrigin() {
         return calculatedOrigin;
     }

--- a/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/XYPlot.java
@@ -25,9 +25,9 @@ import com.androidplot.util.AttrUtils;
 import com.androidplot.util.PixelUtils;
 import com.androidplot.util.SeriesUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A View to graphically display x/y coordinates.
@@ -106,8 +106,10 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
     @SuppressWarnings("FieldCanBeLocal")
     private Number rangeOriginExtent = null;
 
-    private ArrayList<YValueMarker> yValueMarkers;
-    private ArrayList<XValueMarker> xValueMarkers;
+    // XYGraphWidget.drawMarkers iterates these on the render thread while markers may be
+    // added / removed from another thread, so they must be safe to mutate during iteration:
+    private List<YValueMarker> yValueMarkers;
+    private List<XValueMarker> xValueMarkers;
 
     private PreviewMode previewMode;
 
@@ -219,8 +221,8 @@ public class XYPlot extends Plot<XYSeries, XYSeriesFormatter, XYSeriesRenderer, 
         setPlotMarginTop(PixelUtils.dpToPix(DEFAULT_PLOT_TOP_MARGIN_DP));
         setPlotMarginBottom(PixelUtils.dpToPix(DEFAULT_PLOT_BOTTOM_MARGIN_DP));
 
-        xValueMarkers = new ArrayList<>();
-        yValueMarkers = new ArrayList<>();
+        xValueMarkers = new CopyOnWriteArrayList<>();
+        yValueMarkers = new CopyOnWriteArrayList<>();
 
         domainStepModel = new StepModel(StepMode.SUBDIVIDE, 10);
         rangeStepModel = new StepModel(StepMode.SUBDIVIDE, 10);

--- a/androidplot-core/src/main/java/com/androidplot/xy/ZoomEstimator.java
+++ b/androidplot-core/src/main/java/com/androidplot/xy/ZoomEstimator.java
@@ -11,13 +11,25 @@ public class ZoomEstimator extends Estimator {
     public void run(XYPlot plot, XYSeriesBundle sf) {
         if(sf.getSeries() instanceof SampledXYSeries) {
             SampledXYSeries oxy = (SampledXYSeries) sf.getSeries();
+            if (oxy.getBounds() == null) {
+                // nothing to estimate against; leave the current zoom level as-is.
+                return;
+            }
             final double factor = calculateZoom(oxy, plot.getBounds());
             oxy.setZoomFactor(factor);
         }
     }
 
+    /**
+     * @param series
+     * @param visibleBounds
+     * @return The zoom factor to apply to series, or 1 (no zoom) if series has no bounds.
+     */
     protected double calculateZoom(SampledXYSeries series, RectRegion visibleBounds) {
         RectRegion seriesBounds = series.getBounds();
+        if (seriesBounds == null) {
+            return 1;
+        }
         final double ratio = seriesBounds.getxRegion().ratio(visibleBounds.getxRegion()).doubleValue();
         final double maxFactor = series.getMaxZoomFactor();
         final double factor = Math.abs(Math.round(maxFactor / ratio));

--- a/androidplot-core/src/test/java/com/androidplot/PlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/PlotTest.java
@@ -205,7 +205,7 @@ public class PlotTest extends AndroidplotTest {
     @Test
     public void testAddListener() {
         Plot plot = new MockPlot("MockPlot");
-        ArrayList<PlotListener> listeners = plot.getListeners();
+        List<PlotListener> listeners = plot.getListeners();
 
         assertEquals(0, listeners.size());
 
@@ -231,7 +231,7 @@ public class PlotTest extends AndroidplotTest {
     @Test
     public void testRemoveListener() {
         Plot plot = new MockPlot("MockPlot");
-        ArrayList<PlotListener> listeners = plot.getListeners();
+        List<PlotListener> listeners = plot.getListeners();
 
         assertEquals(0, listeners.size());
 
@@ -284,6 +284,84 @@ public class PlotTest extends AndroidplotTest {
         Plot plot = new MockPlot("foo");
         plot.setTitle("bar");
         assertEquals("bar", plot.getTitle().getText());
+    }
+
+    /** Counts onAfterDraw invocations. */
+    static class CountingPlotListener extends MockPlotListener {
+        int afterDrawCount;
+
+        @Override
+        public void onAfterDraw(Plot source, Canvas canvas) {
+            afterDrawCount++;
+        }
+    }
+
+    @Test
+    public void renderOnCanvas_listenerRemovingItselfDuringDraw_doesNotThrow() {
+        final Plot plot = new MockPlot("MockPlot", Plot.RenderMode.USE_MAIN_THREAD);
+        final PlotListener selfRemovingListener = new PlotListener() {
+            @Override
+            public void onBeforeDraw(Plot source, Canvas canvas) {
+            }
+
+            @Override
+            public void onAfterDraw(Plot source, Canvas canvas) {
+                source.removeListener(this);
+            }
+        };
+        CountingPlotListener otherListener = new CountingPlotListener();
+        plot.addListener(otherListener);
+        plot.addListener(selfRemovingListener);
+
+        plot.renderOnCanvas(new Canvas());
+
+        assertEquals(1, otherListener.afterDrawCount);
+        assertEquals(1, plot.getListeners().size());
+        assertTrue(plot.getListeners().contains(otherListener));
+    }
+
+    @Test
+    public void renderOnCanvas_listenerRemovingItselfDuringDraw_stillNotifiesRemainingListeners() {
+        final Plot plot = new MockPlot("MockPlot", Plot.RenderMode.USE_MAIN_THREAD);
+        final PlotListener selfRemovingListener = new PlotListener() {
+            @Override
+            public void onBeforeDraw(Plot source, Canvas canvas) {
+            }
+
+            @Override
+            public void onAfterDraw(Plot source, Canvas canvas) {
+                source.removeListener(this);
+            }
+        };
+        CountingPlotListener otherListener = new CountingPlotListener();
+        plot.addListener(selfRemovingListener);
+        plot.addListener(otherListener);
+
+        plot.renderOnCanvas(new Canvas());
+
+        assertEquals(1, otherListener.afterDrawCount);
+        assertEquals(1, plot.getListeners().size());
+        assertTrue(plot.getListeners().contains(otherListener));
+    }
+
+    @Test
+    public void renderOnCanvas_seriesRemovingItselfDuringDraw_doesNotThrow() {
+        final Plot plot = new MockPlot("MockPlot", Plot.RenderMode.USE_MAIN_THREAD);
+        // series implementing PlotListener are auto-registered as listeners:
+        final MockSeries selfRemovingSeries = new MockSeries() {
+            @Override
+            public void onAfterDraw(Plot source, Canvas canvas) {
+                source.removeSeries(this);
+            }
+        };
+        plot.addSeries(new MockSeries(), new MockFormatter1());
+        plot.addSeries(selfRemovingSeries, new MockFormatter1());
+        assertEquals(2, plot.getListeners().size());
+
+        plot.renderOnCanvas(new Canvas());
+
+        assertEquals(1, plot.getListeners().size());
+        assertEquals(1, plot.getRegistry().size());
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/RegionTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/RegionTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import static junit.framework.Assert.assertNotSame;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class RegionTest {
@@ -21,6 +22,45 @@ public class RegionTest {
     @After
     public void tearDown() throws Exception {
 
+    }
+
+    @Test
+    public void testConstructor_preservesNullPlacement() throws Exception {
+        // a null min means negative infinity and a null max means positive infinity,
+        // so they must not be swapped:
+        Region lr = new Region(null, 5);
+        assertNull(lr.getMin());
+        assertEquals(5, lr.getMax().intValue());
+
+        lr = new Region(5, null);
+        assertEquals(5, lr.getMin().intValue());
+        assertNull(lr.getMax());
+
+        lr = new Region(null, null);
+        assertNull(lr.getMin());
+        assertNull(lr.getMax());
+    }
+
+    @Test
+    public void testIntersects_nullIsInfinity() throws Exception {
+        Region lr = new Region(0, 10);
+
+        assertTrue(lr.intersects(null, 5));
+        assertTrue(lr.intersects(null, 0));
+        assertFalse(lr.intersects(null, -5));
+
+        assertTrue(lr.intersects(5, null));
+        assertTrue(lr.intersects(10, null));
+        assertFalse(lr.intersects(15, null));
+
+        assertTrue(lr.intersects(null, null));
+
+        // this region's own null bounds are treated the same way:
+        assertTrue(new Region(null, 5).intersects(0, 10));
+        assertFalse(new Region(null, -5).intersects(0, 10));
+        assertTrue(new Region(5, null).intersects(0, 10));
+        assertFalse(new Region(15, null).intersects(0, 10));
+        assertTrue(new Region(null, null).intersects(0, 10));
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/util/LinkedLayerListOrganizerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/LinkedLayerListOrganizerTest.java
@@ -6,9 +6,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class LinkedLayerListOrganizerTest {
     @Before
@@ -28,12 +30,66 @@ public class LinkedLayerListOrganizerTest {
 
     @Test
     public void testMoveAbove() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+        LinkedList<Object> list = new LinkedList<>(Arrays.asList(obj1, obj2, obj3));
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
 
+        organizer.moveAbove(obj1, obj2);
+        assertEquals(Arrays.asList(obj2, obj1, obj3), list);
+
+        organizer.moveAbove(obj2, obj3);
+        assertEquals(Arrays.asList(obj1, obj3, obj2), list);
+    }
+
+    @Test
+    public void testMoveAbove_unknownReference_throwsAndLeavesListUnchanged() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+        LinkedList<Object> list = new LinkedList<>(Arrays.asList(obj1, obj2, obj3));
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
+
+        try {
+            organizer.moveAbove(obj1, new Object());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+        assertEquals(Arrays.asList(obj1, obj2, obj3), list);
     }
 
     @Test
     public void testMoveBeneath() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+        LinkedList<Object> list = new LinkedList<>(Arrays.asList(obj1, obj2, obj3));
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
 
+        organizer.moveBeneath(obj3, obj2);
+        assertEquals(Arrays.asList(obj1, obj3, obj2), list);
+
+        organizer.moveBeneath(obj2, obj1);
+        assertEquals(Arrays.asList(obj2, obj1, obj3), list);
+    }
+
+    @Test
+    public void testMoveBeneath_unknownReference_throwsAndLeavesListUnchanged() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+        LinkedList<Object> list = new LinkedList<>(Arrays.asList(obj1, obj2, obj3));
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
+
+        try {
+            organizer.moveBeneath(obj1, new Object());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+        assertEquals(Arrays.asList(obj1, obj2, obj3), list);
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/xy/LineAndPointRendererTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/LineAndPointRendererTest.java
@@ -227,6 +227,36 @@ public class LineAndPointRendererTest extends AndroidplotTest {
     }
 
     @Test
+    public void renderPath_rendersRegionsWithUnboundedEdges() {
+        LineAndPointFormatter formatter =
+                new LineAndPointFormatter(0, 0, 0, null);
+
+        // null edges represent infinity; this region covers everything below / left of 0.5:
+        XYRegionFormatter open = new XYRegionFormatter(Color.RED);
+        formatter.addRegion(new RectRegion(null, 0.5, null, 0.5, "open"), open);
+
+        // everything above / right of 5, which is outside the plot's visible bounds of -1..1:
+        XYRegionFormatter far = new XYRegionFormatter(Color.GREEN);
+        formatter.addRegion(new RectRegion(5, null, 5, null, "far"), far);
+
+        SimpleXYSeries series = new SimpleXYSeries(
+                SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "some data", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+        xyPlot.addSeries(series, formatter);
+        LineAndPointRenderer renderer = xyPlot.getRenderer(LineAndPointRenderer.class);
+
+        renderer.renderPath(canvas, plotArea, new Path(), mock(PointF.class), mock(PointF.class), formatter);
+
+        ArgumentCaptor<RectF> rect = ArgumentCaptor.forClass(RectF.class);
+        verify(canvas).drawRect(rect.capture(), eq(open.getPaint()));
+        verify(canvas, never()).drawRect(any(RectF.class), eq(far.getPaint()));
+
+        // the unbounded edges are clipped to the plot area:
+        assertEquals(plotArea.left, rect.getValue().left);
+        assertEquals(plotArea.bottom, rect.getValue().bottom);
+    }
+
+    @Test
     public void drawSeries_withPointLabelFormatter_drawsPointLabels() {
         LineAndPointFormatter formatter =
                 new LineAndPointFormatter(0, 0, 0, null);

--- a/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
@@ -235,4 +235,80 @@ public class PanZoomTest extends AndroidplotTest {
         assertEquals(10f, distance.right);
         assertEquals(10f, distance.bottom);
     }
+
+    private XYPlot newRealPlot() {
+        XYPlot plot = new XYPlot(getContext(), "test");
+        plot.addSeries(TestUtils.generateXYSeries("series", 10, 0, 100), new LineAndPointFormatter());
+        return plot;
+    }
+
+    @Test
+    public void setState_withUnpopulatedState_leavesPlotBoundariesIntact() {
+        XYPlot plot = newRealPlot();
+        plot.setDomainBoundaries(2, 8, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(-1, 1, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+
+        // a partial config (no vertical pan, no zoom) never touches the range axis:
+        PanZoom panZoom = PanZoom.attach(plot, PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+
+        // simulates restoring a state that was captured before any pan / zoom gesture:
+        panZoom.setState(new PanZoom.State());
+
+        // this is what the render thread does on the next frame:
+        plot.calculateMinMaxVals();
+
+        assertEquals(2.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(8.0, plot.getBounds().getMaxX().doubleValue(), 0);
+        assertEquals(-1.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(1.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void getState_setState_roundTrip_preservesFixedBoundaries() {
+        XYPlot plot = newRealPlot();
+        plot.setDomainBoundaries(2, 8, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(-1, 1, BoundaryMode.FIXED);
+        PanZoom panZoom = PanZoom.attach(plot);
+
+        // capture before any gesture, as an Activity would in onSaveInstanceState:
+        PanZoom.State state = panZoom.getState();
+
+        // boundaries change (eg. a new Activity instance is created with different defaults)...
+        plot.setDomainBoundaries(0, 100, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(0, 100, BoundaryMode.FIXED);
+
+        // ...and restoring the state brings the originals back:
+        panZoom.setState(state);
+        plot.calculateMinMaxVals();
+
+        assertEquals(2.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(8.0, plot.getBounds().getMaxX().doubleValue(), 0);
+        assertEquals(-1.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(1.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void getState_setState_roundTrip_preservesMixedBoundaryModes() {
+        XYPlot plot = newRealPlot();
+        plot.setDomainBoundaries(2, BoundaryMode.FIXED, 8, BoundaryMode.AUTO);
+        plot.setRangeBoundaries(-1, BoundaryMode.AUTO, 1, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+        final double autoMaxX = plot.getBounds().getMaxX().doubleValue();
+        final double autoMinY = plot.getBounds().getMinY().doubleValue();
+        PanZoom panZoom = PanZoom.attach(plot);
+
+        PanZoom.State state = panZoom.getState();
+
+        plot.setDomainBoundaries(0, 100, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(0, 100, BoundaryMode.FIXED);
+
+        panZoom.setState(state);
+        plot.calculateMinMaxVals();
+
+        assertEquals(2.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(autoMaxX, plot.getBounds().getMaxX().doubleValue(), 0);
+        assertEquals(autoMinY, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(1.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
 }

--- a/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/PanZoomTest.java
@@ -14,6 +14,12 @@ import com.androidplot.util.*;
 import org.junit.*;
 import org.mockito.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
@@ -286,6 +292,85 @@ public class PanZoomTest extends AndroidplotTest {
         assertEquals(8.0, plot.getBounds().getMaxX().doubleValue(), 0);
         assertEquals(-1.0, plot.getBounds().getMinY().doubleValue(), 0);
         assertEquals(1.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void state_serialVersionUID_matchesOriginalClass() {
+        // States serialized by older versions of the library must keep deserializing; see the
+        // comment on PanZoom.State.serialVersionUID.
+        assertEquals(-4221152827129598653L,
+                ObjectStreamClass.lookup(PanZoom.State.class).getSerialVersionUID());
+    }
+
+    @Test
+    public void state_javaSerialization_roundTrip_preservesBoundaries() throws Exception {
+        XYPlot plot = newRealPlot();
+        plot.setDomainBoundaries(2, BoundaryMode.FIXED, 8, BoundaryMode.AUTO);
+        plot.setRangeBoundaries(-1, BoundaryMode.AUTO, 1, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+        final double autoMaxX = plot.getBounds().getMaxX().doubleValue();
+        final double autoMinY = plot.getBounds().getMinY().doubleValue();
+        PanZoom panZoom = PanZoom.attach(plot);
+
+        // serialize as a Bundle would when saving instance state:
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(bytes);
+        out.writeObject(panZoom.getState());
+        out.close();
+
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+        PanZoom.State restored = (PanZoom.State) in.readObject();
+        in.close();
+
+        plot.setDomainBoundaries(0, 100, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(0, 100, BoundaryMode.FIXED);
+
+        panZoom.setState(restored);
+        plot.calculateMinMaxVals();
+
+        assertEquals(2.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(autoMaxX, plot.getBounds().getMaxX().doubleValue(), 0);
+        assertEquals(autoMinY, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(1.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    /**
+     * A State serialized by the library as it was before per-edge boundary modes were added
+     * (domain 2..8 FIXED, range -1..1 FIXED), captured from the compiled class on master.
+     */
+    private static final String LEGACY_STATE_HEX =
+            "aced000573720020636f6d2e616e64726f6964706c6f742e78792e50616e5a6f6f6d245374617465c56b73de4c4ded43" +
+            "0200064c0012646f6d61696e426f756e646172794d6f64657400214c636f6d2f616e64726f6964706c6f742f78792f42" +
+            "6f756e646172794d6f64653b4c0013646f6d61696e4c6f776572426f756e646172797400124c6a6176612f6c616e672f" +
+            "4e756d6265723b4c0013646f6d61696e5570706572426f756e6461727971007e00024c001172616e6765426f756e6461" +
+            "72794d6f646571007e00014c001272616e67654c6f776572426f756e6461727971007e00024c001272616e6765557070" +
+            "6572426f756e6461727971007e000278707e72001f636f6d2e616e64726f6964706c6f742e78792e426f756e64617279" +
+            "4d6f646500000000000000001200007872000e6a6176612e6c616e672e456e756d000000000000000012000078707400" +
+            "054649584544737200116a6176612e6c616e672e496e746567657212e2a0a4f781873802000149000576616c75657872" +
+            "00106a6176612e6c616e672e4e756d62657286ac951d0b94e08b0200007870000000027371007e00080000000871007e" +
+            "00067371007e0008ffffffff7371007e000800000001";
+
+    @Test
+    public void state_serializedByOlderVersion_deserializesAndAppliesAsNoOp() throws Exception {
+        byte[] bytes = new byte[LEGACY_STATE_HEX.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) Integer.parseInt(LEGACY_STATE_HEX.substring(i * 2, i * 2 + 2), 16);
+        }
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes));
+        PanZoom.State legacy = (PanZoom.State) in.readObject();
+        in.close();
+
+        // the legacy stream carries no per-edge modes, so applying it must leave the plot alone:
+        XYPlot plot = newRealPlot();
+        plot.setDomainBoundaries(10, 20, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(30, 40, BoundaryMode.FIXED);
+        PanZoom.attach(plot).setState(legacy);
+        plot.calculateMinMaxVals();
+
+        assertEquals(10.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(20.0, plot.getBounds().getMaxX().doubleValue(), 0);
+        assertEquals(30.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(40.0, plot.getBounds().getMaxY().doubleValue(), 0);
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/xy/RectRegionTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/RectRegionTest.java
@@ -9,6 +9,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -69,6 +71,36 @@ public class RectRegionTest extends AndroidplotTest{
         RectRegion region5 = new RectRegion(-100, 1, -100, 1, "");
         assertTrue(region1.intersects(region5));
         assertTrue(region5.intersects(region1));
+    }
+
+    @Test
+    public void testIntersects_nullBoundsAreTreatedAsInfinity() throws Exception {
+        RectRegion region = new RectRegion(0, 10, 0, 10);
+
+        // open towards negative infinity on both axes, overlapping region:
+        assertTrue(region.intersects(new RectRegion(null, 5, null, 5)));
+        assertTrue(region.intersects(null, 5, null, 5));
+
+        // open towards negative infinity on both axes, entirely below / left of region:
+        assertFalse(region.intersects(new RectRegion(null, -5, null, -5)));
+        assertFalse(region.intersects(null, -5, null, -5));
+
+        // open towards positive infinity:
+        assertTrue(region.intersects(new RectRegion(5, null, 5, null)));
+        assertFalse(region.intersects(new RectRegion(15, null, 15, null)));
+
+        // open on one axis only:
+        assertTrue(region.intersects(new RectRegion(null, null, 5, 6)));
+        assertFalse(region.intersects(new RectRegion(null, null, 15, 16)));
+
+        // unbounded on all sides intersects everything, in either direction:
+        assertTrue(region.intersects(new RectRegion(null, null, null, null)));
+        assertTrue(new RectRegion(null, null, null, null).intersects(region));
+
+        // the list form used by the renderers for fill regions:
+        assertEquals(1, region.intersects(Arrays.asList(
+                new RectRegion(null, 5, null, 5),
+                new RectRegion(null, -5, null, -5))).size());
     }
 
     @Test

--- a/androidplot-core/src/test/java/com/androidplot/xy/SampledXYSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/SampledXYSeriesTest.java
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.androidplot.xy;
 
+import android.graphics.Canvas;
+
 import com.androidplot.test.*;
 
 import org.junit.*;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -89,5 +92,70 @@ public class SampledXYSeriesTest extends AndroidplotTest {
         XYSeries rawData = TestUtils.generateXYSeriesWithNulls("my series", 10000);
         SampledXYSeries sampledXYSeries = new SampledXYSeries(rawData, 2, 200);
         assertEquals(5, sampledXYSeries.getZoomLevels().size());
+    }
+
+    @Test
+    public void constructor_withNoSampledZoomLevels_isUsableBeforeSetZoomFactor() {
+        // 150 / 2 = 75 is already below the threshold, so no sampled zoom levels are generated:
+        XYSeries rawData = TestUtils.generateXYSeries("my series", 150);
+        SampledXYSeries series = new SampledXYSeries(
+                rawData, OrderedXYSeries.XOrder.ASCENDING, 2, 100);
+
+        assertEquals(0, series.getZoomLevels().size());
+        assertEquals(150, series.size());
+        assertEquals(rawData.getY(5), series.getY(5));
+        assertNotNull(series.getBounds());
+        assertNotNull(series.minMax());
+        assertEquals(0.0, series.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(149.0, series.getBounds().getMaxX().doubleValue(), 0);
+
+        // the estimator runs against this series before the first frame:
+        assertEquals(1.0, new ZoomEstimator().calculateZoom(series, new RectRegion(0, 149, 0, 1)), 0);
+    }
+
+    @Test
+    public void constructor_withSampledZoomLevels_isUsableBeforeSetZoomFactor() {
+        XYSeries rawData = TestUtils.generateXYSeries("my series", 1000);
+        SampledXYSeries series = new SampledXYSeries(
+                rawData, OrderedXYSeries.XOrder.ASCENDING, 2, 100);
+
+        assertEquals(3, series.getZoomLevels().size());
+        assertEquals(1000, series.size());
+        assertEquals(rawData.getY(5), series.getY(5));
+        assertNotNull(series.getBounds());
+    }
+
+    @Test
+    public void firstDraw_withFixedDomainSmallerThanData_doesNotThrow() {
+        XYPlot plot = new XYPlot(getContext(), "test");
+        plot.getRegistry().setEstimator(new ZoomEstimator());
+        SampledXYSeries series = new SampledXYSeries(
+                TestUtils.generateXYSeries("my series", 1000), OrderedXYSeries.XOrder.ASCENDING, 2, 100);
+        plot.addSeries(series, new LineAndPointFormatter());
+
+        // a fixed domain window smaller than the data rejects the series' precomputed bounds,
+        // forcing the min/max calculation to walk the series point by point:
+        plot.setDomainBoundaries(10, 20, BoundaryMode.FIXED);
+
+        // this is what the render thread runs before each frame, outside of its exception guard:
+        plot.notifyListenersBeforeDraw(new Canvas());
+
+        assertEquals(10.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(20.0, plot.getBounds().getMaxX().doubleValue(), 0);
+    }
+
+    @Test
+    public void firstDraw_withNoSampledZoomLevels_doesNotThrow() {
+        XYPlot plot = new XYPlot(getContext(), "test");
+        plot.getRegistry().setEstimator(new ZoomEstimator());
+        SampledXYSeries series = new SampledXYSeries(
+                TestUtils.generateXYSeries("my series", 150), OrderedXYSeries.XOrder.ASCENDING, 2, 100);
+        plot.addSeries(series, new LineAndPointFormatter());
+
+        plot.notifyListenersBeforeDraw(new Canvas());
+
+        assertEquals(0.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(149.0, plot.getBounds().getMaxX().doubleValue(), 0);
+        assertEquals(150, series.size());
     }
 }

--- a/androidplot-core/src/test/java/com/androidplot/xy/SimpleXYSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/SimpleXYSeriesTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.NoSuchElementException;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
 
 public class SimpleXYSeriesTest {
 
@@ -187,5 +188,69 @@ public class SimpleXYSeriesTest {
 
         series.clear();
         assertEquals(0, series.size());
+    }
+
+    private static SimpleXYSeries newImplicitXSeries() {
+        SimpleXYSeries series = new SimpleXYSeries(
+                Arrays.asList(1, 2, 3),
+                SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "series");
+        series.useImplicitXVals();
+        return series;
+    }
+
+    @Test
+    public void setModel_afterUseImplicitXVals_yValsOnly() {
+        SimpleXYSeries series = newImplicitXSeries();
+
+        series.setModel(Arrays.asList(7, 8, 9, 10), SimpleXYSeries.ArrayFormat.Y_VALS_ONLY);
+
+        assertEquals(4, series.size());
+        assertEquals(3, series.getX(3));
+        assertEquals(10, series.getY(3));
+
+        // x-vals remain implicit:
+        assertNull(series.getxVals());
+    }
+
+    @Test
+    public void setModel_afterUseImplicitXVals_xyInterleaved() {
+        SimpleXYSeries series = newImplicitXSeries();
+
+        series.setModel(Arrays.asList(10, 1, 20, 2), SimpleXYSeries.ArrayFormat.XY_VALS_INTERLEAVED);
+
+        assertEquals(2, series.size());
+        assertEquals(20, series.getX(1));
+        assertEquals(2, series.getY(1));
+    }
+
+    @Test
+    public void resize_afterUseImplicitXVals() {
+        SimpleXYSeries series = newImplicitXSeries();
+
+        series.resize(5);
+        assertEquals(5, series.size());
+        assertEquals(4, series.getX(4));
+        assertNull(series.getY(4));
+
+        series.resize(2);
+        assertEquals(2, series.size());
+        assertEquals(1, series.getX(1));
+        assertEquals(2, series.getY(1));
+    }
+
+    @Test
+    public void setXY_afterUseImplicitXVals_setsYOnly() {
+        SimpleXYSeries series = newImplicitXSeries();
+
+        series.setXY(99, 42, 1);
+
+        assertEquals(1, series.getX(1));
+        assertEquals(42, series.getY(1));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void setX_afterUseImplicitXVals_throwsIllegalStateException() {
+        SimpleXYSeries series = newImplicitXSeries();
+        series.setX(99, 1);
     }
 }

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
@@ -14,6 +14,7 @@ import org.robolectric.RuntimeEnvironment;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
@@ -159,6 +160,50 @@ public class XYPlotTest extends AndroidplotTest {
 
         assertEquals(0.0, plot.getBounds().getMinY().doubleValue(), 0);
         assertEquals(100.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void addRemoveMarker_whileIteratingYValueMarkers_doesNotThrow() throws Exception {
+        plot.addMarker(new YValueMarker(1, "one"));
+        plot.addMarker(new YValueMarker(2, "two"));
+        YValueMarker three = new YValueMarker(3, "three");
+
+        // XYGraphWidget.drawMarkers iterates this list on the render thread while markers
+        // may be added / removed from another thread:
+        Iterator<YValueMarker> iterator = plot.getYValueMarkers().iterator();
+        iterator.next();
+        plot.addMarker(three);
+        plot.removeMarker(three);
+        plot.addMarker(three);
+        iterator.next();
+        assertEquals(3, plot.getYValueMarkers().size());
+
+        iterator = plot.getYValueMarkers().iterator();
+        iterator.next();
+        assertEquals(3, plot.removeYMarkers());
+        iterator.next();
+        assertEquals(0, plot.getYValueMarkers().size());
+    }
+
+    @Test
+    public void addRemoveMarker_whileIteratingXValueMarkers_doesNotThrow() throws Exception {
+        plot.addMarker(new XValueMarker(1, "one"));
+        plot.addMarker(new XValueMarker(2, "two"));
+        XValueMarker three = new XValueMarker(3, "three");
+
+        Iterator<XValueMarker> iterator = plot.getXValueMarkers().iterator();
+        iterator.next();
+        plot.addMarker(three);
+        plot.removeMarker(three);
+        plot.addMarker(three);
+        iterator.next();
+        assertEquals(3, plot.getXValueMarkers().size());
+
+        iterator = plot.getXValueMarkers().iterator();
+        iterator.next();
+        assertEquals(3, plot.removeMarkers());
+        iterator.next();
+        assertEquals(0, plot.getXValueMarkers().size());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYPlotTest.java
@@ -110,6 +110,57 @@ public class XYPlotTest extends AndroidplotTest {
                 
     }
 
+    @Test
+    public void testRangeOriginFixedMode() throws Exception {
+        plot.addSeries(series0To100, new LineAndPointFormatter());
+        plot.centerOnRangeOrigin(50, 20, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+
+        assertEquals(30.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(70.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void testRangeOriginGrowMode() throws Exception {
+        plot.addSeries(series0To100, new LineAndPointFormatter());
+        plot.centerOnRangeOrigin(50, null, BoundaryMode.GROW);
+        plot.calculateMinMaxVals();
+
+        assertEquals(0.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(100.0, plot.getBounds().getMaxY().doubleValue(), 0);
+
+        // introduce a larger range set.  boundaries should change
+        series0To100.setModel(numList2, SimpleXYSeries.ArrayFormat.Y_VALS_ONLY);
+        plot.calculateMinMaxVals();
+
+        assertEquals(-100.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(200.0, plot.getBounds().getMaxY().doubleValue(), 0);
+
+        // revert series model back to the previous set.  boundaries should remain the same
+        series0To100.setModel(numList1, SimpleXYSeries.ArrayFormat.Y_VALS_ONLY);
+        plot.calculateMinMaxVals();
+
+        assertEquals(-100.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(200.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void testRangeOriginShrinkMode() throws Exception {
+        plot.addSeries(series0To100, new LineAndPointFormatter());
+        plot.centerOnRangeOrigin(50, null, BoundaryMode.SHRINK);
+        plot.calculateMinMaxVals();
+
+        assertEquals(0.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(100.0, plot.getBounds().getMaxY().doubleValue(), 0);
+
+        // update with more extreme values...nothing should change in shrink mode:
+        series0To100.setModel(numList2, SimpleXYSeries.ArrayFormat.Y_VALS_ONLY);
+        plot.calculateMinMaxVals();
+
+        assertEquals(0.0, plot.getBounds().getMinY().doubleValue(), 0);
+        assertEquals(100.0, plot.getBounds().getMaxY().doubleValue(), 0);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void centerOnRangeOrigin_throwsIllegalArgumentException_ifNullOrigin() {
         plot.centerOnRangeOrigin(null);

--- a/androidplot-core/src/test/java/com/androidplot/xy/ZoomEstimatorTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/ZoomEstimatorTest.java
@@ -63,4 +63,20 @@ public class ZoomEstimatorTest extends AndroidplotTest {
         assertEquals(1d, estimator.calculateZoom(series, new RectRegion(0, 1, 0, 1)));
 
     }
+
+    @Test
+    public void run_withNullSeriesBounds_leavesZoomUnchanged() {
+        ZoomEstimator estimator = new ZoomEstimator();
+        SampledXYSeries series =
+                spy(new SampledXYSeries(TestUtils
+                        .generateXYSeries("test series", 1000), 2, 100));
+        series.setBounds(null);
+        XYSeriesBundle bundle = new XYSeriesBundle(series, null);
+        when(xyPlot.getBounds()).thenReturn(new RectRegion(0, 1000, 0, 1000));
+
+        estimator.run(xyPlot, bundle);
+
+        verify(series, never()).setZoomFactor(anyDouble());
+        assertEquals(1d, estimator.calculateZoom(series, new RectRegion(0, 1000, 0, 1000)));
+    }
 }

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -28,6 +28,9 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix `SampledXYSeries` crashing the render thread on its first draw: the series had no active
   data until a zoom factor was applied, and had no bounds when its data was too small to produce
   any sampled zoom level.  `ZoomEstimator` also tolerates a series without bounds.
+* Fix `ConcurrentModificationException` (and silently skipped listeners) when a `PlotListener`
+  or series removes itself from the plot from within `onBeforeDraw` / `onAfterDraw`.  The
+  listener list is now a `CopyOnWriteArrayList`; `Plot.getListeners()` returns a `List`.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -34,6 +34,9 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix `centerOnRangeOrigin(...)` with `BoundaryMode.FIXED`, `GROW` or `SHRINK` throwing
   `UnsupportedOperationException` on every frame; the range axis now supports the same origin
   boundary modes as the domain axis.
+* Fix `NullPointerException` when a `RectRegion` with a null (unbounded) edge is tested for
+  intersection, eg. a fill region added to a `LineAndPointFormatter`.  Null now means infinity as
+  documented, and the `Region(v1, v2)` constructor no longer swaps a null value to the wrong edge.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -37,6 +37,8 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix `NullPointerException` when a `RectRegion` with a null (unbounded) edge is tested for
   intersection, eg. a fill region added to a `LineAndPointFormatter`.  Null now means infinity as
   documented, and the `Region(v1, v2)` constructor no longer swaps a null value to the wrong edge.
+* Fix `ConcurrentModificationException` on the render thread when `XYPlot` value markers are
+  added or removed while the plot is drawing; the marker lists are now `CopyOnWriteArrayList`s.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -39,6 +39,9 @@ For details on what to expect in general when updating to a new version of Andro
   documented, and the `Region(v1, v2)` constructor no longer swaps a null value to the wrong edge.
 * Fix `ConcurrentModificationException` on the render thread when `XYPlot` value markers are
   added or removed while the plot is drawing; the marker lists are now `CopyOnWriteArrayList`s.
+* Fix `NullPointerException` from `SimpleXYSeries.setModel(...)`, `resize(...)` and `setXY(...)`
+  after `useImplicitXVals()`.  `setModel` and `resize` keep the x-vals implicit, `setXY` sets
+  only the y value, and `setX` throws an `IllegalStateException` explaining why.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -23,8 +23,9 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix crash on the render thread after restoring a `PanZoom.State` that was captured before any
   pan or zoom gesture (eg. saving `getState()` in `onSaveInstanceState` and rotating the device).
   `getState()` now snapshots the plot's actual boundaries and modes for both axes, and applying a
-  state skips any axis edge it holds no mode for.  `XYPlot` gains public getters for its four
-  boundary modes.
+  state skips any axis edge it holds no mode for.  A `State` serialized by an earlier version
+  still deserializes (its `serialVersionUID` is pinned) and restores as a no-op.  `XYPlot` gains
+  public getters for its four boundary modes.
 * Fix `SampledXYSeries` crashing the render thread on its first draw: the series had no active
   data until a zoom factor was applied, and had no bounds when its data was too small to produce
   any sampled zoom level.  `ZoomEstimator` also tolerates a series without bounds.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -42,6 +42,10 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix `NullPointerException` from `SimpleXYSeries.setModel(...)`, `resize(...)` and `setXY(...)`
   after `useImplicitXVals()`.  `setModel` and `resize` keep the x-vals implicit, `setXY` sets
   only the y value, and `setX` throws an `IllegalStateException` explaining why.
+* Fix `LayerListOrganizer.moveBeneath(...)` losing the moved element (and throwing
+  `IndexOutOfBoundsException`) and `moveAbove(...)` silently moving it to the bottom when the
+  reference element is not in the list; both now throw `IllegalArgumentException` and leave the
+  list unchanged.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -37,6 +37,7 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix `NullPointerException` when a `RectRegion` with a null (unbounded) edge is tested for
   intersection, eg. a fill region added to a `LineAndPointFormatter`.  Null now means infinity as
   documented, and the `Region(v1, v2)` constructor no longer swaps a null value to the wrong edge.
+  `LineAndPointRenderer` draws such a region clipped to the plot's visible bounds.
 * Fix `ConcurrentModificationException` on the render thread when `XYPlot` value markers are
   added or removed while the plot is drawing; the marker lists are now `CopyOnWriteArrayList`s.
 * Fix `NullPointerException` from `SimpleXYSeries.setModel(...)`, `resize(...)` and `setXY(...)`

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -31,6 +31,9 @@ For details on what to expect in general when updating to a new version of Andro
 * Fix `ConcurrentModificationException` (and silently skipped listeners) when a `PlotListener`
   or series removes itself from the plot from within `onBeforeDraw` / `onAfterDraw`.  The
   listener list is now a `CopyOnWriteArrayList`; `Plot.getListeners()` returns a `List`.
+* Fix `centerOnRangeOrigin(...)` with `BoundaryMode.FIXED`, `GROW` or `SHRINK` throwing
+  `UnsupportedOperationException` on every frame; the range axis now supports the same origin
+  boundary modes as the domain axis.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -20,6 +20,11 @@ For details on what to expect in general when updating to a new version of Andro
   [XML Configuration](xml_configuration.md) doc.
 * Compile and target SDK 37; build updated to AGP 9.4 / Gradle 9.7 / Kotlin 2.2.
 * Snapshot builds of unreleased changes are now published to the Central snapshots repository.
+* Fix crash on the render thread after restoring a `PanZoom.State` that was captured before any
+  pan or zoom gesture (eg. saving `getState()` in `onSaveInstanceState` and rotating the device).
+  `getState()` now snapshots the plot's actual boundaries and modes for both axes, and applying a
+  state skips any axis edge it holds no mode for.  `XYPlot` gains public getters for its four
+  boundary modes.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -25,6 +25,9 @@ For details on what to expect in general when updating to a new version of Andro
   `getState()` now snapshots the plot's actual boundaries and modes for both axes, and applying a
   state skips any axis edge it holds no mode for.  `XYPlot` gains public getters for its four
   boundary modes.
+* Fix `SampledXYSeries` crashing the render thread on its first draw: the series had no active
+  data until a zoom factor was applied, and had no bounds when its data was too small to produce
+  any sampled zoom level.  `ZoomEstimator` also tolerates a series without bounds.
 
 **Behavior changes for `RenderMode.USE_BACKGROUND_THREAD`:**
 * The plot view is now composited with hardware acceleration when the app has it enabled.  The


### PR DESCRIPTION
Eight crash / data-loss fixes, each with a regression test that was confirmed to fail on the unfixed code and pass after the fix. One commit per fix; release notes updated under `# 1.6.0`.

## 1. `PanZoom.State` restore crashes the render thread

**Cause.** `State`'s fields default to null and `getState()` returned that never-populated object until the first gesture. Restoring it via `setState()` called `plot.setDomainBoundaries(null, null, null)`, storing null boundary modes into `XYConstraints`; `XYPlot.calculateMinMaxVals()` then hit `switch (mode)` on the render thread. Trigger: `TouchZoomExampleActivity` saves `getState()` in `onSaveInstanceState` and restores it, so rotating without touching the plot crashed. A partial config (`Pan.HORIZONTAL` + `Zoom.NONE`) left the range modes null even after a gesture.

**Change.** `getState()` now snapshots the plot's actual user boundaries and boundary modes for each edge of both axes; `State.apply()` sets each edge independently and skips any edge whose mode is null, so a stale or legacy state cannot poison the plot. `State` gains 4-arg `setDomainBoundaries` / `setRangeBoundaries` overloads (lower mode / upper mode) mirroring `XYPlot`; the 3-arg ones delegate. `XYPlot` gains public `getDomain/RangeLower/UpperBoundaryMode()` and protected `getUserMinX/MaxX/MinY/MaxY()`. **Serialization compatibility.** `State`'s private field layout changed, which would have changed its JVM-computed `serialVersionUID` and made a `State` serialized by an older library version (eg. held in an Activity's saved instance state across an app update) fail with `InvalidClassException`. The UID is therefore pinned to the value `serialver` computes for the class on master (`-4221152827129598653L`, with a comment that it must never change), so old streams still load; their legacy single-mode field is dropped, the per-edge modes deserialize as null, and `apply()` skips them, so restoring an old state is a no-op rather than a crash. Covered by `state_serialVersionUID_matchesOriginalClass`, `state_javaSerialization_roundTrip_preservesBoundaries` (ObjectOutputStream/ObjectInputStream round-trip of a mixed-mode state) and `state_serializedByOlderVersion_deserializesAndAppliesAsNoOp` (deserializes a stream captured from the master build of the class). Without the pin the latter two fail with `InvalidClassException: ... stream classdesc serialVersionUID = -4221152827129598653, local class serialVersionUID = 3691914940198708979`. Also note that since `setXxxBoundary` forces `XYFramingModel.EDGE`, a round-trip on an ORIGIN-framed plot ends up EDGE-framed (a pan gesture already did that).

**Evidence.** `PanZoomTest`: `setState_withUnpopulatedState_leavesPlotBoundariesIntact`, `getState_setState_roundTrip_preservesFixedBoundaries`, `getState_setState_roundTrip_preservesMixedBoundaryModes`.
Before: all three `java.lang.NullPointerException: Cannot invoke "com.androidplot.xy.BoundaryMode.ordinal()" because "mode" is null` at `XYPlot.getCalculatedUpperBoundary(XYPlot.java:525)`. After: 12/12 pass (including the three serialization tests above).

## 2. `SampledXYSeries` crashes on its first draw

**Cause.** `activeSeries` was only assigned by `setZoomFactor()`, so `size()`/`getX()`/`getY()` NPE'd whenever the plot touched the series before the `ZoomEstimator` ran, eg. a FIXED domain smaller than the data rejects the precomputed bounds in `SeriesUtils.minMax` and walks the series point by point. `bounds` was only assigned inside the per-zoom-level sampler threads, so a series whose `size / ratio` was already below the threshold (150 pts, ratio 2, threshold 100) never got any and `ZoomEstimator.calculateZoom()` dereferenced null. Both run in `notifyListenersBeforeDraw()` outside the render exception guard.

**Change.** `resample()` starts the series on the raw data (1x) and computes `bounds` from the raw data (`SeriesUtils.minMax(rawData)`) when no zoom level is generated, so `getBounds()`/`minMax()` are never null after construction. `ZoomEstimator.run()` leaves the zoom untouched if a series has no bounds (`setBounds(null)` is public) and `calculateZoom()` returns 1 in that case.

Fixed slightly differently than described: the 150-point example from the report does *not* reach the `size()` NPE on the unfixed code because null bounds make `SeriesUtils.minMax` skip the series (`continue`); it reaches the `ZoomEstimator` NPE. The `size()` NPE needs a series whose sampler loop *does* run (bounds non-null, `activeSeries` still null) plus a FIXED domain; the tests cover both shapes.

**Evidence.** `SampledXYSeriesTest`: `constructor_withNoSampledZoomLevels_isUsableBeforeSetZoomFactor`, `constructor_withSampledZoomLevels_isUsableBeforeSetZoomFactor`, `firstDraw_withFixedDomainSmallerThanData_doesNotThrow`, `firstDraw_withNoSampledZoomLevels_doesNotThrow`; `ZoomEstimatorTest.run_withNullSeriesBounds_leavesZoomUnchanged`.
Before: three fail with `NullPointerException: Cannot invoke "com.androidplot.xy.XYSeries.size()" because "this.activeSeries" is null` at `SampledXYSeries.size(SampledXYSeries.java:165)`; two fail with `NullPointerException: Cannot invoke "com.androidplot.xy.RectRegion.getxRegion()" because "seriesBounds" is null` at `ZoomEstimator.calculateZoom(ZoomEstimator.java:21)`. After: 9/9 and 3/3 pass.

## 3. `ConcurrentModificationException` when a listener removes itself during draw

**Cause.** `notifyListenersBeforeDraw`/`AfterDraw` iterated the live `ArrayList`; `addListener`/`removeListener`/`addSeries`/`removeSeries` mutate it under the same monitor as `renderOnCanvas`, so a listener (or a `SimpleXYSeries`, which is auto-registered as a `PlotListener`) removing itself from a callback mutated the list mid-iteration. If it was the last listener the iterator threw a CME (uncaught on the render thread in background mode); otherwise `ArrayList`'s iterator ended early and the remaining listeners were silently skipped.

**Change.** `listeners` is a `CopyOnWriteArrayList`; `Plot.getListeners()` (protected) now returns `List<PlotListener>` instead of `ArrayList`.

**Evidence.** `PlotTest`: `renderOnCanvas_listenerRemovingItselfDuringDraw_doesNotThrow`, `renderOnCanvas_seriesRemovingItselfDuringDraw_doesNotThrow`, `renderOnCanvas_listenerRemovingItselfDuringDraw_stillNotifiesRemainingListeners`.
Before: first two `java.util.ConcurrentModificationException` at `Plot.notifyListenersAfterDraw(Plot.java:657)`; third `AssertionFailedError: expected:<1> but was:<0>` (following listener skipped). After: 23/23 pass.

## 4. `centerOnRangeOrigin` with FIXED / GROW / SHRINK throws every frame

**Cause.** `updateRangeMinMaxForOriginModel()` only implemented `AUTO` and threw `UnsupportedOperationException` for every other mode from `calculateMinMaxVals()`, while the domain version supports all four.

**Change.** Implemented the range version as an exact mirror of `updateDomainMinMaxForOriginModel()` (x -> y, `prevMinX/MaxX` -> `prevMinY/MaxY`).

**Evidence.** `XYPlotTest`: `testRangeOriginFixedMode` (50 +/- 20 -> 30..70), `testRangeOriginGrowMode`, `testRangeOriginShrinkMode`, mirroring the existing domain tests.
Before: `UnsupportedOperationException: Range Origin Boundary Mode not yet supported: FIXED` (resp. GROW, SHRINK) at `XYPlot.updateRangeMinMaxForOriginModel(XYPlot.java:748)`. After: pass.

## 5. `Region.intersects` NPE on a null (unbounded) edge

**Cause.** `RectRegion.intersects` documents null as infinity, but `Region.intersects(Number, Number)` unboxed both params and this region's own min/max unconditionally. Reached from `LineAndPointRenderer` fill regions via `bounds.intersects(formatter.getRegions().elements())`. Two further problems on the same path: `Region(v1, v2)` swapped a null value to the opposite edge (`new Region(null, 5)` became min=5, max=null, ie. "everything above 5"), and after `intersects` accepted the region the renderer called `bounds.transform(thisRegion, ...)`, which unboxed the null coordinates before the `isFullyDefined()` guard.

**Change.** `Region.intersects` substitutes -Infinity / +Infinity for null on either side, keeping the existing comparison structure (which also handles inverted min > max regions). The constructor only reorders when both values are non-null. `LineAndPointRenderer.renderPath` replaces a null edge with the corresponding edge of the plot's visible bounds before transforming (nothing beyond them is drawable anyway) and checks `isFullyDefined()` on the transformed region, so such regions now render clipped to the plot area.

**Evidence.** `RegionTest`: `testConstructor_preservesNullPlacement`, `testIntersects_nullIsInfinity`; `RectRegionTest.testIntersects_nullBoundsAreTreatedAsInfinity` (`RectRegion(0,10,0,10).intersects(new RectRegion(null, 5, null, 5))` true, `(null, -5, null, -5)` false, plus the list form); `LineAndPointRendererTest.renderPath_rendersRegionsWithUnboundedEdges`.
Before: constructor test `AssertionError: expected null, but was:<5.0>`; intersects tests `NullPointerException: Cannot invoke "java.lang.Number.doubleValue()" because "line2Min" is null` at `Region.intersects(Region.java:181)`; renderer test (run with only the `Region` fixes applied) `NullPointerException: ... because "x" is null` at `RectRegion.transform(RectRegion.java:69)`. After: 12/12, 12/12, 7/7 pass.

## 6. Marker lists unsynchronized

**Cause.** `addMarker`/`removeMarker`/`removeMarkers`/`removeXMarkers`/`removeYMarkers` mutate plain `ArrayList`s that `XYGraphWidget.drawMarkers` iterates on the render thread through the live lists returned by `getXValueMarkers()`/`getYValueMarkers()`.

**Change.** Both lists are `CopyOnWriteArrayList`s (field type `List`); the getters keep their semantics.

**Evidence.** `XYPlotTest`: `addRemoveMarker_whileIteratingYValueMarkers_doesNotThrow`, `addRemoveMarker_whileIteratingXValueMarkers_doesNotThrow` (iterate the returned list while calling `addMarker`/`removeMarker`/`removeMarkers`).
Before: `java.util.ConcurrentModificationException`. After: 25/25 pass.

## 7. `SimpleXYSeries` NPEs after `useImplicitXVals()`

**Cause.** `useImplicitXVals()` sets `xVals = null`; `setModel()` called `xVals.clear()` before its own null guard (dead code), and `resize()`/`setX()`/`setXY()` dereferenced `xVals` unguarded.

**Change.** `setModel` skips the clear and, for `Y_VALS_ONLY`, does not re-materialise x-vals when they are implicit (`XY_VALS_INTERLEAVED` recreates them as before); `resize` is driven by `yVals.size()` and only touches `xVals` when non-null; `setXY` sets only the y value on an implicit-x series (documented in the javadoc); `setX` throws `IllegalStateException("Cannot set an x value on a series that uses implicit x-vals.")`.

**Evidence.** `SimpleXYSeriesTest`: `setModel_afterUseImplicitXVals_yValsOnly`, `setModel_afterUseImplicitXVals_xyInterleaved`, `resize_afterUseImplicitXVals`, `setXY_afterUseImplicitXVals_setsYOnly`, `setX_afterUseImplicitXVals_throwsIllegalStateException`.
Before: NPEs at `SimpleXYSeries.setModel(:130)`, `resize(:203)`, `setXY(:229)`, and `setX(:179)` (expected `IllegalStateException`, got `NullPointerException`). After: 18/18 pass.

## 8. `LayerListOrganizer.moveAbove` / `moveBeneath` with an unknown reference

**Cause.** Both removed `objectToMove` before looking up the reference; with an unknown reference `indexOf` returned -1, so `moveBeneath` threw `IndexOutOfBoundsException` having already dropped the element, and `moveAbove` silently re-inserted it at the bottom.

**Change.** Both verify the reference is present before mutating and throw `IllegalArgumentException` otherwise, leaving the list unchanged.

**Evidence.** `LinkedLayerListOrganizerTest`: filled in the empty `testMoveAbove`/`testMoveBeneath` (normal case; pass before and after) and added `testMoveAbove_unknownReference_throwsAndLeavesListUnchanged`, `testMoveBeneath_unknownReference_throwsAndLeavesListUnchanged`.
Before: `AssertionError: expected IllegalArgumentException` (moveAbove silently succeeded) and `IndexOutOfBoundsException: Index: -1, Size: 2` at `LayerListOrganizer.moveBeneath(LayerListOrganizer.java:51)`. After: 10/10 pass.

## Found, not fixed (out of scope)

`XYConstraints.contains(RectRegion)` passes `rectRegion.getMinY()` for both the x and y arguments of the first `contains(x, y)` call, so the `SeriesUtils.minMax` fast path is rejected more often than it should be. Left as-is; worth a separate fix.

## Verification

`./gradlew testDebugUnitTest lint :androidplot-core:assembleRelease :demoapp:assembleDebug` succeeds. Unit tests: 254 (224 on master + 30 new), 1 pre-existing skip, 0 failures. CRLF files (`XYPlot.java`, `SimpleXYSeries.java`, `LineAndPointRenderer.java` and the CRLF test files) keep their line endings; diffs touch only the changed lines.
