### PR TITLE
Demo: add an About button and screen

### DIFF
--- a/demoapp/src/main/AndroidManifest.xml
+++ b/demoapp/src/main/AndroidManifest.xml
@@ -105,6 +105,7 @@
         <activity android:name=".FXPlotExampleActivity"/>
         <activity android:name=".BubbleChartActivity"/>
         <activity android:name=".DualScaleActivity"/>
+        <activity android:name=".AboutActivity" android:label="@string/about_title"/>
         
         <!-- receiver for demo app widget -->
         <receiver

--- a/demoapp/src/main/java/com/androidplot/demos/AboutActivity.kt
+++ b/demoapp/src/main/java/com/androidplot/demos/AboutActivity.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.widget.Toast
+import androidx.core.net.toUri
+import com.androidplot.demos.databinding.AboutBinding
+
+/**
+ * Shows the app and library version, a short description, useful links and the license.
+ */
+class AboutActivity : Activity() {
+
+    private lateinit var binding: AboutBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = AboutBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setTitle(R.string.about_title)
+
+        binding.aboutVersion.text = getString(R.string.about_version, versionName())
+
+        binding.aboutWebsite.setOnClickListener { openUrl(WEBSITE_URL) }
+        binding.aboutSource.setOnClickListener { openUrl(SOURCE_URL) }
+        binding.aboutDocs.setOnClickListener { openUrl(DOCS_URL) }
+        binding.aboutIssues.setOnClickListener { openUrl(ISSUES_URL) }
+        binding.aboutLicense.setOnClickListener { openUrl(LICENSE_URL) }
+    }
+
+    /** The app's version name, which carries the Androidplot library version it was built with. */
+    private fun versionName(): String {
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            packageManager.getPackageInfo(packageName, android.content.pm.PackageManager.PackageInfoFlags.of(0))
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getPackageInfo(packageName, 0)
+        }
+        return info.versionName ?: "?"
+    }
+
+    private fun openUrl(url: String) {
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, url.toUri()))
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(this, url, Toast.LENGTH_LONG).show()
+        }
+    }
+
+    companion object {
+        private const val WEBSITE_URL = "https://androidplot.com"
+        private const val SOURCE_URL = "https://github.com/halfhp/androidplot"
+        private const val DOCS_URL = "https://github.com/halfhp/androidplot/blob/master/docs/index.md"
+        private const val ISSUES_URL = "https://github.com/halfhp/androidplot/issues"
+        private const val LICENSE_URL = "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+}

--- a/demoapp/src/main/java/com/androidplot/demos/MainActivity.kt
+++ b/demoapp/src/main/java/com/androidplot/demos/MainActivity.kt
@@ -90,6 +90,10 @@ class MainActivity : Activity() {
             startActivity(Intent(this@MainActivity, BubbleChartActivity::class.java))
         }
 
+        binding.aboutButton.setOnClickListener {
+            startActivity(Intent(this@MainActivity, AboutActivity::class.java))
+        }
+
         setContentView(binding.root)
     }
 }

--- a/demoapp/src/main/res/layout/about.xml
+++ b/demoapp/src/main/res/layout/about.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <ImageView
+            android:layout_width="72dp"
+            android:layout_height="72dp"
+            android:layout_gravity="center_horizontal"
+            android:contentDescription="@string/about_icon_description"
+            android:src="@drawable/ic_launcher"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center"
+            android:text="@string/app_name"
+            android:textAppearance="?android:attr/textAppearanceLarge"/>
+
+        <TextView
+            android:id="@+id/aboutVersion"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:gravity="center"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/about_description"
+            android:textAppearance="?android:attr/textAppearanceMedium"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/about_links_heading"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textStyle="bold"/>
+
+        <Button
+            android:id="@+id/aboutWebsite"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/about_website"/>
+
+        <Button
+            android:id="@+id/aboutSource"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/about_source"/>
+
+        <Button
+            android:id="@+id/aboutDocs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/about_docs"/>
+
+        <Button
+            android:id="@+id/aboutIssues"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/about_issues"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="@string/about_license_heading"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textStyle="bold"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/about_license"/>
+
+        <Button
+            android:id="@+id/aboutLicense"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:text="@string/about_license_link"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:gravity="center"
+            android:text="@string/about_copyright"
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+    </LinearLayout>
+</ScrollView>

--- a/demoapp/src/main/res/layout/main.xml
+++ b/demoapp/src/main/res/layout/main.xml
@@ -143,7 +143,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:backgroundTint="@color/about_button"
-                android:text="@string/about_button"/>
+                android:text="@string/about_button"
+                android:textColor="@color/about_button_text"
+                android:textStyle="bold"/>
         </LinearLayout>
     </ScrollView>
 </LinearLayout>

