### PR TITLE
README: refresh the front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ If you enjoy the lib, please [rate us on codix.io](https://codix.io/gh/repo/half
 * Bubble Charts
 * Dynamic plots
 * Pan & Zoom
+* Background-thread rendering
+* Large datasets (automatic downsampling)
+* Value markers & shaded regions
+* XML styling & custom renderers
 
 # Getting Started
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you enjoy the lib, please [rate us on codix.io](https://codix.io/gh/repo/half
 * Dynamic plots
 * Pan & Zoom
 * Background-thread rendering
-* Large datasets (automatic downsampling)
+* Large datasets (zoom-aware downsampling)
 * Value markers & shaded regions
 * XML styling & custom renderers
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-# ![image](docs/images/aplogo_small.png) Androidplot [![AndroidPlot](https://www.appbrain.com/stats/libraries/shield/androidplot.svg)](https://www.appbrain.com/stats/libraries/details/androidplot/androidplot) [![Codix](http://codix.io/gh/badge/halfhp/androidplot)](http://codix.io/gh/repo/halfhp/androidplot) [![codecov](https://codecov.io/gh/halfhp/androidplot/branch/master/graph/badge.svg)](https://codecov.io/gh/halfhp/androidplot) [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/androidplot.svg?style=social&label=Follow%20Us)](https://twitter.com/androidplot)
+# ![image](docs/images/aplogo_small.png) Androidplot [![Maven Central](https://img.shields.io/maven-central/v/com.androidplot/androidplot-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.androidplot/androidplot-core) [![AndroidPlot](https://www.appbrain.com/stats/libraries/shield/androidplot.svg)](https://www.appbrain.com/stats/libraries/details/androidplot/androidplot) [![codecov](https://codecov.io/gh/halfhp/androidplot/branch/master/graph/badge.svg)](https://codecov.io/gh/halfhp/androidplot) [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/androidplot.svg?style=social&label=Follow%20Us)](https://twitter.com/androidplot)
 
-A library for creating dynamic and static charts in Android apps. 
+A library for creating dynamic and static charts in Android apps.
 
-Androidplot is compatible with all versions of Android from 1.6 onward, works equally with Kotlin and Java codebases
-and is compatible with Jetpack compose.
-
-If you enjoy the lib, please [rate us on codix.io](http://codix.io/gh/repo/halfhp/androidplot)!
+Androidplot runs on Android 2.0 (API 5) and up, works equally well from Kotlin and Java, and can be
+used from Jetpack Compose via `AndroidView`.
 
 <img src="docs/images/screens/fx_vert.png" width="115"> <img src="docs/images/screens/candlestick_vert.png" width="115"> <img src="docs/images/screens/pie_vert.png" width="115"> <img src="docs/images/screens/scatter_vert.png" width="115"> <img src="docs/images/screens/step_vert.png" width="115"> <img src="docs/images/screens/bubble_vert.png" width="115"> <img src="docs/images/screens/bar_vert.png" width="115">
 
@@ -21,19 +19,33 @@ If you enjoy the lib, please [rate us on codix.io](http://codix.io/gh/repo/halfh
 * Dynamic plots
 * Pan & Zoom
 
-# Usage
+# Getting Started
 
-* **[Quickstart](docs/quickstart.md)** :star: 
-* [Full Documentation](docs/index.md)
+```groovy
+dependencies {
+    implementation "com.androidplot:androidplot-core:1.5.11"
+}
+```
+
+Then follow the **[Quickstart](docs/quickstart.md)** :star: to get your first plot on screen, or dive into
+the [full documentation](docs/index.md).  Every push to master also publishes a
+[snapshot build](docs/quickstart.md#add-the-dependency) if you want to try unreleased changes.
+
+# Demo App
+
+The demo app showcases every plot type and feature, and its source is the best reference for how
+things fit together:
+
+* [Install it from Google Play](https://play.google.com/store/apps/details?id=com.androidplot.demos)
+* [Browse the source](demoapp/src/main/java/com/androidplot/demos)
 
 # Links
 
 * [Website](http://androidplot.com)
-* [Github Repo](https://github.com/halfhp/androidplot)
-* [Bitbucket Repo](https://bitbucket.org/androidplot/androidplot)
-* [Demo App (Google Play Store)](https://play.google.com/store/apps/details?id=com.androidplot.demos&hl=en)
-* [Demo App Soure Code](https://bitbucket.org/androidplot/androidplot/src/1538c5dfa56aed0d2cfdcbc7cdc6173e605543cd/demoapp/?at=master)
-* [Bugs](https://github.com/halfhp/androidplot/issues) :ant: 
+* :movie_camera: [Watch Androidplot get a cavity check at Google I/O 2018](https://www.youtube.com/watch?v=x9T5EYE-QWQ),
+  where it stars in *Effective ProGuard keep rules for smaller applications*
+* [Bugs](https://github.com/halfhp/androidplot/issues) :ant:
+* [Release Notes](docs/release_notes.md)
 * [Contributing Source Code](docs/contributing.md)
 
 # Help

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-# ![image](docs/images/aplogo_small.png) Androidplot [![Maven Central](https://img.shields.io/maven-central/v/com.androidplot/androidplot-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.androidplot/androidplot-core) [![AndroidPlot](https://www.appbrain.com/stats/libraries/shield/androidplot.svg)](https://www.appbrain.com/stats/libraries/details/androidplot/androidplot) [![codecov](https://codecov.io/gh/halfhp/androidplot/branch/master/graph/badge.svg)](https://codecov.io/gh/halfhp/androidplot) [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/androidplot.svg?style=social&label=Follow%20Us)](https://twitter.com/androidplot)
+# ![image](docs/images/aplogo_small.png) Androidplot [![Maven Central](https://img.shields.io/maven-central/v/com.androidplot/androidplot-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.androidplot/androidplot-core) [![AndroidPlot](https://www.appbrain.com/stats/libraries/shield/androidplot.svg)](https://www.appbrain.com/stats/libraries/details/androidplot/androidplot) [![Codix](https://codix.io/gh/badge/halfhp/androidplot)](https://codix.io/gh/repo/halfhp/androidplot) [![codecov](https://codecov.io/gh/halfhp/androidplot/branch/master/graph/badge.svg)](https://codecov.io/gh/halfhp/androidplot) [![Twitter URL](https://img.shields.io/twitter/url/https/twitter.com/androidplot.svg?style=social&label=Follow%20Us)](https://twitter.com/androidplot)
 
 A library for creating dynamic and static charts in Android apps.
 
 Androidplot runs on Android 2.0 (API 5) and up, works equally well from Kotlin and Java, and can be
 used from Jetpack Compose via `AndroidView`.
+
+If you enjoy the lib, please [rate us on codix.io](https://codix.io/gh/repo/halfhp/androidplot)!
 
 <img src="docs/images/screens/fx_vert.png" width="115"> <img src="docs/images/screens/candlestick_vert.png" width="115"> <img src="docs/images/screens/pie_vert.png" width="115"> <img src="docs/images/screens/scatter_vert.png" width="115"> <img src="docs/images/screens/step_vert.png" width="115"> <img src="docs/images/screens/bubble_vert.png" width="115"> <img src="docs/images/screens/bar_vert.png" width="115">
 


### PR DESCRIPTION
## Summary

An improvement pass on the README's top half. The license section is unchanged.

- **Maven Central badge** showing the current release, and a **Getting Started** section with the dependency snippet plus a pointer to the snapshot builds published from master.
- **Compatibility line** corrected: the library's minimum is API 5 (Android 2.0), not 1.6, and Compose usage is described accurately (via `AndroidView`).
- **Demo app section** linking the Play listing and the source on GitHub. The two Bitbucket links are gone: that mirror's demo-source link pointed at a 2017 commit.
- **Google I/O 2018 video**: "Watch Androidplot get a cavity check at Google I/O 2018", linking Google's *Effective ProGuard keep rules for smaller applications* session.
- The release notes are linked from the front page. The codix.io badge and rating link stay (now over https).

Preview: https://github.com/halfhp/androidplot/blob/readme-refresh/README.md

Note: the dependency snippet reads 1.5.11, the current release. It and the quickstart's line should move to 1.6.0 in the release commit.