--- a/demoapp/src/main/res/layout/main.xml
+++ b/demoapp/src/main/res/layout/main.xml
@@ -138,14 +138,13 @@
                 android:layout_height="wrap_content"
                 android:text="Bubble Chart Example"
                 android:enabled="true"/>
+            <Button
+                android:id="@+id/aboutButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@color/about_button"
+                android:text="@string/about_button"/>
         </LinearLayout>
     </ScrollView>
-
-    <Button
-        android:id="@+id/aboutButton"
-        style="?android:attr/borderlessButtonStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/about_button"/>
 </LinearLayout>
 

--- a/demoapp/src/main/res/layout/main.xml
+++ b/demoapp/src/main/res/layout/main.xml
@@ -141,12 +141,11 @@
         </LinearLayout>
     </ScrollView>
 
-    <TextView
-        android:id="@+id/text"
-        android:layout_width="fill_parent"
+    <Button
+        android:id="@+id/aboutButton"
+        style="?android:attr/borderlessButtonStyle"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:autoLink="web"
-        android:gravity="center"
-        android:text="http://androidplot.com"/>
+        android:text="@string/about_button"/>
 </LinearLayout>
 

--- a/demoapp/src/main/res/values/colors.xml
+++ b/demoapp/src/main/res/values/colors.xml
@@ -3,4 +3,5 @@
 <resources>
     <color name="line_point_formatter_line">#00AA00</color>
     <color name="about_button">#3DDC84</color>
+    <color name="about_button_text">#073042</color>
 </resources>

--- a/demoapp/src/main/res/values/colors.xml
+++ b/demoapp/src/main/res/values/colors.xml
@@ -2,4 +2,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <resources>
     <color name="line_point_formatter_line">#00AA00</color>
+    <color name="about_button">#2E6FB5</color>
 </resources>

--- a/demoapp/src/main/res/values/colors.xml
+++ b/demoapp/src/main/res/values/colors.xml
@@ -2,5 +2,5 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 <resources>
     <color name="line_point_formatter_line">#00AA00</color>
-    <color name="about_button">#2E6FB5</color>
+    <color name="about_button">#3DDC84</color>
 </resources>

--- a/demoapp/src/main/res/values/strings.xml
+++ b/demoapp/src/main/res/values/strings.xml
@@ -6,4 +6,22 @@
     <string name="sxy_title">A Simple XY Plot</string>
     <string name="ts_title">Time Series</string>
     <string name="ts_plot1_title">UFO Sightings</string>
+
+    <string name="about_button">About Androidplot</string>
+    <string name="about_title">About</string>
+    <string name="about_version">Version %1$s</string>
+    <string name="about_description">Androidplot is an open source library for creating dynamic and
+        static charts in Android apps. This app demonstrates its plot types and features; the
+        source for every example is in the repository.</string>
+    <string name="about_links_heading">Links</string>
+    <string name="about_website">Website</string>
+    <string name="about_source">Source code on GitHub</string>
+    <string name="about_docs">Documentation</string>
+    <string name="about_issues">Report a bug</string>
+    <string name="about_license_heading">License</string>
+    <string name="about_license">Androidplot and this demo app are released under the Apache
+        License, Version 2.0.</string>
+    <string name="about_license_link">View license</string>
+    <string name="about_copyright">Copyright 2026 Androidplot.com</string>
+    <string name="about_icon_description">Androidplot logo</string>
 </resources>


### PR DESCRIPTION
## Summary

Adds an **About Androidplot** button as the last item in the demo's example list and a new `AboutActivity` it opens. The bare `http://androidplot.com` footer that used to sit below the list is removed; the link lives on the About screen instead.

### The button
- Last entry in the scrolling list, full width like the examples.
- Android brand green background (`#3DDC84`) with dark navy bold text (`#073042`) for contrast, so it stands apart from the grey example buttons. Note the Holo button drawable's own shading renders the green a shade darker than the flat brand color.

### The About screen
- Launcher icon, app name and version. The version is read from `PackageManager`, so it reads e.g. `1.6.0-beta.559` for a beta and `1.6.0` for a release, and doubles as the library version the app was built against.
- A short description of the library.
- Link buttons for the website, GitHub source, documentation and issue tracker, each opened via an `ACTION_VIEW` intent with a toast fallback if no browser is available.
- Apache 2.0 license note with a link to the license text, and the copyright line.

All text is in `strings.xml`; new colors are in `colors.xml`; lint reports no issues in the new files.

## Verification

Installed on an API 37 emulator: the About button opens the screen, the layout renders correctly under the Holo dark theme, and tapping Website opens Chrome.
