### PR TITLE
Test coverage: demo app activities, render smoke, gestures, layout and attrs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,11 @@ jobs:
         with:
           fetch-depth: 0 # the demoapp version code is derived from the commit count
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       # Caches Gradle distributions and dependencies between runs. Only master
       # writes to the cache so feature branches don't evict useful entries.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,11 @@ jobs:
             exit 1
           fi
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Set Up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ demoapp/publisher.json
 
 # macOS
 .DS_Store
+
+# worktrees created by Claude Code agents
+.claude/worktrees/

--- a/androidplot-core/build.gradle
+++ b/androidplot-core/build.gradle
@@ -63,6 +63,9 @@ android {
     }
 
     testOptions {
+        // needed so Robolectric can resolve the library's own attrs/styleables from
+        // AttributeSets built in tests (see XYPlotAttrsTest etc.)
+        unitTests.includeAndroidResources = true
         unitTests.all {
             jacoco {
                 includeNoLocationClasses = true

--- a/androidplot-core/src/main/java/com/androidplot/util/PixelUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/PixelUtils.java
@@ -92,6 +92,10 @@ public class PixelUtils {
             // Match found.
             // Extract value.
             float value = Float.valueOf(matcher.group(1));
+            // the pattern accepts a leading '-' outside the value group; apply it here:
+            if (dimension.trim().startsWith("-")) {
+                value = -value;
+            }
             // Extract dimension units.
             String unit = matcher.group(3).toLowerCase();
             // Get Android dimension constant.

--- a/androidplot-core/src/main/java/com/androidplot/util/Redrawer.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/Redrawer.java
@@ -45,6 +45,9 @@ public class Redrawer implements Runnable {
             this.plots.add(new WeakReference<>(plot));
         }
         setMaxRefreshRate(maxRefreshRate);
+        // armed before the thread starts so that a finish() arriving before the thread has
+        // been scheduled is not undone by run() (which used to set this flag itself).
+        keepAlive = true;
         thread = new Thread(this, "Androidplot Redrawer");
         thread.start();
         if(startImmediately) {
@@ -87,7 +90,6 @@ public class Redrawer implements Runnable {
 
     @Override
     public void run() {
-        keepAlive = true;
         try {
         while(keepAlive) {
             if(keepRunning) {

--- a/androidplot-core/src/main/java/com/androidplot/util/fig/Fig.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/fig/Fig.java
@@ -135,25 +135,54 @@ public abstract class Fig {
         }
     }
 
-    private static Method getMethodByName(Class clazz, final String methodName)
+    /**
+     * Finds a public method by case insensitive name.  Class.getMethods() returns overloads in
+     * no particular order, so when several methods share the name the one whose parameter list
+     * has the expected count and consists only of types this configurator can inflate is
+     * preferred (eg. Paint.setColor(int) over Paint.setColor(long)); otherwise the first match
+     * is returned so that the caller can report the mismatch.
+     */
+    private static Method getMethodByName(Class clazz, final String methodName, int paramCount)
             throws NoSuchMethodException {
-        final Method[] methods = clazz.getMethods();
-        for (Method method : methods) {
+        Method fallback = null;
+        for (Method method : clazz.getMethods()) {
             if (method.getName().equalsIgnoreCase(methodName)) {
-                return method;
+                final Class[] paramTypes = method.getParameterTypes();
+                if (paramTypes.length == paramCount && isInflatable(paramTypes)) {
+                    return method;
+                }
+                if (fallback == null) {
+                    fallback = method;
+                }
             }
+        }
+        if (fallback != null) {
+            return fallback;
         }
         throw new NoSuchMethodException("No such public method (case insensitive): " +
                 methodName + " in " + clazz);
     }
 
+    private static boolean isInflatable(Class[] paramTypes) {
+        for (Class param : paramTypes) {
+            if (!(Enum.class.isAssignableFrom(param)
+                    || param == Float.TYPE || param == Float.class
+                    || param == Integer.TYPE || param == Integer.class
+                    || param == Boolean.TYPE || param == Boolean.class
+                    || param == String.class)) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-    private static Method getSetter(Class clazz, final String fieldId) throws NoSuchMethodException {
-        return getMethodByName(clazz, SETTER_PREFIX + fieldId);
+    private static Method getSetter(Class clazz, final String fieldId, int paramCount)
+            throws NoSuchMethodException {
+        return getMethodByName(clazz, SETTER_PREFIX + fieldId, paramCount);
     }
 
     private static Method getGetter(Class clazz, final String fieldId) throws NoSuchMethodException {
-        return getMethodByName(clazz, GETTER_PREFIX + fieldId);
+        return getMethodByName(clazz, GETTER_PREFIX + fieldId, 0);
     }
 
     /**
@@ -307,14 +336,14 @@ public abstract class Fig {
                 int idx = key.lastIndexOf(DOT_SEPARATOR);
                 String fieldId = idx > 0 ? key.substring(idx + 1, key.length()) : key;
 
-                Method m = getSetter(o.getClass(), fieldId);
+                // split on "|"
+                // TODO: add support for String args containing a '|'
+                String[] paramStrs = value.split("\\|");
+
+                Method m = getSetter(o.getClass(), fieldId, paramStrs.length);
                 Class[] paramTypes = m.getParameterTypes();
                 // TODO: add support for generic type params
                 if (paramTypes.length >= 1) {
-
-                    // split on "|"
-                    // TODO: add support for String args containing a '|'
-                    String[] paramStrs = value.split("\\|");
                     if (paramStrs.length == paramTypes.length) {
                         Object[] oa = inflateParams(ctx, paramTypes, paramStrs);
                         m.invoke(o, oa);

--- a/androidplot-core/src/main/java/com/androidplot/util/fig/Fig.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/fig/Fig.java
@@ -148,8 +148,50 @@ public abstract class Fig {
     }
 
 
+    /**
+     * Finds the setter for fieldId.  When the name is overloaded, an overload whose parameters
+     * can all be inflated from XML (see {@link #inflateParams}) is preferred: eg. since API 29
+     * {@link android.graphics.Paint} has both setColor(int) and setColor(long), and the order
+     * in which reflection lists them is unspecified, so picking the first match by name alone
+     * would make an attribute like backgroundPaint.color fail to inflate on some runtimes.
+     */
     private static Method getSetter(Class clazz, final String fieldId) throws NoSuchMethodException {
-        return getMethodByName(clazz, SETTER_PREFIX + fieldId);
+        final String methodName = SETTER_PREFIX + fieldId;
+        Method fallback = null;
+        for (Method method : clazz.getMethods()) {
+            if (method.getName().equalsIgnoreCase(methodName)) {
+                if (isInflatable(method.getParameterTypes())) {
+                    return method;
+                } else if (fallback == null) {
+                    fallback = method;
+                }
+            }
+        }
+        if (fallback != null) {
+            return fallback;
+        }
+        throw new NoSuchMethodException("No such public method (case insensitive): " +
+                methodName + " in " + clazz);
+    }
+
+    private static boolean isInflatable(Class[] params) {
+        for (Class param : params) {
+            if (!isInflatable(param)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return true if {@link #inflateParams} can produce a value of the given type.
+     */
+    private static boolean isInflatable(Class param) {
+        return Enum.class.isAssignableFrom(param)
+                || param.equals(Float.TYPE) || param == Float.class
+                || param.equals(Integer.TYPE) || param == Integer.class
+                || param.equals(Boolean.TYPE) || param == Boolean.class
+                || param.equals(String.class);
     }
 
     private static Method getGetter(Class clazz, final String fieldId) throws NoSuchMethodException {

--- a/androidplot-core/src/main/java/com/androidplot/util/fig/FigUtils.java
+++ b/androidplot-core/src/main/java/com/androidplot/util/fig/FigUtils.java
@@ -58,6 +58,10 @@ abstract class FigUtils {
         if (matcher.matches()) {
             // Match found; extract value.
             float value = Float.valueOf(matcher.group(1));
+            // the pattern accepts a leading '-' outside the value group; apply it here:
+            if (dimension.trim().startsWith("-")) {
+                value = -value;
+            }
             // Extract dimension units.
             String unit = matcher.group(3).toLowerCase();
             // Get Android dimension constant.

--- a/androidplot-core/src/test/java/com/androidplot/RenderSmokeTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/RenderSmokeTest.java
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+
+import com.androidplot.pie.PieChart;
+import com.androidplot.pie.PieRenderer;
+import com.androidplot.pie.Segment;
+import com.androidplot.pie.SegmentFormatter;
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.xy.AdvancedLineAndPointRenderer;
+import com.androidplot.xy.BarFormatter;
+import com.androidplot.xy.BarRenderer;
+import com.androidplot.xy.BoundaryMode;
+import com.androidplot.xy.BubbleFormatter;
+import com.androidplot.xy.BubbleRenderer;
+import com.androidplot.xy.BubbleSeries;
+import com.androidplot.xy.CandlestickFormatter;
+import com.androidplot.xy.CandlestickMaker;
+import com.androidplot.xy.CandlestickSeries;
+import com.androidplot.xy.CatmullRomInterpolator;
+import com.androidplot.xy.FastLineAndPointRenderer;
+import com.androidplot.xy.FillDirection;
+import com.androidplot.xy.LineAndPointFormatter;
+import com.androidplot.xy.RectRegion;
+import com.androidplot.xy.SimpleXYSeries;
+import com.androidplot.xy.StepFormatter;
+import com.androidplot.xy.XValueMarker;
+import com.androidplot.xy.XYPlot;
+import com.androidplot.xy.XYRegionFormatter;
+import com.androidplot.xy.XYSeries;
+import com.androidplot.xy.XYSeriesFormatter;
+import com.androidplot.xy.YValueMarker;
+
+import org.junit.Test;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.GraphicsMode;
+import org.robolectric.shadows.ShadowLog;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Renders every plot / renderer type onto a real bitmap and checks that (a) nothing blew up and
+ * (b) the series actually contributed pixels.  The same renderers are then driven over a table of
+ * degenerate datasets where the only requirement is that rendering does not fail.
+ *
+ * Native graphics (and therefore an SDK >= 26) are required for {@link Bitmap#getPixel(int, int)}
+ * to return anything but 0 under Robolectric; the rest of the suite runs at the default SDK.
+ *
+ * Note that {@link Plot#renderOnCanvas(Canvas)} catches and logs any exception thrown while
+ * drawing, so "no exception" is verified by inspecting the log rather than by catching.
+ */
+@Config(sdk = 36)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+public class RenderSmokeTest extends AndroidplotTest {
+
+    private static final int WIDTH = 400;
+    private static final int HEIGHT = 300;
+
+    /** A degenerate dataset, applied to an otherwise standard XYPlot. */
+    private static final class EdgeCase {
+        final String name;
+        final Supplier<XYSeries> series;
+        final Consumer<XYPlot> configure;
+
+        EdgeCase(String name, Supplier<XYSeries> series, Consumer<XYPlot> configure) {
+            this.name = name;
+            this.series = series;
+            this.configure = configure;
+        }
+    }
+
+    private static EdgeCase edge(String name, Number... yVals) {
+        return new EdgeCase(name, () -> yVals(name, yVals), null);
+    }
+
+    private static EdgeCase edge(String name, Consumer<XYPlot> configure, Number... yVals) {
+        return new EdgeCase(name, () -> yVals(name, yVals), configure);
+    }
+
+    /**
+     * Each of these is rendered through each of {@link #LINE_FAMILY_FORMATTERS}.  Adding a row
+     * here adds a case for every renderer.
+     */
+    private static final EdgeCase[] EDGE_CASES = {
+            edge("empty"),
+            edge("singlePoint", 5),
+            edge("flatLine", 3, 3, 3, 3, 3),
+            edge("nullInMiddle", 1, 2, null, 4, 5),
+            edge("negativeValues", -1, -5, -2, -8, -3),
+            edge("allNull", (Number) null, null, null),
+            edge("invertedDomain", p -> p.setDomainBoundaries(10, 0, BoundaryMode.FIXED), 1, 2, 3, 4),
+            edge("invertedRange", p -> p.setRangeBoundaries(10, 0, BoundaryMode.FIXED), 1, 2, 3, 4),
+            edge("widerThanFixedWindow", p -> p.setDomainBoundaries(5, 8, BoundaryMode.FIXED),
+                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19),
+            edge("fixedWindowOutsideData", p -> p.setDomainBoundaries(100, 200, BoundaryMode.FIXED),
+                    1, 2, 3, 4),
+            edge("zeroWidthFixedDomain", p -> p.setDomainBoundaries(2, 2, BoundaryMode.FIXED), 1, 2, 3, 4),
+    };
+
+    /** The renderers that accept a plain {@link XYSeries}; one row per renderer / configuration. */
+    private static final Object[][] LINE_FAMILY_FORMATTERS = {
+            {"line", (Supplier<XYSeriesFormatter<?>>) RenderSmokeTest::lineFormatter},
+            {"lineCatmullRom", (Supplier<XYSeriesFormatter<?>>) RenderSmokeTest::catmullRomFormatter},
+            {"lineFillTop", (Supplier<XYSeriesFormatter<?>>) () -> lineFormatter(FillDirection.TOP)},
+            {"lineFillRangeOrigin", (Supplier<XYSeriesFormatter<?>>) () -> lineFormatter(FillDirection.RANGE_ORIGIN)},
+            {"fastLine", (Supplier<XYSeriesFormatter<?>>) RenderSmokeTest::fastFormatter},
+            {"advancedLine", (Supplier<XYSeriesFormatter<?>>) RenderSmokeTest::advancedFormatter},
+            {"bar", (Supplier<XYSeriesFormatter<?>>) RenderSmokeTest::barFormatter},
+            {"step", (Supplier<XYSeriesFormatter<?>>) RenderSmokeTest::stepFormatter},
+    };
+
+    // ---------------------------------------------------------------------------------------
+    // happy path: every renderer draws something
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * The "series contributed pixels" assertions compare two renders with {@link Bitmap#sameAs};
+     * this pins the other direction: identical renders compare equal, so a difference is real.
+     */
+    @Test
+    public void render_isDeterministic() {
+        XYPlot plot = newXYPlot();
+        plot.addSeries(sampleSeries("s"), lineFormatter());
+        assertTrue(render(plot).sameAs(render(plot)));
+    }
+
+    @Test
+    public void lineAndPoint_plain() {
+        XYPlot plot = newXYPlot();
+        plot.addSeries(sampleSeries("s"), new LineAndPointFormatter(Color.RED, Color.GREEN, null, null));
+        assertSeriesDrawn(plot);
+    }
+
+    @Test
+    public void lineAndPoint_withCatmullRomInterpolation() {
+        for (CatmullRomInterpolator.Type type : CatmullRomInterpolator.Type.values()) {
+            XYPlot plot = newXYPlot();
+            LineAndPointFormatter formatter = lineFormatter();
+            formatter.setInterpolationParams(new CatmullRomInterpolator.Params(10, type));
+            plot.addSeries(sampleSeries("s"), formatter);
+            assertSeriesDrawn(type.name(), plot);
+        }
+    }
+
+    @Test
+    public void lineAndPoint_fillDirections() {
+        for (FillDirection direction : Arrays.asList(
+                FillDirection.TOP, FillDirection.BOTTOM, FillDirection.RANGE_ORIGIN)) {
+            XYPlot plot = newXYPlot();
+            plot.setRangeBoundaries(-10, 10, BoundaryMode.FIXED);
+            plot.setUserRangeOrigin(0);
+            plot.addSeries(sampleSeries("s"), lineFormatter(direction));
+            assertSeriesDrawn(direction.name(), plot);
+        }
+    }
+
+    /**
+     * LEFT / RIGHT / DOMAIN_ORIGIN are documented as not yet implemented.  The plot must survive
+     * them (the failure is logged) rather than take the app down mid-frame.
+     */
+    @Test
+    public void lineAndPoint_unimplementedFillDirections_logRatherThanCrash() {
+        for (FillDirection direction : Arrays.asList(
+                FillDirection.LEFT, FillDirection.RIGHT, FillDirection.DOMAIN_ORIGIN)) {
+            XYPlot plot = newXYPlot();
+            plot.addSeries(sampleSeries("s"), lineFormatter(direction));
+            ShadowLog.clear();
+            render(plot);
+            List<Throwable> logged = loggedThrowables();
+            assertTrue(direction + ": expected an UnsupportedOperationException to be logged",
+                    logged.size() == 1 && logged.get(0) instanceof UnsupportedOperationException);
+        }
+    }
+
+    @Test
+    public void lineAndPoint_withRegionFormatter() {
+        XYPlot plot = newXYPlot();
+        LineAndPointFormatter formatter = lineFormatter();
+        formatter.addRegion(new RectRegion(1, 3, 2, 8), new XYRegionFormatter(Color.MAGENTA));
+        plot.addSeries(sampleSeries("s"), formatter);
+        assertSeriesDrawn(plot);
+    }
+
+    @Test
+    public void advancedLineAndPoint() {
+        XYPlot plot = newXYPlot();
+        plot.addSeries(sampleSeries("s"), advancedFormatter());
+        plot.getRenderer(AdvancedLineAndPointRenderer.class).setLatestIndex(2);
+        assertSeriesDrawn(plot);
+    }
+
+    @Test
+    public void fastLineAndPoint() {
+        XYPlot plot = newXYPlot();
+        plot.addSeries(sampleSeries("s"), fastFormatter());
+        assertSeriesDrawn(plot);
+    }
+
+    @Test
+    public void bar_allOrientationsAndWidthModes() {
+        for (BarRenderer.BarOrientation orientation : BarRenderer.BarOrientation.values()) {
+            for (BarRenderer.BarGroupWidthMode widthMode : BarRenderer.BarGroupWidthMode.values()) {
+                XYPlot plot = newXYPlot();
+                plot.addSeries(sampleSeries("s1"), barFormatter());
+                plot.addSeries(yVals("s2", 4, 1, 6, 2, 7, 3, 2), new BarFormatter(Color.BLUE, Color.CYAN));
+                BarRenderer<?> renderer = plot.getRenderer(BarRenderer.class);
+                renderer.setBarOrientation(orientation);
+                renderer.setBarGroupWidth(widthMode, 20);
+                assertSeriesDrawn(orientation + "/" + widthMode, plot);
+            }
+        }
+    }
+
+    @Test
+    public void step() {
+        XYPlot plot = newXYPlot();
+        plot.addSeries(sampleSeries("s"), stepFormatter());
+        assertSeriesDrawn(plot);
+    }
+
+    @Test
+    public void candlestick() {
+        XYPlot plot = newXYPlot();
+        plot.setRangeBoundaries(0, 20, BoundaryMode.FIXED);
+        CandlestickMaker.make(plot, new CandlestickFormatter(), sampleCandlesticks());
+        assertSeriesDrawn(plot);
+    }
+
+    @Test
+    public void bubble_allScaleModes() {
+        for (BubbleRenderer.BubbleScaleMode mode : BubbleRenderer.BubbleScaleMode.values()) {
+            XYPlot plot = newXYPlot();
+            plot.addSeries(new BubbleSeries(1, 2, 5, 3, 6, 20, 5, 4, 50), new BubbleFormatter(Color.RED, Color.BLUE));
+            plot.getRenderer(BubbleRenderer.class).setBubbleScaleMode(mode);
+            assertSeriesDrawn(mode.name(), plot);
+        }
+    }
+
+    @Test
+    public void pie_withAndWithoutDonut() {
+        for (float donutSize : new float[]{0f, 0.5f}) {
+            PieChart chart = newPieChart();
+            addSegments(chart, 10, 20, 30, 40);
+            chart.getRenderer(PieRenderer.class).setDonutSize(donutSize, PieRenderer.DonutMode.PERCENT);
+            assertSeriesDrawn("donut=" + donutSize, chart);
+        }
+    }
+
+    @Test
+    public void valueMarkers() {
+        XYPlot plot = newXYPlot();
+        plot.addSeries(sampleSeries("s"), lineFormatter());
+        Bitmap without = render(plot);
+
+        plot.addMarker(new XValueMarker(2, "x marker"));
+        plot.addMarker(new YValueMarker(5, "y marker"));
+        Bitmap with = render(plot);
+        assertNotUniform(with);
+        assertFalse("markers were not drawn", with.sameAs(without));
+    }
+
+    @Test
+    public void legend() {
+        XYPlot plot = newXYPlot();
+        plot.addSeries(sampleSeries("first"), lineFormatter());
+        plot.addSeries(yVals("second", 4, 1, 6, 2, 7), barFormatter());
+        plot.getLegend().setVisible(false);
+        Bitmap without = render(plot);
+
+        plot.getLegend().setVisible(true);
+        Bitmap with = render(plot);
+        assertNotUniform(with);
+        assertFalse("legend was not drawn", with.sameAs(without));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // edge cases: nothing may fail, drawing may legitimately be blank
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void edgeCases_lineFamilyRenderers() {
+        List<String> failures = new ArrayList<>();
+        for (Object[] row : LINE_FAMILY_FORMATTERS) {
+            @SuppressWarnings("unchecked")
+            Supplier<XYSeriesFormatter<?>> formatter = (Supplier<XYSeriesFormatter<?>>) row[1];
+            for (EdgeCase edgeCase : EDGE_CASES) {
+                XYPlot plot = newXYPlot();
+                plot.setDomainBoundaries(null, null, BoundaryMode.AUTO);
+                plot.setRangeBoundaries(null, null, BoundaryMode.AUTO);
+                plot.addSeries(edgeCase.series.get(), formatter.get());
+                if (edgeCase.configure != null) {
+                    edgeCase.configure.accept(plot);
+                }
+                collectRenderFailure(row[0] + "/" + edgeCase.name, plot, failures);
+            }
+        }
+        assertNoFailures(failures);
+    }
+
+    @Test
+    public void edgeCases_bubble() {
+        List<String> failures = new ArrayList<>();
+        Object[][] cases = {
+                {"zeroZ", new BubbleSeries(1, 2, 0, 3, 6, 0)},
+                {"negativeZ", new BubbleSeries(1, 2, -5, 3, 6, -1)},
+                {"mixedZ", new BubbleSeries(1, 2, -5, 3, 6, 0, 5, 4, 50)},
+                {"singleBubble", new BubbleSeries(1, 2, 3)},
+                {"nullZ", new BubbleSeries(Arrays.asList((Number) 1, 2), Arrays.asList((Number) 3, 4),
+                        Arrays.asList((Number) null, 5), "nullZ")},
+        };
+        for (Object[] row : cases) {
+            XYPlot plot = newXYPlot();
+            plot.addSeries((BubbleSeries) row[1], new BubbleFormatter(Color.RED, Color.BLUE));
+            collectRenderFailure("bubble/" + row[0], plot, failures);
+        }
+        assertNoFailures(failures);
+    }
+
+    @Test
+    public void edgeCases_candlestick() {
+        List<String> failures = new ArrayList<>();
+        Object[][] cases = {
+                {"empty", new CandlestickSeries()},
+                {"single", new CandlestickSeries(new CandlestickSeries.Item(1, 5, 2, 4))},
+                {"flat", new CandlestickSeries(
+                        new CandlestickSeries.Item(3, 3, 3, 3), new CandlestickSeries.Item(3, 3, 3, 3))},
+                {"negative", new CandlestickSeries(
+                        new CandlestickSeries.Item(-9, -1, -5, -2), new CandlestickSeries.Item(-8, -2, -3, -6))},
+        };
+        for (Object[] row : cases) {
+            XYPlot plot = newXYPlot();
+            plot.setDomainBoundaries(null, null, BoundaryMode.AUTO);
+            plot.setRangeBoundaries(null, null, BoundaryMode.AUTO);
+            CandlestickMaker.make(plot, new CandlestickFormatter(), (CandlestickSeries) row[1]);
+            collectRenderFailure("candlestick/" + row[0], plot, failures);
+        }
+        assertNoFailures(failures);
+    }
+
+    @Test
+    public void edgeCases_pie() {
+        List<String> failures = new ArrayList<>();
+        Object[][] cases = {
+                {"noSegments", new Number[]{}},
+                {"zeroValueSegment", new Number[]{10, 0, 30}},
+                {"zeroTotal", new Number[]{0, 0, 0}},
+                {"singleSegment", new Number[]{42}},
+                {"negativeSegment", new Number[]{10, -5, 30}},
+        };
+        for (Object[] row : cases) {
+            for (float donutSize : new float[]{0f, 0.5f}) {
+                PieChart chart = newPieChart();
+                addSegments(chart, (Number[]) row[1]);
+                if (chart.getRegistry().size() > 0) {
+                    chart.getRenderer(PieRenderer.class).setDonutSize(donutSize, PieRenderer.DonutMode.PERCENT);
+                }
+                collectRenderFailure("pie/" + row[0] + "/donut=" + donutSize, chart, failures);
+            }
+        }
+        assertNoFailures(failures);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // fixtures
+    // ---------------------------------------------------------------------------------------
+
+    private XYPlot newXYPlot() {
+        XYPlot plot = new XYPlot(getContext(), "smoke", Plot.RenderMode.USE_MAIN_THREAD);
+        // fixed bounds keep the grid and labels identical with and without data, so that the
+        // with / without comparison in assertSeriesDrawn isolates the series renderer's output:
+        plot.setDomainBoundaries(0, 6, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(0, 10, BoundaryMode.FIXED);
+        plot.getLegend().setVisible(false);
+        plot.layout(0, 0, WIDTH, HEIGHT);
+        return plot;
+    }
+
+    private PieChart newPieChart() {
+        PieChart chart = new PieChart(getContext(), "pie", Plot.RenderMode.USE_MAIN_THREAD);
+        chart.layout(0, 0, WIDTH, HEIGHT);
+        return chart;
+    }
+
+    private static void addSegments(PieChart chart, Number... values) {
+        int[] colors = {Color.RED, Color.GREEN, Color.BLUE, Color.YELLOW, Color.MAGENTA};
+        for (int i = 0; i < values.length; i++) {
+            chart.addSegment(new Segment("seg" + i, values[i]),
+                    new SegmentFormatter(colors[i % colors.length], Color.BLACK));
+        }
+    }
+
+    private static XYSeries yVals(String title, Number... yVals) {
+        return new SimpleXYSeries(Arrays.asList(yVals), SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, title);
+    }
+
+    private static XYSeries sampleSeries(String title) {
+        return yVals(title, 1, 4, 2, 8, 5, 7, 3);
+    }
+
+    private static CandlestickSeries sampleCandlesticks() {
+        return new CandlestickSeries(
+                new CandlestickSeries.Item(1, 10, 2, 9),
+                new CandlestickSeries.Item(4, 18, 6, 17),
+                new CandlestickSeries.Item(3, 11, 10, 5),
+                new CandlestickSeries.Item(2, 17, 15, 3),
+                new CandlestickSeries.Item(6, 16, 15, 5));
+    }
+
+    private static LineAndPointFormatter lineFormatter() {
+        return lineFormatter(FillDirection.BOTTOM);
+    }
+
+    private static LineAndPointFormatter lineFormatter(FillDirection fillDirection) {
+        return new LineAndPointFormatter(Color.RED, Color.GREEN, Color.argb(100, 0, 0, 255), null, fillDirection);
+    }
+
+    private static LineAndPointFormatter catmullRomFormatter() {
+        LineAndPointFormatter formatter = lineFormatter();
+        formatter.setInterpolationParams(
+                new CatmullRomInterpolator.Params(10, CatmullRomInterpolator.Type.Centripetal));
+        return formatter;
+    }
+
+    private static FastLineAndPointRenderer.Formatter fastFormatter() {
+        return new FastLineAndPointRenderer.Formatter(Color.RED, Color.GREEN, null);
+    }
+
+    private static AdvancedLineAndPointRenderer.Formatter advancedFormatter() {
+        return new AdvancedLineAndPointRenderer.Formatter();
+    }
+
+    private static BarFormatter barFormatter() {
+        return new BarFormatter(Color.RED, Color.GREEN);
+    }
+
+    private static StepFormatter stepFormatter() {
+        return new StepFormatter(Color.RED, Color.argb(100, 0, 0, 255));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // rendering + assertions
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Renders plot onto a fresh bitmap.  Any exception thrown while drawing is swallowed and
+     * logged by {@link Plot#renderOnCanvas(Canvas)}; use {@link #loggedThrowables()} to find it.
+     */
+    private static Bitmap render(Plot plot) {
+        Bitmap bitmap = Bitmap.createBitmap(WIDTH, HEIGHT, Bitmap.Config.ARGB_8888);
+        plot.renderOnCanvas(new Canvas(bitmap));
+        return bitmap;
+    }
+
+    private static List<Throwable> loggedThrowables() {
+        List<Throwable> result = new ArrayList<>();
+        for (ShadowLog.LogItem item : ShadowLog.getLogs()) {
+            if (item.throwable != null) {
+                result.add(item.throwable);
+            }
+        }
+        return result;
+    }
+
+    private void assertSeriesDrawn(Plot plot) {
+        assertSeriesDrawn("", plot);
+    }
+
+    /**
+     * Renders plot, requiring a clean render that is not uniformly one color and that differs
+     * from a render of the same plot after all of its series have been removed.
+     */
+    private void assertSeriesDrawn(String label, Plot plot) {
+        ShadowLog.clear();
+        Bitmap with = render(plot);
+        assertRenderedCleanly(label);
+        assertNotUniform(with);
+
+        plot.clear();
+        Bitmap without = render(plot);
+        assertRenderedCleanly(label);
+        assertFalse(label + ": series contributed no pixels", with.sameAs(without));
+    }
+
+    private static void assertRenderedCleanly(String label) {
+        List<Throwable> logged = loggedThrowables();
+        if (!logged.isEmpty()) {
+            throw new AssertionError(label + ": exception logged while rendering", logged.get(0));
+        }
+    }
+
+    private static void assertNotUniform(Bitmap bitmap) {
+        Set<Integer> colors = new HashSet<>();
+        for (int x = 0; x < bitmap.getWidth(); x += 4) {
+            for (int y = 0; y < bitmap.getHeight(); y += 4) {
+                colors.add(bitmap.getPixel(x, y));
+            }
+        }
+        assertTrue("nothing was drawn; bitmap is uniformly " + colors, colors.size() > 1);
+    }
+
+    private static void collectRenderFailure(String label, Plot plot, List<String> failures) {
+        ShadowLog.clear();
+        try {
+            render(plot);
+        } catch (Throwable t) {
+            failures.add(label + ": " + t);
+            return;
+        }
+        for (Throwable t : loggedThrowables()) {
+            failures.add(label + ": " + t);
+        }
+    }
+
+    private static void assertNoFailures(List<String> failures) {
+        if (!failures.isEmpty()) {
+            fail(failures.size() + " case(s) failed to render:\n  " + String.join("\n  ", failures));
+        }
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/pie/PieChartAttrsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/pie/PieChartAttrsTest.java
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.pie;
+
+import com.androidplot.Plot;
+import com.androidplot.R;
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.Anchor;
+import com.androidplot.ui.HorizontalPositioning;
+import com.androidplot.ui.SizeMode;
+import com.androidplot.ui.VerticalPositioning;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.android.AttributeSetBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * XML attribute processing of {@link PieChart} driven through a real AttributeSet.
+ */
+public class PieChartAttrsTest extends AndroidplotTest {
+
+    private static final int COLOR_1 = 0xFF112233;
+    private static final int COLOR_2 = 0xFF445566;
+
+    PieChart defaults;
+
+    @Before
+    public void setUp() {
+        defaults = new PieChart(getContext(), attrs().build());
+    }
+
+    private static AttributeSetBuilder attrs() {
+        return Robolectric.buildAttributeSet();
+    }
+
+    private PieChart chart(AttributeSetBuilder builder) {
+        return new PieChart(getContext(), builder.build());
+    }
+
+    @Test
+    public void pieBorderAttrs_configureBorderPaint() {
+        final PieChart chart = chart(attrs()
+                .addAttribute(R.attr.pieBorderColor, "#FF112233")
+                .addAttribute(R.attr.pieBorderThickness, "9px"));
+
+        assertEquals(COLOR_1, chart.getBorderPaint().getColor());
+        assertEquals(9f, chart.getBorderPaint().getStrokeWidth(), 0);
+    }
+
+    @Test
+    public void pieBorderAttrs_absent_keepDefaults() {
+        final PieChart chart = chart(attrs().addAttribute(R.attr.title, "t"));
+        assertEquals(defaults.getBorderPaint().getColor(), chart.getBorderPaint().getColor());
+        assertEquals(defaults.getBorderPaint().getStrokeWidth(), chart.getBorderPaint().getStrokeWidth(), 0);
+    }
+
+    @Test
+    public void plotBorderAttrs_applyAfterPieBorderAttrs() {
+        // both target the plot's border paint; base Plot attrs are applied last and win
+        final PieChart chart = chart(attrs()
+                .addAttribute(R.attr.pieBorderColor, "#FF112233")
+                .addAttribute(R.attr.pieBorderThickness, "9px")
+                .addAttribute(R.attr.borderColor, "#FF445566")
+                .addAttribute(R.attr.borderThickness, "4px"));
+
+        assertEquals(COLOR_2, chart.getBorderPaint().getColor());
+        assertEquals(4f, chart.getBorderPaint().getStrokeWidth(), 0);
+    }
+
+    @Test
+    public void plotBaseAttrs_applyToPieChart() {
+        final PieChart chart = chart(attrs()
+                .addAttribute(R.attr.title, "Pie")
+                .addAttribute(R.attr.titleTextSize, "23px")
+                .addAttribute(R.attr.titleTextColor, "#FF112233")
+                .addAttribute(R.attr.backgroundColor, "#FF445566")
+                .addAttribute(R.attr.renderMode, "use_background_thread")
+                .addAttribute(R.attr.markupEnabled, "true")
+                .addAttribute(R.attr.marginTop, "1px")
+                .addAttribute(R.attr.marginBottom, "2px")
+                .addAttribute(R.attr.marginLeft, "3px")
+                .addAttribute(R.attr.marginRight, "4px")
+                .addAttribute(R.attr.paddingTop, "5px")
+                .addAttribute(R.attr.paddingBottom, "6px")
+                .addAttribute(R.attr.paddingLeft, "7px")
+                .addAttribute(R.attr.paddingRight, "8px"));
+
+        assertEquals("Pie", chart.getTitle().getText());
+        assertEquals(23f, chart.getTitle().getLabelPaint().getTextSize(), 0);
+        assertEquals(COLOR_1, chart.getTitle().getLabelPaint().getColor());
+        assertEquals(COLOR_2, chart.getBackgroundPaint().getColor());
+        assertEquals(Plot.RenderMode.USE_BACKGROUND_THREAD, chart.getRenderMode());
+        assertTrue(chart.getLayoutManager().isDrawOutlinesEnabled());
+        assertEquals(1f, chart.getPlotMarginTop(), 0);
+        assertEquals(2f, chart.getPlotMarginBottom(), 0);
+        assertEquals(3f, chart.getPlotMarginLeft(), 0);
+        assertEquals(4f, chart.getPlotMarginRight(), 0);
+        assertEquals(5f, chart.getPlotPaddingTop(), 0);
+        assertEquals(6f, chart.getPlotPaddingBottom(), 0);
+        assertEquals(7f, chart.getPlotPaddingLeft(), 0);
+        assertEquals(8f, chart.getPlotPaddingRight(), 0);
+
+        // pie widget untouched by plot-level attrs:
+        assertEquals(defaults.getPie().getPaddingLeft(), chart.getPie().getPaddingLeft(), 0);
+        assertEquals(defaults.getPie().getSize().getHeight().getValue(),
+                chart.getPie().getSize().getHeight().getValue(), 0);
+    }
+
+    @Test
+    public void onPreInit_defaultsSurviveAttrProcessing() {
+        final PieChart chart = chart(attrs()
+                .addAttribute(R.attr.title, "Pie")
+                .addAttribute(R.attr.marginTop, "1px"));
+        assertEquals("Pie", chart.getTitle().getText());
+
+        assertFalse(chart.getLegend().isVisible());
+        assertEquals(SizeMode.FILL, chart.getPie().getSize().getHeight().getLayoutType());
+        assertEquals(Anchor.CENTER, chart.getPie().getAnchor());
+        assertEquals(HorizontalPositioning.ABSOLUTE_FROM_CENTER,
+                chart.getPie().getPositionMetrics().getXPositionMetric().getLayoutType());
+        assertEquals(VerticalPositioning.ABSOLUTE_FROM_CENTER,
+                chart.getPie().getPositionMetrics().getYPositionMetric().getLayoutType());
+        assertEquals(Anchor.RIGHT_BOTTOM, chart.getLegend().getAnchor());
+        assertEquals(5f, chart.getPie().getPaddingLeft(), 0);
+    }
+
+    @Test
+    public void noAttrs_titleIsNull() {
+        assertNull(defaults.getTitle().getText());
+    }
+
+    @Test
+    public void setPie_replacesPieWidget() {
+        final PieChart chart = new PieChart(getContext(), "pie");
+        final PieWidget original = chart.getPie();
+        final PieWidget replacement = new PieWidget(chart.getLayoutManager(), chart,
+                original.getSize());
+        chart.setPie(replacement);
+        assertSame(replacement, chart.getPie());
+    }
+
+    @Test
+    public void addAndRemoveSegment_updateRegistry() {
+        final PieChart chart = new PieChart(getContext(), "pie");
+        final Segment segment = new Segment("a", 1);
+        chart.addSegment(segment, new SegmentFormatter(0xFF00FF00));
+        assertEquals(1, chart.getRegistry().size());
+        assertTrue(chart.getRegistry().contains(segment, SegmentFormatter.class));
+        chart.removeSegment(segment);
+        assertEquals(0, chart.getRegistry().size());
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/pie/SegmentFormatterTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/pie/SegmentFormatterTest.java
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.pie;
+
+import android.graphics.Color;
+import android.graphics.Paint;
+
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.SeriesRenderer;
+import com.androidplot.util.fig.Fig;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class SegmentFormatterTest extends AndroidplotTest {
+
+    @Test
+    public void defaults() {
+        final SegmentFormatter formatter = new SegmentFormatter(Color.BLUE);
+        assertEquals(Color.BLUE, formatter.getFillPaint().getColor());
+        assertTrue(formatter.isLegendIconEnabled());
+        assertEquals(0f, formatter.getOffset(), 0);
+        assertEquals(0f, formatter.getRadialInset(), 0);
+        assertEquals(0f, formatter.getInnerInset(), 0);
+        assertEquals(0f, formatter.getOuterInset(), 0);
+
+        for (Paint edge : new Paint[]{formatter.getOuterEdgePaint(),
+                formatter.getInnerEdgePaint(), formatter.getRadialEdgePaint()}) {
+            assertNotNull(edge);
+            assertEquals(Paint.Style.STROKE, edge.getStyle());
+            assertEquals(3f, edge.getStrokeWidth(), 0);
+            assertTrue(edge.isAntiAlias());
+        }
+        assertNotSame(formatter.getOuterEdgePaint(), formatter.getInnerEdgePaint());
+        assertNotSame(formatter.getInnerEdgePaint(), formatter.getRadialEdgePaint());
+
+        assertEquals(Color.WHITE, formatter.getLabelPaint().getColor());
+        assertEquals(18f, formatter.getLabelPaint().getTextSize(), 0);
+        assertEquals(Paint.Align.CENTER, formatter.getLabelPaint().getTextAlign());
+        assertEquals(Color.WHITE, formatter.getLabelMarkerPaint().getColor());
+        assertEquals(3f, formatter.getLabelMarkerPaint().getStrokeWidth(), 0);
+    }
+
+    @Test
+    public void nullFillColor_isTransparent() {
+        final SegmentFormatter formatter = new SegmentFormatter((Integer) null);
+        assertEquals(Color.TRANSPARENT, formatter.getFillPaint().getColor());
+    }
+
+    @Test
+    public void fillAndBorderConstructor_colorsAllEdges() {
+        final SegmentFormatter formatter = new SegmentFormatter(Color.RED, Color.GREEN);
+        assertEquals(Color.RED, formatter.getFillPaint().getColor());
+        assertEquals(Color.GREEN, formatter.getOuterEdgePaint().getColor());
+        assertEquals(Color.GREEN, formatter.getInnerEdgePaint().getColor());
+        assertEquals(Color.GREEN, formatter.getRadialEdgePaint().getColor());
+    }
+
+    @Test
+    public void perEdgeConstructor_colorsEachEdge() {
+        final SegmentFormatter formatter = new SegmentFormatter(Color.RED, Color.GREEN, Color.BLUE, Color.YELLOW);
+        assertEquals(Color.RED, formatter.getFillPaint().getColor());
+        assertEquals(Color.GREEN, formatter.getOuterEdgePaint().getColor());
+        assertEquals(Color.BLUE, formatter.getInnerEdgePaint().getColor());
+        assertEquals(Color.YELLOW, formatter.getRadialEdgePaint().getColor());
+    }
+
+    @Test
+    public void renderer() {
+        final SegmentFormatter formatter = new SegmentFormatter(Color.RED);
+        assertEquals(PieRenderer.class, formatter.getRendererClass());
+        final PieChart chart = new PieChart(getContext(), "pie");
+        final SeriesRenderer renderer = formatter.doGetRendererInstance(chart);
+        assertTrue(renderer instanceof PieRenderer);
+        final PieRenderer viaGeneric = formatter.getRendererInstance(chart);
+        assertNotNull(viaGeneric);
+        assertNotSame(renderer, viaGeneric);
+    }
+
+    @Test
+    public void setters() {
+        final SegmentFormatter formatter = new SegmentFormatter(Color.RED);
+        final Paint p1 = new Paint();
+        final Paint p2 = new Paint();
+        final Paint p3 = new Paint();
+        final Paint p4 = new Paint();
+        final Paint p5 = new Paint();
+        final Paint p6 = new Paint();
+        formatter.setFillPaint(p1);
+        formatter.setInnerEdgePaint(p2);
+        formatter.setOuterEdgePaint(p3);
+        formatter.setRadialEdgePaint(p4);
+        formatter.setLabelPaint(p5);
+        formatter.setLabelMarkerPaint(p6);
+        formatter.setOffset(1.5f);
+        formatter.setRadialInset(2.5f);
+        formatter.setInnerInset(3.5f);
+        formatter.setOuterInset(4.5f);
+        formatter.setLegendIconEnabled(false);
+
+        assertSame(p1, formatter.getFillPaint());
+        assertSame(p2, formatter.getInnerEdgePaint());
+        assertSame(p3, formatter.getOuterEdgePaint());
+        assertSame(p4, formatter.getRadialEdgePaint());
+        assertSame(p5, formatter.getLabelPaint());
+        assertSame(p6, formatter.getLabelMarkerPaint());
+        assertEquals(1.5f, formatter.getOffset(), 0);
+        assertEquals(2.5f, formatter.getRadialInset(), 0);
+        assertEquals(3.5f, formatter.getInnerInset(), 0);
+        assertEquals(4.5f, formatter.getOuterInset(), 0);
+        assertFalse(formatter.isLegendIconEnabled());
+    }
+
+    @Test
+    public void configure_fromParams_appliesNestedPaintProperties() throws Exception {
+        final SegmentFormatter formatter = new SegmentFormatter(Color.RED);
+        final HashMap<String, String> params = new HashMap<>();
+        params.put("fillPaint.color", "#FF00AA00");
+        params.put("innerEdgePaint.strokeWidth", "7px");
+        params.put("labelPaint.textSize", "21px");
+        params.put("labelPaint.textAlign", "right");
+        params.put("offset", "8dp");
+        params.put("outerInset", "2.5");
+        params.put("legendIconEnabled", "false");
+        Fig.configure(getContext(), formatter, params);
+
+        assertEquals(0xFF00AA00, formatter.getFillPaint().getColor());
+        assertEquals(7f, formatter.getInnerEdgePaint().getStrokeWidth(), 0);
+        assertEquals(21f, formatter.getLabelPaint().getTextSize(), 0);
+        assertEquals(Paint.Align.RIGHT, formatter.getLabelPaint().getTextAlign());
+        assertEquals(8f, formatter.getOffset(), 0);
+        assertEquals(2.5f, formatter.getOuterInset(), 0);
+        assertFalse(formatter.isLegendIconEnabled());
+    }
+
+    @Test
+    public void xmlConfigConstructor_appliesResourceConfig() {
+        // the test xml resource is packaged but absent from the compile time R stub
+        final int cfgId = getContext().getResources().getIdentifier(
+                "segment_formatter_cfg", "xml", getContext().getPackageName());
+        assertNotEquals("test xml resource not found", 0, cfgId);
+
+        final SegmentFormatter formatter = new SegmentFormatter(getContext(), cfgId);
+
+        assertEquals(0xFF00AA00, formatter.getFillPaint().getColor());
+        assertEquals(0xFF112233, formatter.getOuterEdgePaint().getColor());
+        assertEquals(4f, formatter.getOuterEdgePaint().getStrokeWidth(), 0);
+        assertEquals(15f, formatter.getLabelPaint().getTextSize(), 0);
+        assertEquals(Paint.Align.LEFT, formatter.getLabelPaint().getTextAlign());
+        assertEquals(6f, formatter.getOffset(), 0);
+        assertEquals(1f, formatter.getRadialInset(), 0);
+        assertEquals(2f, formatter.getInnerInset(), 0);
+        assertEquals(3f, formatter.getOuterInset(), 0);
+        assertFalse(formatter.isLegendIconEnabled());
+
+        // untouched defaults survive:
+        assertEquals(3f, formatter.getInnerEdgePaint().getStrokeWidth(), 0);
+        assertEquals(Color.WHITE, formatter.getLabelPaint().getColor());
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/ui/LayoutManagerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/LayoutManagerTest.java
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.ui;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.RectF;
+import android.graphics.Region;
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.widget.Widget;
+import com.androidplot.util.DisplayDimensions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class LayoutManagerTest extends AndroidplotTest {
+
+    private static final RectF CANVAS_RECT = new RectF(0, 0, 300, 200);
+    private static final RectF MARGINATED_RECT = new RectF(5, 5, 295, 195);
+    private static final RectF PADDED_RECT = new RectF(10, 20, 210, 120);
+
+    @Mock
+    Canvas canvas;
+
+    LayoutManager layoutManager;
+    DisplayDimensions dims;
+
+    @Before
+    public void setUp() {
+        layoutManager = new LayoutManager();
+        dims = new DisplayDimensions(CANVAS_RECT, MARGINATED_RECT, PADDED_RECT);
+    }
+
+    @Test
+    public void addToTopAndBottom_orderElements() {
+        final Widget a = newWidget();
+        final Widget b = newWidget();
+        final Widget c = newWidget();
+        layoutManager.addToTop(a);
+        layoutManager.addToTop(b);
+        layoutManager.addToBottom(c);
+        assertEquals(Arrays.asList(c, a, b), layoutManager.elements());
+        assertEquals(3, layoutManager.size());
+    }
+
+    @Test
+    public void position_addsWidgetToTopExactlyOnce() {
+        final Widget a = newWidget();
+        final Widget b = newWidget();
+        assertFalse(layoutManager.contains(a));
+
+        a.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        b.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        a.position(5, HorizontalPositioning.ABSOLUTE_FROM_RIGHT, 5, VerticalPositioning.ABSOLUTE_FROM_BOTTOM,
+                Anchor.RIGHT_BOTTOM);
+        a.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+
+        assertEquals(Arrays.asList(a, b), layoutManager.elements());
+        assertEquals(1, layoutManager.stream().filter(w -> w == a).count());
+    }
+
+    @Test
+    public void zOrderOperations_reorderElements() {
+        final Widget a = newWidget();
+        final Widget b = newWidget();
+        final Widget c = newWidget();
+        layoutManager.addToTop(a);
+        layoutManager.addToTop(b);
+        layoutManager.addToTop(c);
+        assertEquals(Arrays.asList(a, b, c), layoutManager.elements());
+
+        assertTrue(layoutManager.moveToTop(a));
+        assertEquals(Arrays.asList(b, c, a), layoutManager.elements());
+
+        assertTrue(layoutManager.moveToBottom(c));
+        assertEquals(Arrays.asList(c, b, a), layoutManager.elements());
+
+        assertTrue(layoutManager.moveAbove(c, b));
+        assertEquals(Arrays.asList(b, c, a), layoutManager.elements());
+
+        assertTrue(layoutManager.moveBeneath(a, b));
+        assertEquals(Arrays.asList(a, b, c), layoutManager.elements());
+
+        assertTrue(layoutManager.moveUp(a));
+        assertEquals(Arrays.asList(b, a, c), layoutManager.elements());
+
+        assertTrue(layoutManager.moveDown(c));
+        assertEquals(Arrays.asList(b, c, a), layoutManager.elements());
+
+        // already at the extremes is a no-op success:
+        assertTrue(layoutManager.moveUp(a));
+        assertTrue(layoutManager.moveDown(b));
+        assertEquals(Arrays.asList(b, c, a), layoutManager.elements());
+    }
+
+    @Test
+    public void zOrderOperations_unknownWidget() {
+        final Widget a = newWidget();
+        final Widget stranger = newWidget();
+        layoutManager.addToTop(a);
+
+        assertFalse(layoutManager.moveToTop(stranger));
+        assertFalse(layoutManager.moveUp(stranger));
+        assertFalse(layoutManager.moveDown(stranger));
+        assertEquals(Arrays.asList(a), layoutManager.elements());
+
+        try {
+            layoutManager.moveAbove(a, a);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+        try {
+            layoutManager.moveBeneath(a, newWidget());
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void remove_dropsWidgetAndPreservesOrderOfOthers() {
+        final Widget a = newWidget();
+        final Widget b = newWidget();
+        final Widget c = newWidget();
+        layoutManager.addToTop(a);
+        layoutManager.addToTop(b);
+        layoutManager.addToTop(c);
+
+        assertTrue(layoutManager.remove(b));
+        assertEquals(Arrays.asList(a, c), layoutManager.elements());
+        assertFalse(layoutManager.remove(b));
+
+        // a removed widget is re-added by its next position() call:
+        b.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        assertEquals(Arrays.asList(a, c, b), layoutManager.elements());
+    }
+
+    @Test
+    public void layout_propagatesDimensionsToEveryWidget() {
+        final Widget a = newWidget();
+        final Widget b = newWidget();
+        a.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        b.position(0, HorizontalPositioning.ABSOLUTE_FROM_RIGHT, 0, VerticalPositioning.ABSOLUTE_FROM_BOTTOM,
+                Anchor.RIGHT_BOTTOM);
+
+        layoutManager.layout(dims);
+
+        assertEquals(new RectF(10, 20, 50, 50), a.getWidgetDimensions().canvasRect);
+        assertEquals(new RectF(170, 90, 210, 120), b.getWidgetDimensions().canvasRect);
+
+        // a widget added later is laid out on refresh against the last dims:
+        final Widget c = newWidget();
+        c.position(0, HorizontalPositioning.ABSOLUTE_FROM_CENTER, 0, VerticalPositioning.ABSOLUTE_FROM_CENTER,
+                Anchor.CENTER);
+        assertEquals(new RectF(1, 1, 1, 1), c.getWidgetDimensions().canvasRect);
+        layoutManager.refreshLayout();
+        assertEquals(new RectF(90, 55, 130, 85), c.getWidgetDimensions().canvasRect);
+    }
+
+    @Test
+    public void onPostInit_propagatesToEveryWidget() {
+        final Widget a = spy(newWidget());
+        final Widget b = spy(newWidget());
+        layoutManager.addToTop(a);
+        layoutManager.addToTop(b);
+        layoutManager.onPostInit();
+        verify(a).onPostInit();
+        verify(b).onPostInit();
+    }
+
+    @Test
+    public void draw_drawsWidgetsBottomToTopWithSaveRestore() {
+        final Widget bottom = spy(newWidget());
+        final Widget top = spy(newWidget());
+        bottom.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        top.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        layoutManager.layout(dims);
+
+        layoutManager.draw(canvas);
+
+        final InOrder inOrder = Mockito.inOrder(bottom, top);
+        inOrder.verify(bottom).draw(canvas);
+        inOrder.verify(top).draw(canvas);
+
+        // one save/restore pair per widget from the layout manager plus one from Widget.draw:
+        verify(canvas, times(4)).save();
+        verify(canvas, times(4)).restore();
+
+        // no markup by default:
+        verify(canvas, never()).drawRect(any(RectF.class), any(Paint.class));
+        verify(canvas, never()).clipRect(any(RectF.class), any(Region.Op.class));
+    }
+
+    @Test
+    public void draw_clippingEnabledWidget_clipsToWidgetRect() {
+        final Widget widget = newWidget();
+        widget.setClippingEnabled(true);
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        layoutManager.layout(dims);
+
+        layoutManager.draw(canvas);
+
+        verify(canvas).clipRect(new RectF(10, 20, 50, 50), Region.Op.INTERSECT);
+    }
+
+    @Test
+    public void draw_restoresCanvasWhenWidgetDrawThrows() {
+        final Widget widget = spy(newWidget());
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        layoutManager.layout(dims);
+        Mockito.doThrow(new IllegalStateException("boom")).when(widget).draw(canvas);
+
+        try {
+            layoutManager.draw(canvas);
+            fail("expected IllegalStateException");
+        } catch (IllegalStateException expected) {
+            // ok
+        }
+        verify(canvas).save();
+        verify(canvas).restore();
+    }
+
+    @Test
+    public void setMarkupEnabled_togglesAllMarkupFlags() {
+        assertFalse(layoutManager.isDrawOutlinesEnabled());
+        assertFalse(layoutManager.isDrawAnchorsEnabled());
+        assertFalse(layoutManager.isDrawMarginsEnabled());
+        assertFalse(layoutManager.isDrawPaddingEnabled());
+        assertFalse(layoutManager.isDrawOutlineShadowsEnabled());
+        assertNull(layoutManager.getOutlineShadowPaint());
+
+        layoutManager.setMarkupEnabled(true);
+        assertTrue(layoutManager.isDrawOutlinesEnabled());
+        assertTrue(layoutManager.isDrawAnchorsEnabled());
+        assertTrue(layoutManager.isDrawMarginsEnabled());
+        assertTrue(layoutManager.isDrawPaddingEnabled());
+        assertTrue(layoutManager.isDrawOutlineShadowsEnabled());
+        // a default shadow paint is created lazily:
+        assertNotNull(layoutManager.getOutlineShadowPaint());
+
+        layoutManager.setMarkupEnabled(false);
+        assertFalse(layoutManager.isDrawOutlinesEnabled());
+        assertFalse(layoutManager.isDrawAnchorsEnabled());
+        assertFalse(layoutManager.isDrawMarginsEnabled());
+        assertFalse(layoutManager.isDrawPaddingEnabled());
+        assertFalse(layoutManager.isDrawOutlineShadowsEnabled());
+    }
+
+    @Test
+    public void paintSetters_replacePaints() {
+        final Paint outline = new Paint();
+        final Paint shadow = new Paint();
+        final Paint margin = new Paint();
+        final Paint padding = new Paint();
+        layoutManager.setOutlinePaint(outline);
+        layoutManager.setOutlineShadowPaint(shadow);
+        layoutManager.setMarginPaint(margin);
+        layoutManager.setPaddingPaint(padding);
+        assertSame(outline, layoutManager.getOutlinePaint());
+        assertSame(shadow, layoutManager.getOutlineShadowPaint());
+        assertSame(margin, layoutManager.getMarginPaint());
+        assertSame(padding, layoutManager.getPaddingPaint());
+
+        // an explicitly set shadow paint is not replaced by the lazy default:
+        layoutManager.setDrawOutlineShadowsEnabled(true);
+        assertSame(shadow, layoutManager.getOutlineShadowPaint());
+    }
+
+    @Test
+    public void draw_markupEnabled_drawsPlotSpacingAndWidgetMarkup() {
+        final Widget widget = newWidget();
+        widget.setMargins(1, 1, 1, 1);
+        widget.setPadding(2, 2, 2, 2);
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT, 0, VerticalPositioning.ABSOLUTE_FROM_TOP,
+                Anchor.LEFT_TOP);
+        layoutManager.layout(dims);
+        layoutManager.setMarkupEnabled(true);
+
+        layoutManager.draw(canvas);
+
+        final RectF widgetRect = new RectF(10, 20, 50, 50);
+        // plot margins & padding: clip out the inner rect, fill the outer one
+        verify(canvas).clipRect(MARGINATED_RECT, Region.Op.DIFFERENCE);
+        verify(canvas).drawRect(CANVAS_RECT, layoutManager.getMarginPaint());
+        verify(canvas).clipRect(PADDED_RECT, Region.Op.DIFFERENCE);
+        verify(canvas).drawRect(MARGINATED_RECT, layoutManager.getPaddingPaint());
+
+        // widget shadow & outline
+        verify(canvas).drawRect(widgetRect, layoutManager.getOutlineShadowPaint());
+        verify(canvas).drawRect(widgetRect, layoutManager.getOutlinePaint());
+
+        // widget margins & padding
+        verify(canvas).clipRect(new RectF(11, 21, 49, 49), Region.Op.DIFFERENCE);
+        verify(canvas).drawRect(widgetRect, layoutManager.getMarginPaint());
+        verify(canvas).clipRect(new RectF(13, 23, 47, 47), Region.Op.DIFFERENCE);
+        verify(canvas).drawRect(new RectF(11, 21, 49, 49), layoutManager.getPaddingPaint());
+
+        // anchor marker: 8x8 square centered on the LEFT_TOP anchor at (10, 20)
+        verify(canvas).drawRect(eq(6f), eq(16f), eq(14f), eq(24f), any(Paint.class));
+
+        // every save (plot margin, plot padding, widget, widget.draw, widget margin, widget padding)
+        // is paired with a restore:
+        verify(canvas, times(6)).save();
+        verify(canvas, times(6)).restore();
+    }
+
+    @Test
+    public void draw_anchorsEnabled_marksAnchorOfEachWidget() {
+        final Widget widget = newWidget();
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_RIGHT, 0, VerticalPositioning.ABSOLUTE_FROM_BOTTOM,
+                Anchor.RIGHT_BOTTOM);
+        layoutManager.layout(dims);
+        layoutManager.setDrawAnchorsEnabled(true);
+
+        layoutManager.draw(canvas);
+
+        // anchor is at the padded rect's bottom right corner (210, 120):
+        verify(canvas).drawRect(eq(206f), eq(116f), eq(214f), eq(124f), any(Paint.class));
+        verify(canvas, never()).drawRect(any(RectF.class), any(Paint.class));
+        verify(canvas, never()).clipRect(any(RectF.class), any(Region.Op.class));
+    }
+
+    @Test
+    public void onTouch_isNotConsumed() {
+        assertFalse(layoutManager.onTouch(Mockito.mock(View.class), Mockito.mock(MotionEvent.class)));
+    }
+
+    private Widget newWidget() {
+        return new TestWidget(layoutManager, new Size(30, SizeMode.ABSOLUTE, 40, SizeMode.ABSOLUTE));
+    }
+
+    static class TestWidget extends Widget {
+        TestWidget(LayoutManager layoutManager, Size size) {
+            super(layoutManager, size);
+        }
+
+        @Override
+        protected void doOnDraw(Canvas canvas, RectF widgetRect) {
+            // nothing to do
+        }
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/ui/LayoutMetricsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/LayoutMetricsTest.java
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.ui;
+
+import android.graphics.RectF;
+
+import com.androidplot.test.AndroidplotTest;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+/**
+ * Value / validation semantics of the layout metric value classes:
+ * {@link HorizontalPosition}, {@link VerticalPosition}, {@link SizeMetric}, {@link Size},
+ * {@link PositionMetrics} and {@link BoxModel}.
+ */
+public class LayoutMetricsTest extends AndroidplotTest {
+
+    private static final float SIZE = 200;
+
+    @Test
+    public void horizontalPosition_getPixelValue_perPositioning() {
+        assertEquals(30f, new HorizontalPosition(30, HorizontalPositioning.ABSOLUTE_FROM_LEFT)
+                .getPixelValue(SIZE), 0);
+        assertEquals(170f, new HorizontalPosition(30, HorizontalPositioning.ABSOLUTE_FROM_RIGHT)
+                .getPixelValue(SIZE), 0);
+        assertEquals(130f, new HorizontalPosition(30, HorizontalPositioning.ABSOLUTE_FROM_CENTER)
+                .getPixelValue(SIZE), 0);
+        assertEquals(70f, new HorizontalPosition(-30, HorizontalPositioning.ABSOLUTE_FROM_CENTER)
+                .getPixelValue(SIZE), 0);
+        assertEquals(50f, new HorizontalPosition(0.25f, HorizontalPositioning.RELATIVE_TO_LEFT)
+                .getPixelValue(SIZE), 0);
+        assertEquals(150f, new HorizontalPosition(-0.25f, HorizontalPositioning.RELATIVE_TO_RIGHT)
+                .getPixelValue(SIZE), 0);
+        assertEquals(200f, new HorizontalPosition(0, HorizontalPositioning.RELATIVE_TO_RIGHT)
+                .getPixelValue(SIZE), 0);
+        assertEquals(125f, new HorizontalPosition(0.25f, HorizontalPositioning.RELATIVE_TO_CENTER)
+                .getPixelValue(SIZE), 0);
+        assertEquals(0f, new HorizontalPosition(-1, HorizontalPositioning.RELATIVE_TO_CENTER)
+                .getPixelValue(SIZE), 0);
+        assertEquals(200f, new HorizontalPosition(1, HorizontalPositioning.RELATIVE_TO_CENTER)
+                .getPixelValue(SIZE), 0);
+    }
+
+    @Test
+    public void verticalPosition_getPixelValue_perPositioning() {
+        assertEquals(30f, new VerticalPosition(30, VerticalPositioning.ABSOLUTE_FROM_TOP)
+                .getPixelValue(SIZE), 0);
+        assertEquals(170f, new VerticalPosition(30, VerticalPositioning.ABSOLUTE_FROM_BOTTOM)
+                .getPixelValue(SIZE), 0);
+        assertEquals(130f, new VerticalPosition(30, VerticalPositioning.ABSOLUTE_FROM_CENTER)
+                .getPixelValue(SIZE), 0);
+        assertEquals(50f, new VerticalPosition(0.25f, VerticalPositioning.RELATIVE_TO_TOP)
+                .getPixelValue(SIZE), 0);
+        assertEquals(150f, new VerticalPosition(-0.25f, VerticalPositioning.RELATIVE_TO_BOTTOM)
+                .getPixelValue(SIZE), 0);
+        assertEquals(125f, new VerticalPosition(0.25f, VerticalPositioning.RELATIVE_TO_CENTER)
+                .getPixelValue(SIZE), 0);
+    }
+
+    @Test
+    public void positionMetric_relativeValueOutOfRange_throws() {
+        for (HorizontalPositioning hp : new HorizontalPositioning[]{
+                HorizontalPositioning.RELATIVE_TO_LEFT,
+                HorizontalPositioning.RELATIVE_TO_RIGHT,
+                HorizontalPositioning.RELATIVE_TO_CENTER}) {
+            assertThrowsIAE(hp + " 1.01", () -> new HorizontalPosition(1.01f, hp));
+            assertThrowsIAE(hp + " -1.01", () -> new HorizontalPosition(-1.01f, hp));
+            // boundaries are inclusive:
+            new HorizontalPosition(1, hp);
+            new HorizontalPosition(-1, hp);
+        }
+        for (VerticalPositioning vp : new VerticalPositioning[]{
+                VerticalPositioning.RELATIVE_TO_TOP,
+                VerticalPositioning.RELATIVE_TO_BOTTOM,
+                VerticalPositioning.RELATIVE_TO_CENTER}) {
+            assertThrowsIAE(vp + " 1.01", () -> new VerticalPosition(1.01f, vp));
+            assertThrowsIAE(vp + " -1.01", () -> new VerticalPosition(-1.01f, vp));
+            new VerticalPosition(1, vp);
+            new VerticalPosition(-1, vp);
+        }
+    }
+
+    @Test
+    public void positionMetric_absoluteValues_unrestricted() {
+        for (HorizontalPositioning hp : new HorizontalPositioning[]{
+                HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                HorizontalPositioning.ABSOLUTE_FROM_RIGHT,
+                HorizontalPositioning.ABSOLUTE_FROM_CENTER}) {
+            new HorizontalPosition(5000, hp);
+            new HorizontalPosition(-5000, hp);
+        }
+        for (VerticalPositioning vp : new VerticalPositioning[]{
+                VerticalPositioning.ABSOLUTE_FROM_TOP,
+                VerticalPositioning.ABSOLUTE_FROM_BOTTOM,
+                VerticalPositioning.ABSOLUTE_FROM_CENTER}) {
+            new VerticalPosition(5000, vp);
+            new VerticalPosition(-5000, vp);
+        }
+    }
+
+    @Test
+    public void positionMetric_setters_revalidateAndUpdate() {
+        final HorizontalPosition hpos = new HorizontalPosition(50, HorizontalPositioning.ABSOLUTE_FROM_LEFT);
+
+        // switching to a relative mode with an out of range value must fail and leave state intact:
+        assertThrowsIAE("setLayoutType", () -> hpos.setLayoutType(HorizontalPositioning.RELATIVE_TO_LEFT));
+        assertEquals(HorizontalPositioning.ABSOLUTE_FROM_LEFT, hpos.getLayoutType());
+        assertEquals(50f, hpos.getValue(), 0);
+
+        hpos.setValue(0.5f);
+        hpos.setLayoutType(HorizontalPositioning.RELATIVE_TO_LEFT);
+        assertEquals(100f, hpos.getPixelValue(SIZE), 0);
+
+        assertThrowsIAE("setValue", () -> hpos.setValue(2));
+        assertEquals(0.5f, hpos.getValue(), 0);
+
+        hpos.set(20, HorizontalPositioning.ABSOLUTE_FROM_RIGHT);
+        assertEquals(180f, hpos.getPixelValue(SIZE), 0);
+        assertThrowsIAE("set", () -> hpos.set(2, HorizontalPositioning.RELATIVE_TO_CENTER));
+
+        final VerticalPosition vpos = new VerticalPosition(50, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        assertThrowsIAE("setLayoutType", () -> vpos.setLayoutType(VerticalPositioning.RELATIVE_TO_TOP));
+        vpos.setValue(-0.5f);
+        vpos.setLayoutType(VerticalPositioning.RELATIVE_TO_BOTTOM);
+        assertEquals(100f, vpos.getPixelValue(SIZE), 0);
+        assertThrowsIAE("setValue", () -> vpos.setValue(-2));
+    }
+
+    @Test
+    public void sizeMetric_getPixelValue_perMode() {
+        assertEquals(30f, new SizeMetric(30, SizeMode.ABSOLUTE).getPixelValue(SIZE), 0);
+        assertEquals(30f, new SizeMetric(30, SizeMode.ABSOLUTE).getPixelValue(0), 0);
+        assertEquals(50f, new SizeMetric(0.25f, SizeMode.RELATIVE).getPixelValue(SIZE), 0);
+        assertEquals(0f, new SizeMetric(0, SizeMode.RELATIVE).getPixelValue(SIZE), 0);
+        assertEquals(200f, new SizeMetric(1, SizeMode.RELATIVE).getPixelValue(SIZE), 0);
+        assertEquals(200f, new SizeMetric(0, SizeMode.FILL).getPixelValue(SIZE), 0);
+        assertEquals(170f, new SizeMetric(30, SizeMode.FILL).getPixelValue(SIZE), 0);
+    }
+
+    @Test
+    public void sizeMetric_relativeOutOfRange_throws() {
+        assertThrowsIAE("1.01", () -> new SizeMetric(1.01f, SizeMode.RELATIVE));
+        assertThrowsIAE("-0.01", () -> new SizeMetric(-0.01f, SizeMode.RELATIVE));
+
+        final SizeMetric metric = new SizeMetric(5, SizeMode.ABSOLUTE);
+        assertThrowsIAE("setLayoutType", () -> metric.setLayoutType(SizeMode.RELATIVE));
+        assertEquals(SizeMode.ABSOLUTE, metric.getLayoutType());
+        metric.setLayoutType(SizeMode.FILL);
+        assertEquals(195f, metric.getPixelValue(SIZE), 0);
+        assertThrowsIAE("set", () -> metric.set(5, SizeMode.RELATIVE));
+        metric.set(0.5f, SizeMode.RELATIVE);
+        assertEquals(100f, metric.getPixelValue(SIZE), 0);
+        assertThrowsIAE("setValue", () -> metric.setValue(5));
+
+        // absolute and fill accept anything, including negatives:
+        new SizeMetric(-5, SizeMode.ABSOLUTE);
+        new SizeMetric(-5, SizeMode.FILL);
+    }
+
+    @Test
+    public void size_getRectF_appliesEachMetricToMatchingCanvasDimension() {
+        final RectF canvas = new RectF(50, 60, 250, 160); // 200 x 100
+        assertEquals(new RectF(0, 0, 40, 30),
+                new Size(30, SizeMode.ABSOLUTE, 40, SizeMode.ABSOLUTE).getRectF(canvas));
+        assertEquals(new RectF(0, 0, 100, 25),
+                new Size(0.25f, SizeMode.RELATIVE, 0.5f, SizeMode.RELATIVE).getRectF(canvas));
+        assertEquals(new RectF(0, 0, 190, 90),
+                new Size(10, SizeMode.FILL, 10, SizeMode.FILL).getRectF(canvas));
+        assertEquals(new RectF(0, 0, 200, 100), Size.FILL.getRectF(canvas));
+    }
+
+    @Test
+    public void size_setters_replaceMetrics() {
+        final Size size = new Size(1, SizeMode.ABSOLUTE, 2, SizeMode.ABSOLUTE);
+        final SizeMetric height = new SizeMetric(0.5f, SizeMode.RELATIVE);
+        final SizeMetric width = new SizeMetric(0, SizeMode.FILL);
+        size.setHeight(height);
+        size.setWidth(width);
+        assertSame(height, size.getHeight());
+        assertSame(width, size.getWidth());
+
+        final Size fromMetrics = new Size(height, width);
+        assertSame(height, fromMetrics.getHeight());
+        assertSame(width, fromMetrics.getWidth());
+    }
+
+    @Test
+    public void positionMetrics_constructorAndSetters() {
+        final PositionMetrics metrics = new PositionMetrics(
+                10, HorizontalPositioning.ABSOLUTE_FROM_RIGHT,
+                0.5f, VerticalPositioning.RELATIVE_TO_TOP, Anchor.RIGHT_MIDDLE);
+        assertEquals(10f, metrics.getXPositionMetric().getValue(), 0);
+        assertEquals(HorizontalPositioning.ABSOLUTE_FROM_RIGHT, metrics.getXPositionMetric().getLayoutType());
+        assertEquals(0.5f, metrics.getYPositionMetric().getValue(), 0);
+        assertEquals(VerticalPositioning.RELATIVE_TO_TOP, metrics.getYPositionMetric().getLayoutType());
+        assertEquals(Anchor.RIGHT_MIDDLE, metrics.getAnchor());
+
+        final HorizontalPosition hpos = new HorizontalPosition(1, HorizontalPositioning.ABSOLUTE_FROM_LEFT);
+        final VerticalPosition vpos = new VerticalPosition(2, VerticalPositioning.ABSOLUTE_FROM_BOTTOM);
+        metrics.setXPositionMetric(hpos);
+        metrics.setYPositionMetric(vpos);
+        metrics.setAnchor(Anchor.CENTER);
+        assertSame(hpos, metrics.getXPositionMetric());
+        assertSame(vpos, metrics.getYPositionMetric());
+        assertEquals(Anchor.CENTER, metrics.getAnchor());
+
+        // layer depth is never set, so all instances compare equal:
+        assertEquals(0, metrics.compareTo(new PositionMetrics(
+                0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP)));
+    }
+
+    @Test
+    public void boxModel_defaultConstructor_isZeroEverywhere() {
+        final BoxModel model = new BoxModel();
+        final RectF rect = new RectF(10, 20, 110, 220);
+        assertEquals(rect, model.getMarginatedRect(rect));
+        assertEquals(rect, model.getPaddedRect(rect));
+    }
+
+    @Test
+    public void boxModel_fullConstructor_insetsRects() {
+        final BoxModel model = new BoxModel(1, 2, 3, 4, 5, 6, 7, 8);
+        assertEquals(1f, model.getMarginLeft(), 0);
+        assertEquals(2f, model.getMarginTop(), 0);
+        assertEquals(3f, model.getMarginRight(), 0);
+        assertEquals(4f, model.getMarginBottom(), 0);
+        assertEquals(5f, model.getPaddingLeft(), 0);
+        assertEquals(6f, model.getPaddingTop(), 0);
+        assertEquals(7f, model.getPaddingRight(), 0);
+        assertEquals(8f, model.getPaddingBottom(), 0);
+
+        final RectF rect = new RectF(10, 20, 110, 220);
+        final RectF marginated = model.getMarginatedRect(rect);
+        assertEquals(new RectF(11, 22, 107, 216), marginated);
+        assertEquals(new RectF(16, 28, 100, 208), model.getPaddedRect(marginated));
+    }
+
+    @Test
+    public void boxModel_setMarginsAndPadding_orderIsLeftTopRightBottom() {
+        final BoxModel model = new BoxModel();
+        model.setMargins(1, 2, 3, 4);
+        model.setPadding(5, 6, 7, 8);
+        assertEquals(1f, model.getMarginLeft(), 0);
+        assertEquals(2f, model.getMarginTop(), 0);
+        assertEquals(3f, model.getMarginRight(), 0);
+        assertEquals(4f, model.getMarginBottom(), 0);
+        assertEquals(5f, model.getPaddingLeft(), 0);
+        assertEquals(6f, model.getPaddingTop(), 0);
+        assertEquals(7f, model.getPaddingRight(), 0);
+        assertEquals(8f, model.getPaddingBottom(), 0);
+    }
+
+    @Test
+    public void insets_constructorOrderIsTopBottomLeftRight() {
+        final Insets insets = new Insets(1, 2, 3, 4);
+        assertEquals(1f, insets.getTop(), 0);
+        assertEquals(2f, insets.getBottom(), 0);
+        assertEquals(3f, insets.getLeft(), 0);
+        assertEquals(4f, insets.getRight(), 0);
+    }
+
+    private static void assertThrowsIAE(String message, Runnable runnable) {
+        try {
+            runnable.run();
+            fail("expected IllegalArgumentException: " + message);
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/ui/widget/WidgetLayoutTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/ui/widget/WidgetLayoutTest.java
@@ -1,0 +1,484 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.ui.widget;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.PointF;
+import android.graphics.RectF;
+
+import androidx.annotation.NonNull;
+
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.Anchor;
+import com.androidplot.ui.HorizontalPositioning;
+import com.androidplot.ui.LayoutManager;
+import com.androidplot.ui.PositionMetrics;
+import com.androidplot.ui.Size;
+import com.androidplot.ui.SizeMetric;
+import com.androidplot.ui.SizeMode;
+import com.androidplot.ui.VerticalPositioning;
+import com.androidplot.util.DisplayDimensions;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Layout math of {@link Widget}: how size mode, positioning mode, anchor, box model and
+ * rotation combine into the widget's on-screen rect.
+ */
+public class WidgetLayoutTest extends AndroidplotTest {
+
+    // the plot's padded rect is what widgets are laid out against; canvas and marginated rects
+    // are deliberately different so a widget accidentally using them is caught.
+    private static final RectF CANVAS_RECT = new RectF(0, 0, 300, 200);
+    private static final RectF MARGINATED_RECT = new RectF(5, 5, 295, 195);
+    private static final RectF PADDED_RECT = new RectF(10, 20, 210, 120); // 200 x 100
+
+    private static final float WIDGET_W = 40;
+    private static final float WIDGET_H = 30;
+
+    private static final float ABS_X = 30;
+    private static final float ABS_Y = 10;
+    private static final float REL = 0.25f;
+
+    @Mock
+    Canvas canvas;
+
+    LayoutManager layoutManager;
+    DisplayDimensions plotDims;
+
+    @Before
+    public void setUp() {
+        layoutManager = new LayoutManager();
+        plotDims = new DisplayDimensions(CANVAS_RECT, MARGINATED_RECT, PADDED_RECT);
+    }
+
+    /**
+     * Expected x (relative to the padded rect's left edge) of the anchor point for each
+     * horizontal positioning, computed independently of {@link com.androidplot.ui.PositionMetric}.
+     */
+    private static float expectedAnchorX(HorizontalPositioning positioning) {
+        final float w = PADDED_RECT.width(); // 200
+        switch (positioning) {
+            case ABSOLUTE_FROM_LEFT:
+                return ABS_X;                       // 30
+            case ABSOLUTE_FROM_RIGHT:
+                return w - ABS_X;                   // 170
+            case ABSOLUTE_FROM_CENTER:
+                return w / 2 + ABS_X;               // 130
+            case RELATIVE_TO_LEFT:
+                return w * REL;                     // 50
+            case RELATIVE_TO_RIGHT:
+                return w + w * -REL;                // 150 (negative value moves inward)
+            case RELATIVE_TO_CENTER:
+                return w / 2 + (w / 2) * REL;       // 125
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private static float valueFor(HorizontalPositioning positioning) {
+        switch (positioning) {
+            case ABSOLUTE_FROM_LEFT:
+            case ABSOLUTE_FROM_RIGHT:
+            case ABSOLUTE_FROM_CENTER:
+                return ABS_X;
+            case RELATIVE_TO_RIGHT:
+                return -REL;
+            default:
+                return REL;
+        }
+    }
+
+    private static float expectedAnchorY(VerticalPositioning positioning) {
+        final float h = PADDED_RECT.height(); // 100
+        switch (positioning) {
+            case ABSOLUTE_FROM_TOP:
+                return ABS_Y;                       // 10
+            case ABSOLUTE_FROM_BOTTOM:
+                return h - ABS_Y;                   // 90
+            case ABSOLUTE_FROM_CENTER:
+                return h / 2 + ABS_Y;               // 60
+            case RELATIVE_TO_TOP:
+                return h * REL;                     // 25
+            case RELATIVE_TO_BOTTOM:
+                return h + h * -REL;                // 75
+            case RELATIVE_TO_CENTER:
+                return h / 2 + (h / 2) * REL;       // 62.5
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    private static float valueFor(VerticalPositioning positioning) {
+        switch (positioning) {
+            case ABSOLUTE_FROM_TOP:
+            case ABSOLUTE_FROM_BOTTOM:
+            case ABSOLUTE_FROM_CENTER:
+                return ABS_Y;
+            case RELATIVE_TO_BOTTOM:
+                return -REL;
+            default:
+                return REL;
+        }
+    }
+
+    /**
+     * Offset of the anchor point from the widget's top-left corner, for a 40 x 30 widget.
+     */
+    private static PointF anchorOffset(Anchor anchor) {
+        switch (anchor) {
+            case LEFT_TOP:
+                return new PointF(0, 0);
+            case LEFT_MIDDLE:
+                return new PointF(0, 15);
+            case LEFT_BOTTOM:
+                return new PointF(0, 30);
+            case RIGHT_TOP:
+                return new PointF(40, 0);
+            case RIGHT_MIDDLE:
+                return new PointF(40, 15);
+            case RIGHT_BOTTOM:
+                return new PointF(40, 30);
+            case TOP_MIDDLE:
+                return new PointF(20, 0);
+            case BOTTOM_MIDDLE:
+                return new PointF(20, 30);
+            case CENTER:
+                return new PointF(20, 15);
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+
+    @Test
+    public void layout_everyPositioningAndAnchorCombination_producesExpectedRect() {
+        for (HorizontalPositioning hp : HorizontalPositioning.values()) {
+            for (VerticalPositioning vp : VerticalPositioning.values()) {
+                for (Anchor anchor : Anchor.values()) {
+                    final String combo = hp + " / " + vp + " / " + anchor;
+                    final Widget widget = newAbsoluteWidget();
+                    widget.position(valueFor(hp), hp, valueFor(vp), vp, anchor);
+                    widget.layout(plotDims);
+
+                    final PointF offset = anchorOffset(anchor);
+                    final float expectedLeft = PADDED_RECT.left + expectedAnchorX(hp) - offset.x;
+                    final float expectedTop = PADDED_RECT.top + expectedAnchorY(vp) - offset.y;
+
+                    final RectF actual = widget.getWidgetDimensions().canvasRect;
+                    assertEquals(combo + " left", expectedLeft, actual.left, 0);
+                    assertEquals(combo + " top", expectedTop, actual.top, 0);
+                    assertEquals(combo + " right", expectedLeft + WIDGET_W, actual.right, 0);
+                    assertEquals(combo + " bottom", expectedTop + WIDGET_H, actual.bottom, 0);
+
+                    // the anchor point of the resulting rect must be back where we asked for it:
+                    final PointF anchorCoords = Widget.getAnchorCoordinates(actual, anchor);
+                    assertEquals(combo + " anchor x",
+                            PADDED_RECT.left + expectedAnchorX(hp), anchorCoords.x, 0);
+                    assertEquals(combo + " anchor y",
+                            PADDED_RECT.top + expectedAnchorY(vp), anchorCoords.y, 0);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void layout_positionWithoutAnchor_defaultsToLeftTop() {
+        final Widget widget = newAbsoluteWidget();
+        widget.position(ABS_X, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                ABS_Y, VerticalPositioning.ABSOLUTE_FROM_TOP);
+        widget.layout(plotDims);
+        assertEquals(Anchor.LEFT_TOP, widget.getAnchor());
+        assertEquals(new RectF(40, 30, 80, 60), widget.getWidgetDimensions().canvasRect);
+    }
+
+    @Test
+    public void layout_fillSize_fillsPaddedRect() {
+        final Widget widget = new TestWidget(layoutManager,
+                new Size(0, SizeMode.FILL, 0, SizeMode.FILL));
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP);
+        widget.layout(plotDims);
+        assertEquals(PADDED_RECT, widget.getWidgetDimensions().canvasRect);
+    }
+
+    @Test
+    public void layout_fillSizeWithValue_subtractsValueFromPaddedRect() {
+        final Widget widget = new TestWidget(layoutManager,
+                new Size(10, SizeMode.FILL, 30, SizeMode.FILL));
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP);
+        widget.layout(plotDims);
+        assertEquals(new RectF(10, 20, 10 + 200 - 30, 20 + 100 - 10),
+                widget.getWidgetDimensions().canvasRect);
+    }
+
+    @Test
+    public void layout_relativeSize_scalesWithPaddedRect() {
+        final Widget widget = new TestWidget(layoutManager,
+                new Size(0.5f, SizeMode.RELATIVE, 0.25f, SizeMode.RELATIVE));
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP);
+        widget.layout(plotDims);
+        assertEquals(new RectF(10, 20, 10 + 50, 20 + 50), widget.getWidgetDimensions().canvasRect);
+
+        // resizing the plot re-derives the widget rect:
+        widget.layout(new DisplayDimensions(CANVAS_RECT, MARGINATED_RECT,
+                new RectF(0, 0, 400, 400)));
+        assertEquals(new RectF(0, 0, 100, 200), widget.getWidgetDimensions().canvasRect);
+    }
+
+    @Test
+    public void layout_mixedSizeModes_relativeCenterAnchor() {
+        // 50% wide, 20px tall, centered in the padded rect
+        final Widget widget = new TestWidget(layoutManager,
+                new Size(20, SizeMode.ABSOLUTE, 0.5f, SizeMode.RELATIVE));
+        widget.position(0, HorizontalPositioning.RELATIVE_TO_CENTER,
+                0, VerticalPositioning.RELATIVE_TO_CENTER, Anchor.CENTER);
+        widget.layout(plotDims);
+        assertEquals(new RectF(110 - 50, 70 - 10, 110 + 50, 70 + 10),
+                widget.getWidgetDimensions().canvasRect);
+    }
+
+    @Test
+    public void setWidthAndHeight_updateSizeMetrics() {
+        final Widget widget = newAbsoluteWidget();
+        widget.setWidth(70);
+        widget.setHeight(60);
+        assertEquals(70f, widget.getWidthMetric().getValue(), 0);
+        assertEquals(60f, widget.getHeightMetric().getValue(), 0);
+        assertEquals(SizeMode.ABSOLUTE, widget.getWidthMetric().getLayoutType());
+
+        widget.setWidth(0.5f, SizeMode.RELATIVE);
+        widget.setHeight(0, SizeMode.FILL);
+        assertEquals(SizeMode.RELATIVE, widget.getWidthMetric().getLayoutType());
+        assertEquals(SizeMode.FILL, widget.getHeightMetric().getLayoutType());
+        assertEquals(100f, widget.getWidthPix(200), 0);
+        assertEquals(100f, widget.getHeightPix(100), 0);
+    }
+
+    @Test
+    public void layout_marginsAndPadding_produceMarginatedAndPaddedRects() {
+        final Widget widget = newAbsoluteWidget();
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP);
+        widget.setMargins(1, 2, 3, 4);
+        widget.setPadding(5, 6, 7, 8);
+        widget.layout(plotDims);
+
+        final DisplayDimensions dims = widget.getWidgetDimensions();
+        assertEquals(new RectF(10, 20, 50, 50), dims.canvasRect);
+        assertEquals(new RectF(11, 22, 47, 46), dims.marginatedRect);
+        assertEquals(new RectF(16, 28, 40, 38), dims.paddedRect);
+
+        assertEquals(1f, widget.getMarginLeft(), 0);
+        assertEquals(2f, widget.getMarginTop(), 0);
+        assertEquals(3f, widget.getMarginRight(), 0);
+        assertEquals(4f, widget.getMarginBottom(), 0);
+        assertEquals(5f, widget.getPaddingLeft(), 0);
+        assertEquals(6f, widget.getPaddingTop(), 0);
+        assertEquals(7f, widget.getPaddingRight(), 0);
+        assertEquals(8f, widget.getPaddingBottom(), 0);
+    }
+
+    @Test
+    public void individualMarginAndPaddingSetters_delegateToBoxModel() {
+        final Widget widget = newAbsoluteWidget();
+        widget.setMarginLeft(1);
+        widget.setMarginTop(2);
+        widget.setMarginRight(3);
+        widget.setMarginBottom(4);
+        widget.setPaddingLeft(5);
+        widget.setPaddingTop(6);
+        widget.setPaddingRight(7);
+        widget.setPaddingBottom(8);
+
+        final RectF rect = new RectF(100, 100, 200, 200);
+        assertEquals(new RectF(101, 102, 197, 196), widget.getMarginatedRect(rect));
+        assertEquals(new RectF(105, 106, 193, 192), widget.getPaddedRect(rect));
+    }
+
+    @Test
+    public void refreshLayout_withoutPositionMetrics_isNoOp() {
+        final Widget widget = newAbsoluteWidget();
+        assertNull(widget.getPositionMetrics());
+        widget.layout(plotDims);
+        // untouched default dims:
+        assertEquals(new RectF(1, 1, 1, 1), widget.getWidgetDimensions().canvasRect);
+    }
+
+    @Test
+    public void containsPoint_usesWidgetCanvasRect() {
+        final Widget widget = newAbsoluteWidget();
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP);
+        widget.layout(plotDims);
+        assertTrue(widget.containsPoint(new PointF(10, 20)));
+        assertTrue(widget.containsPoint(new PointF(49, 49)));
+        assertFalse(widget.containsPoint(new PointF(9, 20)));
+        assertFalse(widget.containsPoint(new PointF(50, 50)));
+    }
+
+    @Test
+    public void calculateCoordinates_offsetsByViewRectOrigin() {
+        final PositionMetrics metrics = new PositionMetrics(
+                0, HorizontalPositioning.ABSOLUTE_FROM_RIGHT,
+                0, VerticalPositioning.ABSOLUTE_FROM_BOTTOM, Anchor.RIGHT_BOTTOM);
+        final PointF coords = Widget.calculateCoordinates(30, 40, PADDED_RECT, metrics);
+        assertEquals(PADDED_RECT.right - 40, coords.x, 0);
+        assertEquals(PADDED_RECT.bottom - 30, coords.y, 0);
+    }
+
+    @Test
+    public void getAnchorCoordinates_byOriginAndSize_matchesRectOverload() {
+        for (Anchor anchor : Anchor.values()) {
+            final PointF fromRect = Widget.getAnchorCoordinates(new RectF(10, 20, 50, 50), anchor);
+            final PointF fromCoords = Widget.getAnchorCoordinates(10, 20, 40, 30, anchor);
+            assertEquals(anchor.toString(), fromRect, fromCoords);
+            final PointF offset = anchorOffset(anchor);
+            assertEquals(anchor.toString(), new PointF(10 + offset.x, 20 + offset.y), fromRect);
+        }
+    }
+
+    @Test
+    public void draw_rotationNone_drawsUnrotatedPaddedRect() {
+        final Widget widget = layoutRotated(Widget.Rotation.NONE);
+        widget.draw(canvas);
+
+        assertEquals(new RectF(10, 20, 50, 50), capturedDrawRect(widget));
+        verify(canvas, never()).rotate(anyFloat(), anyFloat(), anyFloat());
+        verify(canvas).save();
+        verify(canvas).restore();
+    }
+
+    @Test
+    public void draw_rotation90_swapsDimensionsAboutCenterAndRotatesCanvas() {
+        final Widget widget = layoutRotated(Widget.Rotation.NINETY_DEGREES);
+        widget.draw(canvas);
+
+        // 40 x 30 rect centered at (30, 35) becomes 30 x 40 about the same center:
+        assertEquals(new RectF(15, 15, 45, 55), capturedDrawRect(widget));
+        verify(canvas).rotate(90, 30, 35);
+    }
+
+    @Test
+    public void draw_rotationNegative90_swapsDimensionsAboutCenterAndRotatesCanvas() {
+        final Widget widget = layoutRotated(Widget.Rotation.NEGATIVE_NINETY_DEGREES);
+        widget.draw(canvas);
+
+        assertEquals(new RectF(15, 15, 45, 55), capturedDrawRect(widget));
+        verify(canvas).rotate(-90, 30, 35);
+    }
+
+    @Test
+    public void draw_rotation180_keepsRectAndRotatesCanvas() {
+        final Widget widget = layoutRotated(Widget.Rotation.ONE_HUNDRED_EIGHTY_DEGREES);
+        widget.draw(canvas);
+
+        assertEquals(new RectF(10, 20, 50, 50), capturedDrawRect(widget));
+        verify(canvas).rotate(180, 30, 35);
+    }
+
+    @Test
+    public void draw_withBackgroundAndBorderPaint_drawsBoth() {
+        final Widget widget = layoutRotated(Widget.Rotation.NINETY_DEGREES);
+        final Paint background = new Paint();
+        final Paint border = new Paint();
+        widget.setBackgroundPaint(background);
+        widget.setBorderPaint(border);
+
+        widget.draw(canvas);
+
+        // background covers the unrotated widget rect; border follows the rotated draw rect:
+        verify(canvas).drawRect(new RectF(10, 20, 50, 50), background);
+        verify(canvas).drawRect(new RectF(15, 15, 45, 55), border);
+    }
+
+    @Test
+    public void draw_invisible_drawsNothing() {
+        final Widget widget = layoutRotated(Widget.Rotation.NONE);
+        widget.setBackgroundPaint(new Paint());
+        widget.setBorderPaint(new Paint());
+        widget.setVisible(false);
+
+        widget.draw(canvas);
+
+        verify(widget, never()).doOnDraw(any(Canvas.class), any(RectF.class));
+        verify(canvas, never()).drawRect(any(RectF.class), any(Paint.class));
+    }
+
+    @Test
+    public void draw_calledTwiceWithSameRect_invokesOnResizeOnce() {
+        final Widget widget = layoutRotated(Widget.Rotation.NONE);
+        widget.draw(canvas);
+        widget.draw(canvas);
+        verify(widget).onResize(any(), any(RectF.class));
+
+        // a new size triggers another resize callback with the previous rect:
+        widget.setWidth(80);
+        widget.layout(plotDims);
+        widget.draw(canvas);
+        verify(widget).onResize(eq(new RectF(10, 20, 50, 50)), eq(new RectF(10, 20, 90, 50)));
+    }
+
+    @Test
+    public void constructor_withSizeMetrics_buildsSize() {
+        final Widget widget = new TestWidget(layoutManager,
+                new SizeMetric(30, SizeMode.ABSOLUTE), new SizeMetric(0.5f, SizeMode.RELATIVE));
+        assertEquals(30f, widget.getHeightMetric().getValue(), 0);
+        assertEquals(SizeMode.RELATIVE, widget.getWidthMetric().getLayoutType());
+        assertEquals(Widget.Rotation.NONE, widget.getRotation());
+        assertFalse(widget.isClippingEnabled());
+        widget.setClippingEnabled(true);
+        assertTrue(widget.isClippingEnabled());
+    }
+
+    private Widget layoutRotated(Widget.Rotation rotation) {
+        final Widget widget = spy(newAbsoluteWidget());
+        widget.position(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                0, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP);
+        widget.setRotation(rotation);
+        widget.layout(plotDims);
+        assertEquals(rotation, widget.getRotation());
+        return widget;
+    }
+
+    private static RectF capturedDrawRect(Widget widget) {
+        final ArgumentCaptor<RectF> captor = ArgumentCaptor.forClass(RectF.class);
+        verify(widget).doOnDraw(any(Canvas.class), captor.capture());
+        return captor.getValue();
+    }
+
+    private Widget newAbsoluteWidget() {
+        return new TestWidget(layoutManager,
+                new Size(WIDGET_H, SizeMode.ABSOLUTE, WIDGET_W, SizeMode.ABSOLUTE));
+    }
+
+    static class TestWidget extends Widget {
+        TestWidget(@NonNull LayoutManager layoutManager, @NonNull Size size) {
+            super(layoutManager, size);
+        }
+
+        TestWidget(@NonNull LayoutManager layoutManager, SizeMetric height, SizeMetric width) {
+            super(layoutManager, height, width);
+        }
+
+        @Override
+        protected void doOnDraw(Canvas canvas, RectF widgetRect) {
+            // nothing to do
+        }
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/util/AttrUtilsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/AttrUtilsTest.java
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util;
+
+import android.content.res.TypedArray;
+import android.graphics.Paint;
+import android.util.TypedValue;
+
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.Anchor;
+import com.androidplot.ui.HorizontalPositioning;
+import com.androidplot.ui.Insets;
+import com.androidplot.ui.PositionMetrics;
+import com.androidplot.ui.Size;
+import com.androidplot.ui.SizeMode;
+import com.androidplot.ui.VerticalPositioning;
+import com.androidplot.xy.StepMode;
+import com.androidplot.xy.StepModel;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Edge cases of {@link AttrUtils} that cannot be reached through a real AttributeSet
+ * (null guards, unsupported value types); the happy paths are covered end to end by
+ * {@link com.androidplot.xy.XYPlotAttrsTest}.
+ */
+public class AttrUtilsTest extends AndroidplotTest {
+
+    private static final int ATTR_A = 1;
+    private static final int ATTR_B = 2;
+    private static final int ATTR_C = 3;
+    private static final int ATTR_D = 4;
+
+    @Mock
+    TypedArray attrs;
+
+    @Before
+    public void setUp() {
+        // behave like an empty attribute set: every lookup returns its default
+        final Answer<Object> returnDefault = new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                return invocation.getArgument(1);
+            }
+        };
+        when(attrs.getBoolean(anyInt(), anyBoolean())).thenAnswer(returnDefault);
+        when(attrs.getInt(anyInt(), anyInt())).thenAnswer(returnDefault);
+        when(attrs.getFloat(anyInt(), anyFloat())).thenAnswer(returnDefault);
+        when(attrs.getDimension(anyInt(), anyFloat())).thenAnswer(returnDefault);
+        when(attrs.getColor(anyInt(), anyInt())).thenAnswer(returnDefault);
+    }
+
+    @Test
+    public void nullAttrs_areIgnored() {
+        final Paint paint = new Paint();
+        paint.setColor(0xFF123456);
+        paint.setTextSize(11);
+        paint.setStrokeWidth(3);
+        AttrUtils.configureTextPaint(null, paint, ATTR_A, ATTR_B);
+        AttrUtils.configureTextPaint(null, paint, ATTR_A, ATTR_B, ATTR_C);
+        AttrUtils.configureTextAlign(null, paint, ATTR_A);
+        AttrUtils.configureLinePaint(null, paint, ATTR_A, ATTR_B);
+        assertEquals(0xFF123456, paint.getColor());
+        assertEquals(11f, paint.getTextSize(), 0);
+        assertEquals(3f, paint.getStrokeWidth(), 0);
+
+        final Size size = new Size(1, SizeMode.ABSOLUTE, 2, SizeMode.ABSOLUTE);
+        AttrUtils.configureSize(null, size, ATTR_A, ATTR_B, ATTR_C, ATTR_D);
+        assertEquals(1f, size.getHeight().getValue(), 0);
+        assertEquals(2f, size.getWidth().getValue(), 0);
+
+        final PositionMetrics metrics = new PositionMetrics(1, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                2, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.CENTER);
+        AttrUtils.configurePositionMetrics(null, metrics, ATTR_A, ATTR_B, ATTR_C, ATTR_D, ATTR_A);
+        assertEquals(Anchor.CENTER, metrics.getAnchor());
+
+        final StepModel step = new StepModel(StepMode.INCREMENT_BY_VAL, 5);
+        AttrUtils.configureStep(null, step, ATTR_A, ATTR_B);
+        assertEquals(StepMode.INCREMENT_BY_VAL, step.getMode());
+        assertEquals(5.0, step.getValue(), 0);
+    }
+
+    @Test
+    public void configurePositionMetrics_nullMetrics_isIgnored() {
+        AttrUtils.configurePositionMetrics(attrs, null, ATTR_A, ATTR_B, ATTR_C, ATTR_D, ATTR_A);
+        verifyNoInteractions(attrs);
+    }
+
+    @Test
+    public void setColor_nullPaint_isIgnored() {
+        AttrUtils.setColor(attrs, null, ATTR_A);
+        verify(attrs, never()).getColor(anyInt(), anyInt());
+    }
+
+    @Test
+    public void configureTextPaint_alignAttrWithoutValue_keepsAlignment() {
+        final Paint paint = new Paint();
+        paint.setTextAlign(Paint.Align.RIGHT);
+        when(attrs.hasValue(ATTR_C)).thenReturn(false);
+        AttrUtils.configureTextPaint(attrs, paint, ATTR_A, ATTR_B, ATTR_C);
+        assertEquals(Paint.Align.RIGHT, paint.getTextAlign());
+
+        when(attrs.hasValue(ATTR_C)).thenReturn(true);
+        when(attrs.getInt(eq(ATTR_C), anyInt())).thenReturn(Paint.Align.CENTER.ordinal());
+        AttrUtils.configureTextPaint(attrs, paint, ATTR_A, ATTR_B, ATTR_C);
+        assertEquals(Paint.Align.CENTER, paint.getTextAlign());
+    }
+
+    @Test
+    public void configureInsets_appliesEachEdge() {
+        final Insets insets = new Insets(1, 2, 3, 4);
+        when(attrs.getDimension(eq(ATTR_A), anyFloat())).thenReturn(10f);
+        when(attrs.getDimension(eq(ATTR_C), anyFloat())).thenReturn(30f);
+        AttrUtils.configureInsets(attrs, insets, ATTR_A, ATTR_B, ATTR_C, ATTR_D);
+        assertEquals(10f, insets.getTop(), 0);
+        assertEquals(2f, insets.getBottom(), 0);
+        assertEquals(30f, insets.getLeft(), 0);
+        assertEquals(4f, insets.getRight(), 0);
+    }
+
+    @Test
+    public void intFloatDimenValue_unsupportedType_throws() {
+        final TypedValue stringValue = new TypedValue();
+        stringValue.type = TypedValue.TYPE_STRING;
+        when(attrs.hasValue(ATTR_B)).thenReturn(true);
+        when(attrs.peekValue(ATTR_B)).thenReturn(stringValue);
+
+        final StepModel step = new StepModel(StepMode.SUBDIVIDE, 5);
+        try {
+            AttrUtils.configureStep(attrs, step, ATTR_A, ATTR_B);
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+        assertEquals(5.0, step.getValue(), 0);
+    }
+
+    @Test
+    public void intFloatDimenValue_intType_usesGetInt() {
+        final TypedValue intValue = new TypedValue();
+        intValue.type = TypedValue.TYPE_INT_DEC;
+        when(attrs.hasValue(ATTR_B)).thenReturn(true);
+        when(attrs.peekValue(ATTR_B)).thenReturn(intValue);
+        when(attrs.getInt(eq(ATTR_B), anyInt())).thenReturn(42);
+
+        final StepModel step = new StepModel(StepMode.SUBDIVIDE, 5);
+        AttrUtils.configureStep(attrs, step, ATTR_A, ATTR_B);
+        assertEquals(42.0, step.getValue(), 0);
+        verify(attrs, never()).getFloat(eq(ATTR_B), anyFloat());
+        verify(attrs, never()).getDimension(eq(ATTR_B), anyFloat());
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/util/AttrsXmlEnumSyncTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/AttrsXmlEnumSyncTest.java
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util;
+
+import android.graphics.Paint;
+
+import com.androidplot.Plot;
+import com.androidplot.R;
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.Anchor;
+import com.androidplot.ui.HorizontalPositioning;
+import com.androidplot.ui.SizeMode;
+import com.androidplot.ui.VerticalPositioning;
+import com.androidplot.ui.widget.Widget;
+import com.androidplot.xy.StepMode;
+import com.androidplot.xy.XYGraphWidget;
+import com.androidplot.xy.XYGraphWidget.Edge;
+import com.androidplot.xy.XYPlot;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.android.AttributeSetBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * {@link AttrUtils} (and Plot / XYPlot) map XML enum attrs to Java enums by ordinal, so the
+ * {@code <enum name="..." value="..."/>} declarations in attrs.xml must stay in sync with the
+ * Java enum declarations.  This test parses attrs.xml from source and, for every declared enum
+ * value, inflates an XYPlot with that value and checks the resulting Java enum constant has the
+ * declared ordinal.  Every enum attr in attrs.xml must be listed in {@link #enumAttrs()}.
+ */
+public class AttrsXmlEnumSyncTest extends AndroidplotTest {
+
+    private interface EnumReader {
+        Enum<?> read(XYPlot plot);
+    }
+
+    private static class EnumAttr {
+        final int attrId;
+        final Class<? extends Enum<?>> enumClass;
+        final EnumReader reader;
+        /** an attr that must be set alongside to keep relative modes valid; 0 for none. */
+        final int companionAttrId;
+
+        EnumAttr(int attrId, Class<? extends Enum<?>> enumClass, EnumReader reader) {
+            this(attrId, enumClass, reader, 0);
+        }
+
+        EnumAttr(int attrId, Class<? extends Enum<?>> enumClass, EnumReader reader, int companionAttrId) {
+            this.attrId = attrId;
+            this.enumClass = enumClass;
+            this.reader = reader;
+            this.companionAttrId = companionAttrId;
+        }
+    }
+
+    /**
+     * Java enum constants that attrs.xml deliberately (or historically) does not expose.  Their
+     * ordinals must still be beyond every declared value so the declared ones stay in sync.
+     */
+    private static final Map<String, List<String>> KNOWN_UNDECLARED = new LinkedHashMap<>();
+    static {
+        // INCREMENT_BY_FIT was added to StepMode without a matching <enum> in attrs.xml
+        KNOWN_UNDECLARED.put("domainStepMode", List.of("INCREMENT_BY_FIT"));
+        KNOWN_UNDECLARED.put("rangeStepMode", List.of("INCREMENT_BY_FIT"));
+    }
+
+    private Map<String, EnumAttr> enumAttrs;
+
+    @Before
+    public void setUp() {
+        enumAttrs = enumAttrs();
+    }
+
+    private static Map<String, EnumAttr> enumAttrs() {
+        final Map<String, EnumAttr> m = new LinkedHashMap<>();
+        m.put("renderMode", new EnumAttr(R.attr.renderMode, Plot.RenderMode.class, Plot::getRenderMode));
+        m.put("previewMode", new EnumAttr(R.attr.previewMode, XYPlot.PreviewMode.class,
+                AttrsXmlEnumSyncTest::previewModeOf));
+        m.put("domainStepMode", new EnumAttr(R.attr.domainStepMode, StepMode.class,
+                plot -> plot.getDomainStepModel().getMode()));
+        m.put("rangeStepMode", new EnumAttr(R.attr.rangeStepMode, StepMode.class,
+                plot -> plot.getRangeStepModel().getMode()));
+
+        m.put("lineLabelAlignTop", new EnumAttr(R.attr.lineLabelAlignTop, Paint.Align.class,
+                plot -> plot.getGraph().getLineLabelStyle(Edge.TOP).getPaint().getTextAlign()));
+        m.put("lineLabelAlignBottom", new EnumAttr(R.attr.lineLabelAlignBottom, Paint.Align.class,
+                plot -> plot.getGraph().getLineLabelStyle(Edge.BOTTOM).getPaint().getTextAlign()));
+        m.put("lineLabelAlignLeft", new EnumAttr(R.attr.lineLabelAlignLeft, Paint.Align.class,
+                plot -> plot.getGraph().getLineLabelStyle(Edge.LEFT).getPaint().getTextAlign()));
+        m.put("lineLabelAlignRight", new EnumAttr(R.attr.lineLabelAlignRight, Paint.Align.class,
+                plot -> plot.getGraph().getLineLabelStyle(Edge.RIGHT).getPaint().getTextAlign()));
+
+        m.put("graphAnchor", new EnumAttr(R.attr.graphAnchor, Anchor.class,
+                plot -> plot.getGraph().getAnchor()));
+        m.put("domainTitleAnchor", new EnumAttr(R.attr.domainTitleAnchor, Anchor.class,
+                plot -> plot.getDomainTitle().getAnchor()));
+        m.put("rangeTitleAnchor", new EnumAttr(R.attr.rangeTitleAnchor, Anchor.class,
+                plot -> plot.getRangeTitle().getAnchor()));
+        m.put("legendAnchor", new EnumAttr(R.attr.legendAnchor, Anchor.class,
+                plot -> plot.getLegend().getAnchor()));
+
+        m.put("graphHeightMode", new EnumAttr(R.attr.graphHeightMode, SizeMode.class,
+                plot -> plot.getGraph().getSize().getHeight().getLayoutType(), R.attr.graphHeight));
+        m.put("graphWidthMode", new EnumAttr(R.attr.graphWidthMode, SizeMode.class,
+                plot -> plot.getGraph().getSize().getWidth().getLayoutType(), R.attr.graphWidth));
+        m.put("domainTitleHeightMode", new EnumAttr(R.attr.domainTitleHeightMode, SizeMode.class,
+                plot -> plot.getDomainTitle().getSize().getHeight().getLayoutType(), R.attr.domainTitleHeight));
+        m.put("domainTitleWidthMode", new EnumAttr(R.attr.domainTitleWidthMode, SizeMode.class,
+                plot -> plot.getDomainTitle().getSize().getWidth().getLayoutType(), R.attr.domainTitleWidth));
+        m.put("rangeTitleHeightMode", new EnumAttr(R.attr.rangeTitleHeightMode, SizeMode.class,
+                plot -> plot.getRangeTitle().getSize().getHeight().getLayoutType(), R.attr.rangeTitleHeight));
+        m.put("rangeTitleWidthMode", new EnumAttr(R.attr.rangeTitleWidthMode, SizeMode.class,
+                plot -> plot.getRangeTitle().getSize().getWidth().getLayoutType(), R.attr.rangeTitleWidth));
+        m.put("legendHeightMode", new EnumAttr(R.attr.legendHeightMode, SizeMode.class,
+                plot -> plot.getLegend().getSize().getHeight().getLayoutType(), R.attr.legendHeight));
+        m.put("legendWidthMode", new EnumAttr(R.attr.legendWidthMode, SizeMode.class,
+                plot -> plot.getLegend().getSize().getWidth().getLayoutType(), R.attr.legendWidth));
+        m.put("legendIconHeightMode", new EnumAttr(R.attr.legendIconHeightMode, SizeMode.class,
+                plot -> plot.getLegend().getIconSize().getHeight().getLayoutType(), R.attr.legendIconHeight));
+        m.put("legendIconWidthMode", new EnumAttr(R.attr.legendIconWidthMode, SizeMode.class,
+                plot -> plot.getLegend().getIconSize().getWidth().getLayoutType(), R.attr.legendIconWidth));
+
+        m.put("graphRotation", new EnumAttr(R.attr.graphRotation, Widget.Rotation.class,
+                plot -> plot.getGraph().getRotation()));
+
+        m.put("graphHorizontalPositioning", new EnumAttr(R.attr.graphHorizontalPositioning,
+                HorizontalPositioning.class,
+                plot -> plot.getGraph().getPositionMetrics().getXPositionMetric().getLayoutType(),
+                R.attr.graphHorizontalPosition));
+        m.put("graphVerticalPositioning", new EnumAttr(R.attr.graphVerticalPositioning,
+                VerticalPositioning.class,
+                plot -> plot.getGraph().getPositionMetrics().getYPositionMetric().getLayoutType(),
+                R.attr.graphVerticalPosition));
+        m.put("domainTitleHorizontalPositioning", new EnumAttr(R.attr.domainTitleHorizontalPositioning,
+                HorizontalPositioning.class,
+                plot -> plot.getDomainTitle().getPositionMetrics().getXPositionMetric().getLayoutType(),
+                R.attr.domainTitleHorizontalPosition));
+        m.put("domainTitleVerticalPositioning", new EnumAttr(R.attr.domainTitleVerticalPositioning,
+                VerticalPositioning.class,
+                plot -> plot.getDomainTitle().getPositionMetrics().getYPositionMetric().getLayoutType(),
+                R.attr.domainTitleVerticalPosition));
+        m.put("rangeTitleHorizontalPositioning", new EnumAttr(R.attr.rangeTitleHorizontalPositioning,
+                HorizontalPositioning.class,
+                plot -> plot.getRangeTitle().getPositionMetrics().getXPositionMetric().getLayoutType(),
+                R.attr.rangeTitleHorizontalPosition));
+        m.put("rangeTitleVerticalPositioning", new EnumAttr(R.attr.rangeTitleVerticalPositioning,
+                VerticalPositioning.class,
+                plot -> plot.getRangeTitle().getPositionMetrics().getYPositionMetric().getLayoutType(),
+                R.attr.rangeTitleVerticalPosition));
+        m.put("legendHorizontalPositioning", new EnumAttr(R.attr.legendHorizontalPositioning,
+                HorizontalPositioning.class,
+                plot -> plot.getLegend().getPositionMetrics().getXPositionMetric().getLayoutType(),
+                R.attr.legendHorizontalPosition));
+        m.put("legendVerticalPositioning", new EnumAttr(R.attr.legendVerticalPositioning,
+                VerticalPositioning.class,
+                plot -> plot.getLegend().getPositionMetrics().getYPositionMetric().getLayoutType(),
+                R.attr.legendVerticalPosition));
+        return m;
+    }
+
+    @Test
+    public void everyDeclaredEnumValue_mapsToJavaEnumOfSameOrdinal() throws Exception {
+        final Map<String, Map<String, Integer>> declared = parseEnumAttrs(attrsXml());
+        assertFalse("no enum attrs parsed from attrs.xml", declared.isEmpty());
+
+        for (Map.Entry<String, Map<String, Integer>> attr : declared.entrySet()) {
+            final String attrName = attr.getKey();
+            final EnumAttr enumAttr = enumAttrs.get(attrName);
+            assertNotNull("attrs.xml enum attr '" + attrName
+                    + "' is not covered by AttrsXmlEnumSyncTest.enumAttrs()", enumAttr);
+
+            final Enum<?>[] constants = enumAttr.enumClass.getEnumConstants();
+            final List<String> undeclared = KNOWN_UNDECLARED.getOrDefault(attrName, List.of());
+            assertEquals("number of <enum> values declared for " + attrName + " vs "
+                    + enumAttr.enumClass.getSimpleName() + " (undeclared: " + undeclared + ")",
+                    constants.length - undeclared.size(), attr.getValue().size());
+            for (String name : undeclared) {
+                final Enum<?> constant = Enum.valueOf((Class) enumAttr.enumClass, name);
+                assertTrue(attrName + ": undeclared constant " + name + " must follow all declared values",
+                        constant.ordinal() >= attr.getValue().size());
+            }
+
+            for (Map.Entry<String, Integer> entry : attr.getValue().entrySet()) {
+                final String xmlName = entry.getKey();
+                final int xmlValue = entry.getValue();
+                assertTrue(attrName + "=" + xmlName + " declares out of range value " + xmlValue,
+                        xmlValue >= 0 && xmlValue < constants.length);
+
+                final AttributeSetBuilder builder = Robolectric.buildAttributeSet()
+                        .addAttribute(enumAttr.attrId, xmlName);
+                if (enumAttr.companionAttrId != 0) {
+                    // a value valid for absolute, relative and fill modes alike:
+                    builder.addAttribute(enumAttr.companionAttrId, "0.5");
+                }
+                final XYPlot plot = new XYPlot(getContext(), builder.build());
+                final Enum<?> actual = enumAttr.reader.read(plot);
+                assertEquals(attrName + "=\"" + xmlName + "\" (value " + xmlValue + ") resolved to "
+                        + actual + " (ordinal " + actual.ordinal() + ")", xmlValue, actual.ordinal());
+            }
+        }
+
+        // and nothing in the map that has disappeared from attrs.xml:
+        for (String attrName : enumAttrs.keySet()) {
+            assertTrue("attr '" + attrName + "' is no longer an enum attr in attrs.xml",
+                    declared.containsKey(attrName));
+        }
+    }
+
+    @Test
+    public void lineLabelsFlags_matchEdgeValues() throws Exception {
+        final Map<String, Integer> flags = parseFlagAttr(attrsXml(), "lineLabels");
+        assertEquals(Edge.values().length, flags.size());
+
+        for (Map.Entry<String, Integer> flag : flags.entrySet()) {
+            final Edge edge = Edge.valueOf(flag.getKey().toUpperCase());
+            assertEquals("lineLabels flag " + flag.getKey(), flag.getValue().intValue(), edge.getValue());
+
+            final XYGraphWidget graph = new XYPlot(getContext(), Robolectric.buildAttributeSet()
+                    .addAttribute(R.attr.lineLabels, flag.getKey()).build()).getGraph();
+            for (Edge e : new Edge[]{Edge.TOP, Edge.BOTTOM, Edge.LEFT, Edge.RIGHT}) {
+                assertEquals("lineLabels=" + flag.getKey() + " enables " + e,
+                        e == edge, graph.isLineLabelEnabled(e));
+            }
+        }
+    }
+
+    private static XYPlot.PreviewMode previewModeOf(XYPlot plot) {
+        // there is no public getter; the mode is only consumed in edit mode
+        try {
+            final Field field = XYPlot.class.getDeclaredField("previewMode");
+            field.setAccessible(true);
+            return (XYPlot.PreviewMode) field.get(plot);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static File attrsXml() {
+        final String[] candidates = {
+                "src/main/res/values/attrs.xml",
+                "androidplot-core/src/main/res/values/attrs.xml"};
+        for (String candidate : candidates) {
+            final File file = new File(candidate);
+            if (file.isFile()) {
+                return file;
+            }
+        }
+        fail("attrs.xml not found relative to " + new File(".").getAbsolutePath());
+        return null;
+    }
+
+    /** attr name -> (enum name -> value), for every top level attr that declares enum children. */
+    private static Map<String, Map<String, Integer>> parseEnumAttrs(File attrsXml) throws Exception {
+        final Map<String, Map<String, Integer>> result = new LinkedHashMap<>();
+        for (Element attr : childAttrs(attrsXml)) {
+            final Map<String, Integer> values = childValues(attr, "enum");
+            if (!values.isEmpty()) {
+                result.put(attr.getAttribute("name"), values);
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, Integer> parseFlagAttr(File attrsXml, String name) throws Exception {
+        for (Element attr : childAttrs(attrsXml)) {
+            if (name.equals(attr.getAttribute("name"))) {
+                final Map<String, Integer> values = childValues(attr, "flag");
+                assertFalse("no flags declared for " + name, values.isEmpty());
+                return values;
+            }
+        }
+        fail("no top level attr named " + name);
+        return null;
+    }
+
+    private static List<Element> childAttrs(File attrsXml) throws Exception {
+        final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(attrsXml);
+        final List<Element> attrs = new ArrayList<>();
+        final NodeList children = doc.getDocumentElement().getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            final Node node = children.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE && "attr".equals(node.getNodeName())) {
+                attrs.add((Element) node);
+            }
+        }
+        return attrs;
+    }
+
+    private static Map<String, Integer> childValues(Element attr, String tag) {
+        final Map<String, Integer> values = new LinkedHashMap<>();
+        final NodeList children = attr.getElementsByTagName(tag);
+        for (int i = 0; i < children.getLength(); i++) {
+            final Element child = (Element) children.item(i);
+            values.put(child.getAttribute("name"), Integer.parseInt(child.getAttribute("value")));
+        }
+        return values;
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/util/LinkedLayerListOrganizerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/LinkedLayerListOrganizerTest.java
@@ -10,6 +10,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class LinkedLayerListOrganizerTest {
@@ -25,7 +27,22 @@ public class LinkedLayerListOrganizerTest {
 
     @Test
     public void testMoveToTop() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+        LinkedList<Object> list = new LinkedList<>(Arrays.asList(obj1, obj2, obj3));
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
 
+        assertTrue(organizer.moveToTop(obj1));
+        assertEquals(Arrays.asList(obj2, obj3, obj1), list);
+
+        // already on top:
+        assertTrue(organizer.moveToTop(obj1));
+        assertEquals(Arrays.asList(obj2, obj3, obj1), list);
+
+        // unknown element is not added:
+        assertFalse(organizer.moveToTop(new Object()));
+        assertEquals(Arrays.asList(obj2, obj3, obj1), list);
     }
 
     @Test
@@ -117,21 +134,71 @@ public class LinkedLayerListOrganizerTest {
 
     @Test
     public void testMoveUp() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+        LinkedList<Object> list = new LinkedList<>(Arrays.asList(obj1, obj2, obj3));
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
 
+        assertTrue(organizer.moveUp(obj1));
+        assertEquals(Arrays.asList(obj2, obj1, obj3), list);
+        assertTrue(organizer.moveUp(obj1));
+        assertEquals(Arrays.asList(obj2, obj3, obj1), list);
+
+        // already at the top:
+        assertTrue(organizer.moveUp(obj1));
+        assertEquals(Arrays.asList(obj2, obj3, obj1), list);
+
+        // unknown element:
+        assertFalse(organizer.moveUp(new Object()));
+        assertEquals(Arrays.asList(obj2, obj3, obj1), list);
     }
 
     @Test
     public void testMoveDown() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        Object obj3 = new Object();
+        LinkedList<Object> list = new LinkedList<>(Arrays.asList(obj1, obj2, obj3));
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
 
+        assertTrue(organizer.moveDown(obj3));
+        assertEquals(Arrays.asList(obj1, obj3, obj2), list);
+        assertTrue(organizer.moveDown(obj3));
+        assertEquals(Arrays.asList(obj3, obj1, obj2), list);
+
+        // already at the bottom:
+        assertTrue(organizer.moveDown(obj3));
+        assertEquals(Arrays.asList(obj3, obj1, obj2), list);
+
+        // unknown element:
+        assertFalse(organizer.moveDown(new Object()));
+        assertEquals(Arrays.asList(obj3, obj1, obj2), list);
     }
 
     @Test
     public void testAddFirst() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        LinkedList<Object> list = new LinkedList<>();
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
 
+        organizer.addToBottom(obj1);
+        organizer.addToBottom(obj2);
+        assertEquals(Arrays.asList(obj2, obj1), list);
+        assertEquals(list, organizer.elements());
     }
 
     @Test
     public void testAddLast() throws Exception {
+        Object obj1 = new Object();
+        Object obj2 = new Object();
+        LinkedList<Object> list = new LinkedList<>();
+        LayerListOrganizer<Object> organizer = new LayerListOrganizer<>(list);
 
+        organizer.addToTop(obj1);
+        organizer.addToTop(obj2);
+        assertEquals(Arrays.asList(obj1, obj2), list);
+        assertEquals(list, organizer.elements());
     }
 }

--- a/androidplot-core/src/test/java/com/androidplot/util/PixelUtilsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/PixelUtilsTest.java
@@ -2,21 +2,141 @@
 
 package com.androidplot.util;
 
+import android.graphics.PointF;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+
+import com.androidplot.test.AndroidplotTest;
+
 import org.junit.Test;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Field;
 import java.util.regex.Pattern;
-import static junit.framework.Assert.assertTrue;
 
-public class PixelUtilsTest {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-    @org.junit.After
-    public void tearDown() throws Exception {
-
-    }
+public class PixelUtilsTest extends AndroidplotTest {
 
     @Test
     public void testDimensionPattern() {
         Pattern DIMENSION_PATTERN = Pattern.compile(PixelUtils.DIMENSION_REGEX);
         assertTrue("Dimension failed dimension pattern match", DIMENSION_PATTERN.matcher("20dp").matches());
         assertTrue("Negative dimension failed dimension pattern match", DIMENSION_PATTERN.matcher("-20dp").matches());
+        assertTrue(DIMENSION_PATTERN.matcher("1.5sp").matches());
+        assertTrue(DIMENSION_PATTERN.matcher(" 20 dp ").matches());
+        assertFalse(DIMENSION_PATTERN.matcher("20").matches());
+        assertFalse(DIMENSION_PATTERN.matcher("dp").matches());
+        assertFalse(DIMENSION_PATTERN.matcher("20dp5").matches());
+    }
+
+    @Test
+    public void addAndSub() {
+        assertEquals(new PointF(4, 6), PixelUtils.add(new PointF(1, 2), new PointF(3, 4)));
+        assertEquals(new PointF(-2, -2), PixelUtils.sub(new PointF(1, 2), new PointF(3, 4)));
+    }
+
+    @Test
+    public void dpAndSpToPix_atDefaultDensity_areIdentity() {
+        final DisplayMetrics metrics = getContext().getResources().getDisplayMetrics();
+        assertEquals(1f, metrics.density, 0);
+        assertEquals(10f, PixelUtils.dpToPix(10), 0);
+        assertEquals(12.5f, PixelUtils.spToPix(12.5f), 0);
+        assertEquals(0f, PixelUtils.dpToPix(0), 0);
+    }
+
+    @Test
+    @Config(qualifiers = "xhdpi")
+    public void dpAndSpToPix_scaleWithDensity() {
+        final DisplayMetrics metrics = getContext().getResources().getDisplayMetrics();
+        assertEquals(2f, metrics.density, 0);
+        assertEquals(20f, PixelUtils.dpToPix(10), 0);
+        assertEquals(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 10, metrics),
+                PixelUtils.spToPix(10), 0);
+        assertEquals(-20f, PixelUtils.dpToPix(-10), 0);
+    }
+
+    @Test
+    public void stringToDimension_convertsEachUnit() {
+        final DisplayMetrics metrics = getContext().getResources().getDisplayMetrics();
+        assertEquals(20f, PixelUtils.stringToDimension("20px"), 0);
+        assertEquals(20f, PixelUtils.stringToDimension("20dp"), 0);
+        assertEquals(20f, PixelUtils.stringToDimension("20dip"), 0);
+        assertEquals(1.5f, PixelUtils.stringToDimension("1.5DP"), 0);
+        assertEquals(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, 20, metrics),
+                PixelUtils.stringToDimension("20sp"), 0);
+        assertEquals(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PT, 20, metrics),
+                PixelUtils.stringToDimension("20pt"), 0);
+        assertEquals(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_IN, 2, metrics),
+                PixelUtils.stringToDimension("2in"), 0);
+        assertEquals(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_MM, 3, metrics),
+                PixelUtils.stringToDimension("3mm"), 0);
+        assertEquals(20f, PixelUtils.stringToDimension(" 20 px "), 0);
+    }
+
+    @Test
+    @Config(qualifiers = "xhdpi")
+    public void stringToDimension_scalesWithDensity() {
+        assertEquals(40f, PixelUtils.stringToDimension("20dp"), 0);
+        assertEquals(20f, PixelUtils.stringToDimension("20px"), 0);
+    }
+
+    @Test
+    public void stringToDimension_negativeValue_keepsSign() {
+        assertEquals(-20f, PixelUtils.stringToDimension("-20dp"), 0);
+        assertEquals(-1.5f, PixelUtils.stringToDimension("-1.5px"), 0);
+    }
+
+    @Test
+    public void stringToDimension_invalidInput_throwsNumberFormatException() {
+        for (String invalid : new String[]{"20", "dp", "20zz", "", "abc", "20dp5"}) {
+            try {
+                PixelUtils.stringToDimension(invalid);
+                fail("expected NumberFormatException for '" + invalid + "'");
+            } catch (NumberFormatException expected) {
+                // ok
+            }
+        }
+    }
+
+    @Test
+    public void dimensionConstantLookup_isReadOnly() {
+        assertEquals(TypedValue.COMPLEX_UNIT_DIP, PixelUtils.dimensionConstantLookup.get("dp").intValue());
+        try {
+            PixelUtils.dimensionConstantLookup.put("foo", 1);
+            fail("expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void uninitialized_throwsHelpfulError() throws Exception {
+        final Field metrics = PixelUtils.class.getDeclaredField("metrics");
+        metrics.setAccessible(true);
+        final Object saved = metrics.get(null);
+        try {
+            metrics.set(null, null);
+            try {
+                PixelUtils.dpToPix(1);
+                fail("expected RuntimeException");
+            } catch (RuntimeException expected) {
+                assertTrue(expected.getMessage().contains("PixelUtils.init"));
+            }
+            try {
+                PixelUtils.spToPix(1);
+                fail("expected RuntimeException");
+            } catch (RuntimeException expected) {
+                assertTrue(expected.getMessage().contains("PixelUtils.init"));
+            }
+        } finally {
+            metrics.set(null, saved);
+        }
+        // init restores normal operation:
+        PixelUtils.init(getContext());
+        assertEquals(1f, PixelUtils.dpToPix(1), 0);
     }
 }

--- a/androidplot-core/src/test/java/com/androidplot/util/RedrawerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/RedrawerTest.java
@@ -88,6 +88,24 @@ public class RedrawerTest extends AndroidplotTest {
         }
     }
 
+    /**
+     * finish() may be called before the redrawer's thread has been scheduled (eg. an activity
+     * created and destroyed back to back on a slow device). The thread must still exit rather
+     * than un-doing the finish and parking forever.
+     */
+    @Test
+    public void finish_beforeThreadRuns_stillExits() throws Exception {
+        Plot plot = mock(Plot.class);
+        Redrawer redrawer = new Redrawer(Collections.singletonList(plot), 100, false);
+        // the constructor already started the real thread; finish it, then replay the race by
+        // invoking run() again as if the thread were only now getting scheduled.
+        redrawer.finish();
+        Thread replay = new Thread(redrawer, "replayed redrawer");
+        replay.start();
+        replay.join(2000);
+        assertFalse("run() invoked after finish() must return immediately", replay.isAlive());
+    }
+
     private static boolean redrawerThreadAlive() {
         for (Thread t : Thread.getAllStackTraces().keySet()) {
             if ("Androidplot Redrawer".equals(t.getName()) && t.isAlive()) {

--- a/androidplot-core/src/test/java/com/androidplot/util/fig/FigParamsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/fig/FigParamsTest.java
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.util.fig;
+
+import android.graphics.Paint;
+
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.SizeMode;
+import com.androidplot.xy.XYPlot;
+
+import org.junit.Test;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Parameter inflation paths of {@link Fig}: enum, boxed and multi-argument setters, string /
+ * float resource references, dimension strings and the error paths.  Basic int / boolean /
+ * nested paths are covered by {@link FigTest}.
+ */
+public class FigParamsTest extends AndroidplotTest {
+
+    public static class Target {
+        SizeMode mode;
+        float left, top, right, bottom;
+        String label;
+        Float boxedFloat;
+        Integer boxedInt;
+        Boolean boxedBool;
+        float size;
+        String name;
+        Target child;
+        Paint paint = new Paint();
+
+        public void setMode(SizeMode mode) {
+            this.mode = mode;
+        }
+
+        public void setMargins(float left, float top, float right, float bottom) {
+            this.left = left;
+            this.top = top;
+            this.right = right;
+            this.bottom = bottom;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public void setBoxedFloat(Float boxedFloat) {
+            this.boxedFloat = boxedFloat;
+        }
+
+        public void setBoxedInt(Integer boxedInt) {
+            this.boxedInt = boxedInt;
+        }
+
+        public void setBoxedBool(Boolean boxedBool) {
+            this.boxedBool = boxedBool;
+        }
+
+        public void setSize(float size) {
+            this.size = size;
+        }
+
+        public void setNameAndSize(String name, float size) {
+            this.name = name;
+            this.size = size;
+        }
+
+        public void setUnsupported(Object o) {
+            fail("must not be invoked");
+        }
+
+        public void setExplodes(int value) {
+            throw new IllegalStateException("boom " + value);
+        }
+
+        public Target getChild() {
+            return child;
+        }
+
+        public void setChild(Target child) {
+            this.child = child;
+        }
+
+        public Paint getPaint() {
+            return paint;
+        }
+
+        /** not a setter: no params */
+        public void setNothing() {
+        }
+
+        long ambiguousLong = -1;
+        int ambiguousInt = -1;
+
+        // overloads that only differ by an uninflatable type, in both declaration orders:
+        public void setAmbiguous(long value) {
+            this.ambiguousLong = value;
+        }
+
+        public void setAmbiguous(int value) {
+            this.ambiguousInt = value;
+        }
+
+        public void setAmbiguousReversed(int value) {
+            this.ambiguousInt = value;
+        }
+
+        public void setAmbiguousReversed(long value) {
+            this.ambiguousLong = value;
+        }
+
+        // overloads that differ by arity:
+        public void setSized(float size) {
+            this.size = size;
+        }
+
+        public void setSized(float size, SizeMode mode) {
+            this.size = size;
+            this.mode = mode;
+        }
+    }
+
+    private static HashMap<String, String> params(String... keyValues) {
+        final HashMap<String, String> params = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            params.put(keyValues[i], keyValues[i + 1]);
+        }
+        return params;
+    }
+
+    @Test
+    public void enumParam_isCaseInsensitive() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("mode", "relative"));
+        assertEquals(SizeMode.RELATIVE, target.mode);
+        Fig.configure(getContext(), target, params("mode", "FILL"));
+        assertEquals(SizeMode.FILL, target.mode);
+        Fig.configure(getContext(), target, params("mode", "Absolute"));
+        assertEquals(SizeMode.ABSOLUTE, target.mode);
+    }
+
+    @Test
+    public void enumParam_unknownConstant_throwsFigException() {
+        try {
+            Fig.configure(getContext(), new Target(), params("mode", "sideways"));
+            fail("expected FigException");
+        } catch (FigException expected) {
+            assertTrue(expected.getCause() instanceof java.lang.reflect.InvocationTargetException);
+        }
+    }
+
+    @Test
+    public void multiArgSetter_splitsOnPipe() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("margins", "1|2.5|3dp|-4"));
+        assertEquals(1f, target.left, 0);
+        assertEquals(2.5f, target.top, 0);
+        assertEquals(3f, target.right, 0);
+        assertEquals(-4f, target.bottom, 0);
+
+        Fig.configure(getContext(), target, params("nameAndSize", "hello|12px"));
+        assertEquals("hello", target.name);
+        assertEquals(12f, target.size, 0);
+    }
+
+    @Test
+    public void multiArgSetter_wrongArgCount_throws() throws Exception {
+        for (String value : new String[]{"1|2", "1|2|3|4|5", "1"}) {
+            try {
+                Fig.configure(getContext(), new Target(), params("margins", value));
+                fail("expected IllegalArgumentException for '" + value + "'");
+            } catch (IllegalArgumentException expected) {
+                assertTrue(expected.getMessage().contains("Unexpected number of argments"));
+            }
+        }
+    }
+
+    @Test
+    public void stringParam_plainValueAndResourceReference() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("label", "plain text"));
+        assertEquals("plain text", target.label);
+
+        Fig.configure(getContext(), target, params("label", "@" + android.R.string.ok));
+        assertEquals(getContext().getString(android.R.string.ok), target.label);
+
+        // a value that merely looks like a reference but has no resource stays a string:
+        Fig.configure(getContext(), target, params("label", "@twitter"));
+        assertEquals("@twitter", target.label);
+    }
+
+    @Test
+    public void floatParam_dimensionStringsResourceReferencesAndPlainNumbers() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("size", "2.5"));
+        assertEquals(2.5f, target.size, 0);
+
+        Fig.configure(getContext(), target, params("size", "12dp"));
+        assertEquals(12f, target.size, 0);
+
+        Fig.configure(getContext(), target, params("size", "7px"));
+        assertEquals(7f, target.size, 0);
+
+        Fig.configure(getContext(), target, params("size", "-3"));
+        assertEquals(-3f, target.size, 0);
+
+        Fig.configure(getContext(), target, params("size", "@" + android.R.dimen.app_icon_size));
+        assertEquals(getContext().getResources().getDimension(android.R.dimen.app_icon_size), target.size, 0);
+    }
+
+    @Test
+    public void floatParam_negativeDimensionString_keepsSign() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("size", "-12dp"));
+        assertEquals(-12f, target.size, 0);
+        Fig.configure(getContext(), target, params("size", "-1.5px"));
+        assertEquals(-1.5f, target.size, 0);
+    }
+
+    @Test
+    public void floatParam_unparseable_throwsNumberFormatException() throws Exception {
+        try {
+            Fig.configure(getContext(), new Target(), params("size", "big"));
+            fail("expected NumberFormatException");
+        } catch (NumberFormatException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void boxedParams() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params(
+                "boxedFloat", "1.5",
+                "boxedInt", "42",
+                "boxedBool", "true"));
+        assertEquals(1.5f, target.boxedFloat, 0);
+        assertEquals(42, target.boxedInt.intValue());
+        assertTrue(target.boxedBool);
+
+        Fig.configure(getContext(), target, params("boxedBool", "nonsense"));
+        assertFalse(target.boxedBool);
+    }
+
+    @Test
+    public void intParam_dimenResourceReference_resolvesToPixelSize() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("boxedInt", "@" + android.R.dimen.app_icon_size));
+        assertEquals(getContext().getResources().getDimensionPixelSize(android.R.dimen.app_icon_size),
+                target.boxedInt.intValue());
+    }
+
+    @Test
+    public void intParam_compressedTransparentColor() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("boxedInt", "#0"));
+        assertEquals(0, target.boxedInt.intValue());
+    }
+
+    @Test
+    public void unsupportedParamType_throwsIllegalArgumentException() throws Exception {
+        try {
+            Fig.configure(getContext(), new Target(), params("unsupported", "x"));
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("unsupported type"));
+        }
+    }
+
+    @Test
+    public void noSuchSetter_throwsFigException() {
+        try {
+            Fig.configure(getContext(), new Target(), params("doesNotExist", "x"));
+            fail("expected FigException");
+        } catch (FigException expected) {
+            assertTrue(expected.getCause() instanceof NoSuchMethodException);
+        }
+    }
+
+    @Test
+    public void setterWithoutParams_throwsIllegalArgumentException() throws Exception {
+        try {
+            Fig.configure(getContext(), new Target(), params("nothing", "x"));
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("no setter method"));
+        }
+    }
+
+    @Test
+    public void setterThrows_wrappedInFigException() {
+        try {
+            Fig.configure(getContext(), new Target(), params("explodes", "5"));
+            fail("expected FigException");
+        } catch (FigException expected) {
+            assertTrue(expected.getCause() instanceof java.lang.reflect.InvocationTargetException);
+            assertTrue(expected.getMessage().contains("explodes"));
+        }
+    }
+
+    @Test
+    public void nestedPath_resolvesThroughGetters() throws Exception {
+        final Target root = new Target();
+        root.setChild(new Target());
+        root.getChild().setChild(new Target());
+        Fig.configure(getContext(), root, params(
+                "child.child.size", "9",
+                "child.mode", "fill",
+                "child.paint.color", "#FF102030",
+                "paint.textAlign", "right"));
+        assertEquals(9f, root.child.child.size, 0);
+        assertEquals(SizeMode.FILL, root.child.mode);
+        assertEquals(0xFF102030, root.child.paint.getColor());
+        assertEquals(Paint.Align.RIGHT, root.paint.getTextAlign());
+        assertNull(root.label);
+
+        assertSame(root.child.child, Fig.getObjectContaining(root, "child.child.size"));
+        assertSame(root, Fig.getObjectContaining(root, "size"));
+    }
+
+    @Test
+    public void nestedPath_nullIntermediate_throwsNullPointerException() throws Exception {
+        try {
+            Fig.configure(getContext(), new Target(), params("child.size", "1"));
+            fail("expected NullPointerException");
+        } catch (NullPointerException expected) {
+            assertTrue(expected.getMessage().contains("size"));
+        }
+    }
+
+    @Test
+    public void configureFromMissingFile_throwsFigException() {
+        try {
+            Fig.configure(getContext(), new Target(), new File("does/not/exist.xml"));
+            fail("expected FigException");
+        } catch (FigException expected) {
+            assertTrue(expected.getCause() instanceof java.io.FileNotFoundException);
+        }
+    }
+
+    @Test
+    public void configureFromXmlResource_appliesConfigElementAttrs() throws Exception {
+        // the test xml resource is packaged but absent from the compile time R stub
+        final int cfgId = getContext().getResources().getIdentifier(
+                "fig_params_cfg", "xml", getContext().getPackageName());
+        assertTrue("test xml resource not found", cfgId != 0);
+
+        final Target target = new Target();
+        Fig.configure(getContext(), target, cfgId);
+
+        assertEquals(3f, target.size, 0);
+        assertEquals(SizeMode.RELATIVE, target.mode);
+        assertEquals("from xml", target.label);
+        assertEquals(1f, target.left, 0);
+        assertEquals(2f, target.top, 0);
+        assertEquals(3f, target.right, 0);
+        assertEquals(4f, target.bottom, 0);
+        assertEquals(0xFF102030, target.paint.getColor());
+        assertTrue(target.boxedBool);
+        assertNull(target.boxedInt);
+    }
+
+    @Test
+    public void configureFromXmlResource_unknownProperty_throwsFigException() {
+        final int cfgId = getContext().getResources().getIdentifier(
+                "segment_formatter_cfg", "xml", getContext().getPackageName());
+        assertTrue("test xml resource not found", cfgId != 0);
+        try {
+            Fig.configure(getContext(), new Target(), cfgId);
+            fail("expected FigException for the unknown properties in the config");
+        } catch (FigException expected) {
+            assertTrue(expected.getCause() instanceof NoSuchMethodException);
+        }
+    }
+
+    @Test
+    public void overloadedSetter_prefersInflatableParamTypes() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("ambiguous", "7"));
+        assertEquals(7, target.ambiguousInt);
+        assertEquals(-1, target.ambiguousLong);
+
+        Fig.configure(getContext(), target, params("ambiguousReversed", "8"));
+        assertEquals(8, target.ambiguousInt);
+        assertEquals(-1, target.ambiguousLong);
+    }
+
+    @Test
+    public void overloadedSetter_prefersMatchingArity() throws Exception {
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("sized", "3"));
+        assertEquals(3f, target.size, 0);
+        assertNull(target.mode);
+
+        Fig.configure(getContext(), target, params("sized", "0.5|relative"));
+        assertEquals(0.5f, target.size, 0);
+        assertEquals(SizeMode.RELATIVE, target.mode);
+
+        // real world case: Widget.setWidth(float) vs Widget.setWidth(float, SizeMode)
+        final XYPlot plot = new XYPlot(getContext(), "plot");
+        Fig.configure(getContext(), plot, params("graph.width", "0.25|relative"));
+        assertEquals(0.25f, plot.getGraph().getWidthMetric().getValue(), 0);
+        assertEquals(SizeMode.RELATIVE, plot.getGraph().getWidthMetric().getLayoutType());
+        Fig.configure(getContext(), plot, params("graph.width", "0.75"));
+        assertEquals(0.75f, plot.getGraph().getWidthMetric().getValue(), 0);
+        assertEquals(SizeMode.RELATIVE, plot.getGraph().getWidthMetric().getLayoutType());
+    }
+
+    /**
+     * On API 29+ Paint declares both setColor(int) and setColor(long); the configurator must pick
+     * the int overload regardless of reflection ordering.
+     */
+    @Test
+    @Config(sdk = 36)
+    public void overloadedSetter_paintSetColorOnModernSdk() throws Exception {
+        final XYPlot plot = new XYPlot(getContext(), "plot");
+        Fig.configure(getContext(), plot, params("backgroundPaint.color", "#FF0000"));
+        assertEquals(0xFFFF0000, plot.getBackgroundPaint().getColor());
+
+        final Target target = new Target();
+        Fig.configure(getContext(), target, params("paint.color", "#FF00FF00"));
+        assertEquals(0xFF00FF00, target.paint.getColor());
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/util/fig/FigTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/util/fig/FigTest.java
@@ -2,6 +2,7 @@
 package com.androidplot.util.fig;
 
 import android.graphics.Color;
+import android.graphics.Paint;
 
 import com.androidplot.test.AndroidplotTest;
 
@@ -81,6 +82,24 @@ public class FigTest extends AndroidplotTest {
         }
     }
 
+    /**
+     * Has the same overloaded setter as {@link android.graphics.Paint#setColor(long)} /
+     * {@link android.graphics.Paint#setColor(int)} on API 29+; only the int overload can be
+     * inflated from XML.
+     */
+    static class Overloaded {
+        private int intColor;
+        private long longColor;
+
+        public void setColor(long color) {
+            this.longColor = color;
+        }
+
+        public void setColor(int color) {
+            this.intColor = color;
+        }
+    }
+
     @Test
     public void testGetFieldAt() throws Exception {
         C c = new C();
@@ -153,6 +172,29 @@ public class FigTest extends AndroidplotTest {
         HashMap<String, String> params = new HashMap<>();
         params.put("d", "@color/does_not_exist");
         Fig.configure(RuntimeEnvironment.application, a, params);
+    }
+
+    /**
+     * An overloaded setter must resolve to the overload Fig can inflate, whatever order
+     * reflection happens to list the overloads in.
+     */
+    @Test
+    public void testConfigure_prefersInflatableOverload() throws Exception {
+        Overloaded o = new Overloaded();
+        HashMap<String, String> params = new HashMap<>();
+        params.put("color", "#FF00AA00");
+        Fig.configure(RuntimeEnvironment.application, o, params);
+        assertEquals(0xFF00AA00, o.intColor);
+        assertEquals(0L, o.longColor);
+    }
+
+    @Test
+    public void testConfigure_paintColor() throws Exception {
+        Paint paint = new Paint();
+        HashMap<String, String> params = new HashMap<>();
+        params.put("color", "#FF00AA00");
+        Fig.configure(RuntimeEnvironment.application, paint, params);
+        assertEquals(0xFF00AA00, paint.getColor());
     }
 
     private File getFileFromPath(String fileName) {

--- a/androidplot-core/src/test/java/com/androidplot/xy/BubbleSeriesTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/BubbleSeriesTest.java
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.xy;
+
+import com.androidplot.Region;
+import com.androidplot.util.SeriesUtils;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class BubbleSeriesTest {
+
+    @Test
+    public void interleavedConstructor_splitsXYZTriples() {
+        final BubbleSeries series = new BubbleSeries(1, 2, 3, 4, 5, 6, 7, 8, 9);
+        assertEquals(3, series.size());
+        assertNull(series.getTitle());
+
+        assertEquals(1, series.getX(0));
+        assertEquals(2, series.getY(0));
+        assertEquals(3, series.getZ(0));
+        assertEquals(4, series.getX(1));
+        assertEquals(5, series.getY(1));
+        assertEquals(6, series.getZ(1));
+        assertEquals(7, series.getX(2));
+        assertEquals(8, series.getY(2));
+        assertEquals(9, series.getZ(2));
+        assertEquals(Arrays.<Number>asList(3, 6, 9), series.getZVals());
+    }
+
+    @Test
+    public void interleavedConstructor_singleTripleAndNullValues() {
+        final BubbleSeries series = new BubbleSeries(1.5, null, 2);
+        assertEquals(1, series.size());
+        assertEquals(1.5, series.getX(0));
+        assertNull(series.getY(0));
+        assertEquals(2, series.getZ(0));
+    }
+
+    @Test
+    public void interleavedConstructor_lengthNotMultipleOfThree_throws() {
+        for (Number[] values : new Number[][]{{1}, {1, 2}, {1, 2, 3, 4}, {1, 2, 3, 4, 5}}) {
+            try {
+                new BubbleSeries(values);
+                fail("expected RuntimeException for " + values.length + " values");
+            } catch (RuntimeException expected) {
+                // ok
+            }
+        }
+    }
+
+    @Test
+    public void interleavedConstructor_nullArray_throws() {
+        try {
+            new BubbleSeries((Number[]) null);
+            fail("expected RuntimeException");
+        } catch (RuntimeException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void interleavedConstructor_empty_isEmptySeries() {
+        final BubbleSeries series = new BubbleSeries();
+        assertEquals(0, series.size());
+        assertEquals(0, series.getZVals().size());
+    }
+
+    @Test
+    public void yzConstructor_generatesXFromIndex() {
+        final List<Number> yVals = Arrays.<Number>asList(10, 20, 30);
+        final List<Number> zVals = Arrays.<Number>asList(1, 2, 3);
+        final BubbleSeries series = new BubbleSeries(yVals, zVals, "yz");
+
+        assertEquals("yz", series.getTitle());
+        assertEquals(3, series.size());
+        for (int i = 0; i < 3; i++) {
+            assertEquals(i, series.getX(i));
+            assertEquals(yVals.get(i), series.getY(i));
+            assertEquals(zVals.get(i), series.getZ(i));
+        }
+        assertSame(zVals, series.getZVals());
+    }
+
+    @Test
+    public void yzConstructor_mismatchedSizes_sizeFollowsZ() {
+        // x is generated from z, so a shorter y list is only detected on access:
+        final BubbleSeries series = new BubbleSeries(
+                Arrays.<Number>asList(10, 20), Arrays.<Number>asList(1, 2, 3), "yz");
+        assertEquals(3, series.size());
+        assertEquals(2, series.getX(2));
+        assertEquals(3, series.getZ(2));
+        assertEquals(20, series.getY(1));
+        try {
+            series.getY(2);
+            fail("expected IndexOutOfBoundsException");
+        } catch (IndexOutOfBoundsException expected) {
+            // ok
+        }
+
+        // a longer y list is simply truncated by size():
+        final BubbleSeries longerY = new BubbleSeries(
+                Arrays.<Number>asList(10, 20, 30, 40), Arrays.<Number>asList(1, 2), "yz");
+        assertEquals(2, longerY.size());
+        assertEquals(30, longerY.getY(2));
+    }
+
+    @Test
+    public void xyzConstructor_usesListsAsGiven() {
+        final List<Number> xVals = Arrays.<Number>asList(5, 6);
+        final List<Number> yVals = Arrays.<Number>asList(7, 8);
+        final List<Number> zVals = Arrays.<Number>asList(9, 10);
+        final BubbleSeries series = new BubbleSeries(xVals, yVals, zVals, "xyz");
+
+        assertEquals("xyz", series.getTitle());
+        assertEquals(2, series.size());
+        assertEquals(5, series.getX(0));
+        assertEquals(8, series.getY(1));
+        assertEquals(10, series.getZ(1));
+        assertSame(zVals, series.getZVals());
+    }
+
+    @Test
+    public void xyzConstructor_mismatchedSizes_sizeFollowsX() {
+        final BubbleSeries series = new BubbleSeries(
+                Arrays.<Number>asList(1, 2, 3), Arrays.<Number>asList(4, 5), Arrays.<Number>asList(6), "xyz");
+        assertEquals(3, series.size());
+        assertEquals(5, series.getY(1));
+        try {
+            series.getZ(1);
+            fail("expected IndexOutOfBoundsException");
+        } catch (IndexOutOfBoundsException expected) {
+            // ok
+        }
+    }
+
+    @Test
+    public void minMax_includesZValues() {
+        final BubbleSeries series = new BubbleSeries(1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+        // x/y bounds via the XYSeries contract:
+        final RectRegion xy = SeriesUtils.minMax(series);
+        assertEquals(1.0, xy.getMinX().doubleValue(), 0);
+        assertEquals(7.0, xy.getMaxX().doubleValue(), 0);
+        assertEquals(2.0, xy.getMinY().doubleValue(), 0);
+        assertEquals(8.0, xy.getMaxY().doubleValue(), 0);
+
+        // z bounds the way BubbleRenderer computes them:
+        final Region z = SeriesUtils.minMax(new Region(), series.getZVals());
+        assertEquals(3.0, z.getMin().doubleValue(), 0);
+        assertEquals(9.0, z.getMax().doubleValue(), 0);
+
+        // z values are ignored by the xy min/max:
+        final BubbleSeries bigZ = new BubbleSeries(1, 1, 1000);
+        final RectRegion bigZBounds = SeriesUtils.minMax(bigZ);
+        assertEquals(1.0, bigZBounds.getMaxX().doubleValue(), 0);
+        assertEquals(1.0, bigZBounds.getMaxY().doubleValue(), 0);
+    }
+
+    @Test
+    public void minMax_zValuesAcrossSeries_unionIntoBounds() {
+        final Region bounds = new Region(5, 5);
+        SeriesUtils.minMax(bounds, new BubbleSeries(0, 0, 2).getZVals());
+        SeriesUtils.minMax(bounds, new BubbleSeries(0, 0, 11, 0, 0, 7).getZVals());
+        assertEquals(2.0, bounds.getMin().doubleValue(), 0);
+        assertEquals(11.0, bounds.getMax().doubleValue(), 0);
+
+        // nulls in z are skipped:
+        final List<Number> zWithNull = new ArrayList<>(Arrays.<Number>asList(null, 3));
+        final Region withNull = SeriesUtils.minMax(new Region(), zWithNull);
+        assertEquals(3.0, withNull.getMin().doubleValue(), 0);
+        assertEquals(3.0, withNull.getMax().doubleValue(), 0);
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/xy/PanZoomGestureTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/PanZoomGestureTest.java
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.xy;
+
+import android.annotation.SuppressLint;
+import android.view.InputDevice;
+import android.view.MotionEvent;
+
+import com.androidplot.test.AndroidplotTest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Drives {@link PanZoom} with real {@link MotionEvent} sequences against a real, laid out
+ * {@link XYPlot} and checks the resulting plot bounds.
+ *
+ * The plot is 1000x500 px showing a domain of 0..100 and a range of 0..50, so one pixel of drag
+ * corresponds to 0.1 units on either axis.  Note that {@link XYPlot#getBounds()} only reflects
+ * boundary changes after {@link XYPlot#calculateMinMaxVals()}, which the render pass normally
+ * does; the gesture helpers here call it explicitly after each gesture.
+ */
+public class PanZoomGestureTest extends AndroidplotTest {
+
+    private static final int WIDTH = 1000;
+    private static final int HEIGHT = 500;
+    private static final double DELTA = 1e-6;
+
+    private static final int SECOND_POINTER_DOWN =
+            MotionEvent.ACTION_POINTER_DOWN | (1 << MotionEvent.ACTION_POINTER_INDEX_SHIFT);
+    private static final int SECOND_POINTER_UP =
+            MotionEvent.ACTION_POINTER_UP | (1 << MotionEvent.ACTION_POINTER_INDEX_SHIFT);
+
+    private XYPlot plot;
+    private PanZoom panZoom;
+
+    @Before
+    public void setUp() {
+        plot = new XYPlot(getContext(), "p");
+        plot.layout(0, 0, WIDTH, HEIGHT);
+        // the FIXED boundaries make the data irrelevant to the bounds, but a plot with no series
+        // skips the outer-limit clamp on its range axis in calculateMinMaxVals:
+        plot.addSeries(new SimpleXYSeries(Arrays.asList(1, 4, 2, 8, 5),
+                SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "series"), new LineAndPointFormatter());
+        plot.setDomainBoundaries(0, 100, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(0, 50, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+    }
+
+    private PanZoom attach(PanZoom.Pan pan, PanZoom.Zoom zoom) {
+        panZoom = PanZoom.attach(plot, pan, zoom);
+        return panZoom;
+    }
+
+    private PanZoom attach(PanZoom.Pan pan, PanZoom.Zoom zoom, PanZoom.ZoomLimit limit) {
+        panZoom = PanZoom.attach(plot, pan, zoom, limit);
+        return panZoom;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // pan
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void horizontalPan_movesDomainByPixelsTimesSpanOverWidth() {
+        attach(PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+
+        // dragging the finger 100px to the left pulls the content left, revealing higher x:
+        drag(500, 250, 400, 250);
+        assertBounds(10, 110, 0, 50);
+
+        // and back to the right, a different distance:
+        drag(400, 250, 650, 250);
+        assertBounds(-15, 85, 0, 50);
+    }
+
+    @Test
+    public void horizontalPan_ignoresVerticalMovement() {
+        attach(PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+        drag(500, 250, 500, 100);
+        assertBounds(0, 100, 0, 50);
+    }
+
+    @Test
+    public void verticalPan_movesRangeByPixelsTimesSpanOverHeight() {
+        attach(PanZoom.Pan.VERTICAL, PanZoom.Zoom.NONE);
+
+        // dragging the finger 50px down pulls the content down, revealing higher y:
+        drag(500, 250, 500, 300);
+        assertBounds(0, 100, 5, 55);
+
+        // horizontal movement is ignored:
+        drag(500, 300, 100, 300);
+        assertBounds(0, 100, 5, 55);
+    }
+
+    @Test
+    public void panBoth_movesBothAxes() {
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.NONE);
+        drag(500, 250, 400, 300);
+        assertBounds(10, 110, 5, 55);
+    }
+
+    @Test
+    public void panNone_ignoresDrags() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.NONE);
+        drag(500, 250, 100, 100);
+        assertBounds(0, 100, 0, 50);
+    }
+
+    @Test
+    public void pan_accumulatesOverMultipleMoveEvents() {
+        attach(PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+        touch(down(500, 250));
+        touch(move(450, 250));
+        plot.calculateMinMaxVals();
+        assertBounds(5, 105, 0, 50);
+
+        touch(move(400, 250));
+        plot.calculateMinMaxVals();
+        assertBounds(10, 110, 0, 50);
+
+        touch(up(400, 250));
+        plot.calculateMinMaxVals();
+        assertBounds(10, 110, 0, 50);
+    }
+
+    @Test
+    public void pan_isClampedToOuterLimitsAndPreservesWindowWidth() {
+        plot.setDomainBoundaries(20, 40, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(10, 20, BoundaryMode.FIXED);
+        plot.getOuterLimits().set(0, 50, 0, 25);
+        plot.calculateMinMaxVals();
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.NONE);
+
+        // an unclamped drag first, to prove the limits are not interfering:
+        drag(500, 250, 400, 300);
+        assertBounds(22, 42, 11, 21);
+
+        // a drag far past the upper limits on both axes (finger left and down):
+        drag(1000, 0, 0, 500);
+        assertBounds(30, 50, 15, 25);
+
+        // and far past the lower limits (the finger may leave the view):
+        drag(0, 500, 2000, -500);
+        assertBounds(0, 20, 0, 10);
+    }
+
+    @Test
+    public void pan_withWindowWiderThanOuterLimits_snapsToLimitsWithoutThrowing() {
+        // the demo app's old default: outer limits narrower than the FIXED window
+        plot.getOuterLimits().set(20, 80, 10, 40);
+        plot.calculateMinMaxVals();
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.NONE);
+
+        // PanZoom snaps the upper edge to the limit (the window is too wide to satisfy both
+        // edges) and the plot then clamps the overshooting lower edge on its next pass:
+        drag(500, 250, 400, 300);
+        assertBounds(20, 80, 10, 40);
+
+        // and again, now that the window matches the limits exactly:
+        drag(400, 300, 500, 250);
+        assertBounds(20, 80, 10, 40);
+    }
+
+    @Test
+    public void pan_onLargeMagnitudeDomain_keepsPrecision() {
+        final double minX = 1.7e12;
+        final double maxX = minX + 60000;
+        plot.setDomainBoundaries(minX, maxX, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+        attach(PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+
+        // 60 units per pixel; 10px must move the window by exactly 600, an offset that float
+        // arithmetic cannot represent at this magnitude (the float ulp of 1.7e12 is 131072).
+        drag(500, 250, 490, 250);
+        assertEquals(minX + 600, plot.getBounds().getMinX().doubleValue(), 1);
+        assertEquals(maxX + 600, plot.getBounds().getMaxX().doubleValue(), 1);
+        assertEquals(60000, plot.getBounds().getxRegion().length().doubleValue(), 1);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // zoom
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void stretchHorizontal_pinchOutNarrowsDomainOnly() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.STRETCH_HORIZONTAL);
+        pinch(400, 250, 600, 250, 300, 250, 700, 250);
+        assertBounds(25, 75, 0, 50);
+    }
+
+    @Test
+    public void stretchHorizontal_pinchInWidensDomainOnly() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.STRETCH_HORIZONTAL);
+        pinch(300, 250, 700, 250, 400, 250, 600, 250);
+        assertBounds(-50, 150, 0, 50);
+    }
+
+    @Test
+    public void stretchHorizontal_ignoresVerticalFingerMovement() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.STRETCH_HORIZONTAL);
+        pinch(400, 200, 600, 300, 400, 100, 600, 400);
+        assertBounds(0, 100, 0, 50);
+    }
+
+    @Test
+    public void stretchVertical_pinchOutNarrowsRangeOnly() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.STRETCH_VERTICAL);
+        pinch(400, 200, 600, 300, 400, 150, 600, 350);
+        assertBounds(0, 100, 12.5, 37.5);
+    }
+
+    @Test
+    public void stretchVertical_pinchInWidensRangeOnly() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.STRETCH_VERTICAL);
+        pinch(400, 150, 600, 350, 400, 200, 600, 300);
+        assertBounds(0, 100, -25, 75);
+    }
+
+    @Test
+    public void stretchBoth_scalesEachAxisByItsOwnFingerDistance() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.STRETCH_BOTH);
+
+        // x distance doubles, y distance quadruples:
+        pinch(400, 200, 600, 300, 300, 50, 700, 450);
+        assertBounds(25, 75, 18.75, 31.25);
+    }
+
+    @Test
+    public void stretchBoth_pinchInWidensBothAxes() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.STRETCH_BOTH);
+        pinch(300, 150, 700, 350, 400, 200, 600, 300);
+        assertBounds(-50, 150, -25, 75);
+    }
+
+    @Test
+    public void scale_pinchOutNarrowsBothAxesByTheSameFactor() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.SCALE);
+
+        // a purely horizontal pinch tripling the finger distance still scales the range:
+        pinch(400, 250, 600, 250, 200, 250, 800, 250);
+        assertBounds(100 / 3.0, 200 / 3.0, 50 / 3.0, 100 / 3.0);
+    }
+
+    @Test
+    public void scale_pinchInWidensBothAxesByTheSameFactor() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.SCALE);
+        pinch(200, 250, 800, 250, 400, 250, 600, 250);
+        assertBounds(-100, 200, -50, 100);
+    }
+
+    @Test
+    public void zoomNone_ignoresPinch() {
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.NONE);
+        pinch(400, 250, 600, 250, 300, 250, 700, 250);
+        assertBounds(0, 100, 0, 50);
+    }
+
+    @Test
+    public void zoom_isClampedToOuterLimits() {
+        plot.getOuterLimits().set(-20, 120, 0, 50);
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.SCALE);
+        pinch(400, 250, 600, 250, 480, 250, 520, 250);
+        assertBounds(-20, 120, 0, 50);
+    }
+
+    @Test
+    public void zoomLimitMinTicks_stopsZoomInAtOneStep() {
+        plot.setDomainStep(StepMode.INCREMENT_BY_VAL, 10);
+        plot.setRangeStep(StepMode.INCREMENT_BY_VAL, 4);
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.SCALE, PanZoom.ZoomLimit.MIN_TICKS);
+
+        // a 50x pinch-out would leave a 2 wide domain and a 1 tall range; instead each axis
+        // stops at exactly one step centered on its midpoint:
+        pinch(490, 250, 510, 250, 0, 250, 1000, 250);
+        assertBounds(45, 55, 23, 27);
+
+        // a further pinch-out stays there:
+        pinch(400, 250, 600, 250, 100, 250, 900, 250);
+        assertBounds(45, 55, 23, 27);
+
+        // zooming out is unaffected:
+        pinch(400, 250, 600, 250, 450, 250, 550, 250);
+        assertBounds(40, 60, 21, 29);
+    }
+
+    @Test
+    public void zoomLimitOuter_allowsZoomInPastOneStep() {
+        plot.setDomainStep(StepMode.INCREMENT_BY_VAL, 10);
+        plot.setRangeStep(StepMode.INCREMENT_BY_VAL, 4);
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.SCALE, PanZoom.ZoomLimit.OUTER);
+        pinch(490, 250, 510, 250, 0, 250, 1000, 250);
+        assertBounds(49, 51, 24.5, 25.5);
+    }
+
+    @Test
+    public void pinch_withFingersTooCloseTogether_doesNotZoom() {
+        attach(PanZoom.Pan.NONE, PanZoom.Zoom.SCALE);
+        // second finger lands within MIN_DIST_2_FING horizontally, so no zoom state is entered:
+        pinch(500, 250, 503, 250, 100, 250, 900, 250);
+        assertBounds(0, 100, 0, 50);
+    }
+
+    @Test
+    public void oneFingerDragAfterPinch_pansFromReleasedPosition() {
+        attach(PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.STRETCH_HORIZONTAL);
+        pinch(400, 250, 600, 250, 300, 250, 700, 250);
+        assertBounds(25, 75, 0, 50);
+
+        // a new one finger gesture pans the zoomed window; 100px is now 5 units:
+        drag(500, 250, 400, 250);
+        assertBounds(30, 80, 0, 50);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // state and delegation
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void getState_setState_roundTripAfterGesture() {
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.SCALE);
+        drag(500, 250, 400, 300);
+        pinch(400, 250, 600, 250, 200, 250, 800, 250);
+        assertBounds(60 - 100 / 6.0, 60 + 100 / 6.0, 30 - 25 / 3.0, 30 + 25 / 3.0);
+        PanZoom.State state = panZoom.getState();
+
+        plot.setDomainBoundaries(-1000, 1000, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(-1000, 1000, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+        assertBounds(-1000, 1000, -1000, 1000);
+
+        panZoom.setState(state);
+        plot.calculateMinMaxVals();
+        assertBounds(60 - 100 / 6.0, 60 + 100 / 6.0, 30 - 25 / 3.0, 30 + 25 / 3.0);
+    }
+
+    @Test
+    public void delegate_consumingEvents_blocksPanning() {
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.SCALE);
+        final List<MotionEvent> seen = new ArrayList<>();
+        panZoom.setDelegate((v, event) -> {
+            seen.add(event);
+            return true;
+        });
+
+        drag(500, 250, 400, 300);
+        assertBounds(0, 100, 0, 50);
+        pinch(400, 250, 600, 250, 300, 250, 700, 250);
+        assertBounds(0, 100, 0, 50);
+        assertEquals(3 + 5, seen.size());
+    }
+
+    @Test
+    public void delegate_notConsumingEvents_allowsPanning() {
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.SCALE);
+        final List<MotionEvent> seen = new ArrayList<>();
+        panZoom.setDelegate((v, event) -> {
+            seen.add(event);
+            return false;
+        });
+
+        drag(500, 250, 400, 300);
+        assertBounds(10, 110, 5, 55);
+        assertEquals(3, seen.size());
+    }
+
+    @Test
+    public void disabled_ignoresGestures() {
+        attach(PanZoom.Pan.BOTH, PanZoom.Zoom.SCALE);
+        panZoom.setEnabled(false);
+        drag(500, 250, 400, 300);
+        pinch(400, 250, 600, 250, 300, 250, 700, 250);
+        assertBounds(0, 100, 0, 50);
+    }
+
+    @Test
+    public void attach_registersAsThePlotsTouchListener() {
+        attach(PanZoom.Pan.HORIZONTAL, PanZoom.Zoom.NONE);
+        assertTrue(plot.dispatchTouchEvent(down(500, 250)));
+        assertTrue(plot.dispatchTouchEvent(move(400, 250)));
+        assertTrue(plot.dispatchTouchEvent(up(400, 250)));
+        plot.calculateMinMaxVals();
+        assertBounds(10, 110, 0, 50);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // gesture helpers
+    // ---------------------------------------------------------------------------------------
+
+    private void touch(MotionEvent event) {
+        panZoom.onTouch(plot, event);
+    }
+
+    /** A complete one finger drag: down at (fromX, fromY), one move to (toX, toY), up. */
+    private void drag(float fromX, float fromY, float toX, float toY) {
+        touch(down(fromX, fromY));
+        touch(move(toX, toY));
+        touch(up(toX, toY));
+        plot.calculateMinMaxVals();
+    }
+
+    /**
+     * A complete two finger gesture: the first finger lands at (x1, y1), the second at (x2, y2),
+     * both move to (x1b, y1b) / (x2b, y2b), then lift.
+     */
+    private void pinch(float x1, float y1, float x2, float y2,
+                       float x1b, float y1b, float x2b, float y2b) {
+        touch(down(x1, y1));
+        touch(twoFingers(SECOND_POINTER_DOWN, x1, y1, x2, y2));
+        touch(twoFingers(MotionEvent.ACTION_MOVE, x1b, y1b, x2b, y2b));
+        touch(twoFingers(SECOND_POINTER_UP, x1b, y1b, x2b, y2b));
+        touch(up(x1b, y1b));
+        plot.calculateMinMaxVals();
+    }
+
+    private static MotionEvent down(float x, float y) {
+        return MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, x, y, 0);
+    }
+
+    private static MotionEvent move(float x, float y) {
+        return MotionEvent.obtain(0, 0, MotionEvent.ACTION_MOVE, x, y, 0);
+    }
+
+    private static MotionEvent up(float x, float y) {
+        return MotionEvent.obtain(0, 0, MotionEvent.ACTION_UP, x, y, 0);
+    }
+
+    @SuppressLint("NewApi")
+    private static MotionEvent twoFingers(int action, float x1, float y1, float x2, float y2) {
+        MotionEvent.PointerProperties[] properties = {pointer(0), pointer(1)};
+        MotionEvent.PointerCoords[] coords = {coords(x1, y1), coords(x2, y2)};
+        return MotionEvent.obtain(0, 0, action, 2, properties, coords,
+                0, 0, 1f, 1f, 0, 0, InputDevice.SOURCE_TOUCHSCREEN, 0);
+    }
+
+    @SuppressLint("NewApi")
+    private static MotionEvent.PointerProperties pointer(int id) {
+        MotionEvent.PointerProperties properties = new MotionEvent.PointerProperties();
+        properties.id = id;
+        properties.toolType = MotionEvent.TOOL_TYPE_FINGER;
+        return properties;
+    }
+
+    @SuppressLint("NewApi")
+    private static MotionEvent.PointerCoords coords(float x, float y) {
+        MotionEvent.PointerCoords coords = new MotionEvent.PointerCoords();
+        coords.x = x;
+        coords.y = y;
+        coords.pressure = 1f;
+        coords.size = 1f;
+        return coords;
+    }
+
+    private void assertBounds(double minX, double maxX, double minY, double maxY) {
+        RectRegion bounds = plot.getBounds();
+        assertEquals("minX", minX, bounds.getMinX().doubleValue(), DELTA);
+        assertEquals("maxX", maxX, bounds.getMaxX().doubleValue(), DELTA);
+        assertEquals("minY", minY, bounds.getMinY().doubleValue(), DELTA);
+        assertEquals("maxY", maxY, bounds.getMaxY().doubleValue(), DELTA);
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/xy/ValueMarkerTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/ValueMarkerTest.java
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.xy;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.RectF;
+
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.HorizontalPosition;
+import com.androidplot.ui.HorizontalPositioning;
+import com.androidplot.ui.TextOrientation;
+import com.androidplot.ui.VerticalPosition;
+import com.androidplot.ui.VerticalPositioning;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ValueMarker}, {@link XValueMarker} and {@link YValueMarker}: construction, label
+ * positioning and the canvas operations performed by draw().
+ */
+public class ValueMarkerTest extends AndroidplotTest {
+
+    /** grid rect the markers are drawn into; 100 wide x 200 tall */
+    private static final RectF GRID = new RectF(0, 0, 100, 200);
+
+    /** text bounds reported by the mocked text paint: 60 wide, 10 above the baseline */
+    private static final int TEXT_WIDTH = 60;
+    private static final float ASCENT = -10;
+    private static final float DESCENT = 2;
+    private static final float TEXT_HEIGHT = -ASCENT + DESCENT; // 12
+
+    @Mock
+    Canvas canvas;
+
+    XYPlot plot;
+    Paint textPaint;
+    Paint linePaint;
+
+    @Before
+    public void setUp() {
+        plot = new XYPlot(getContext(), "markers");
+        // x: 0..10, y: 0..100
+        plot.addSeries(new SimpleXYSeries(Arrays.asList(0, 100), SimpleXYSeries.ArrayFormat.Y_VALS_ONLY, "s"),
+                new LineAndPointFormatter());
+        plot.setDomainBoundaries(0, 10, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(0, 100, BoundaryMode.FIXED);
+        plot.calculateMinMaxVals();
+        assertEquals(0.0, plot.getBounds().getMinX().doubleValue(), 0);
+        assertEquals(10.0, plot.getBounds().getMaxX().doubleValue(), 0);
+        assertEquals(100.0, plot.getBounds().getMaxY().doubleValue(), 0);
+
+        linePaint = new Paint();
+        textPaint = mock(Paint.class);
+        final Paint.FontMetrics metrics = new Paint.FontMetrics();
+        metrics.ascent = ASCENT;
+        metrics.descent = DESCENT;
+        when(textPaint.getFontMetrics()).thenReturn(metrics);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) {
+                final Rect rect = invocation.getArgument(3);
+                rect.set(0, (int) ASCENT, TEXT_WIDTH, 0);
+                return null;
+            }
+        }).when(textPaint).getTextBounds(anyString(), anyInt(), anyInt(), any(Rect.class));
+    }
+
+    // ---- construction ----
+
+    @Test
+    public void defaultConstructors_useRedPaintsAndDefaultTextPosition() {
+        final XValueMarker x = new XValueMarker(1, "x");
+        assertEquals(1, x.getValue());
+        assertEquals("x", x.getText());
+        assertEquals(Color.RED, x.getLinePaint().getColor());
+        assertEquals(Color.RED, x.getTextPaint().getColor());
+        assertEquals(Paint.Style.STROKE, x.getLinePaint().getStyle());
+        assertEquals(3f, x.getTextPosition().getValue(), 0);
+        assertEquals(VerticalPositioning.ABSOLUTE_FROM_TOP, x.getTextPosition().getLayoutType());
+        assertEquals(2, x.getTextMargin());
+        assertNull(x.getTextOrientation());
+
+        final YValueMarker y = new YValueMarker(2, "y");
+        assertEquals(2, y.getValue());
+        assertEquals("y", y.getText());
+        assertEquals(3f, y.getTextPosition().getValue(), 0);
+        assertEquals(HorizontalPositioning.ABSOLUTE_FROM_LEFT, y.getTextPosition().getLayoutType());
+        assertNotSame(x.getLinePaint(), y.getLinePaint());
+    }
+
+    @Test
+    public void paintConstructors_usePaintsAsGiven() {
+        final Paint line = new Paint();
+        final Paint text = new Paint();
+        final VerticalPosition vpos = new VerticalPosition(0.5f, VerticalPositioning.RELATIVE_TO_TOP);
+        final XValueMarker x = new XValueMarker(1, "x", vpos, line, text);
+        assertSame(line, x.getLinePaint());
+        assertSame(text, x.getTextPaint());
+        assertSame(vpos, x.getTextPosition());
+
+        final HorizontalPosition hpos = new HorizontalPosition(5, HorizontalPositioning.ABSOLUTE_FROM_RIGHT);
+        final YValueMarker y = new YValueMarker(2, "y", hpos, line, text);
+        assertSame(line, y.getLinePaint());
+        assertSame(text, y.getTextPaint());
+        assertSame(hpos, y.getTextPosition());
+    }
+
+    @Test
+    public void colorConstructors_colorDefaultPaints() {
+        final XValueMarker x = new XValueMarker(1, "x",
+                new VerticalPosition(1, VerticalPositioning.ABSOLUTE_FROM_BOTTOM), Color.BLUE, Color.GREEN);
+        assertEquals(Color.BLUE, x.getLinePaint().getColor());
+        assertEquals(Color.GREEN, x.getTextPaint().getColor());
+        assertEquals(Paint.Style.STROKE, x.getLinePaint().getStyle());
+
+        final YValueMarker y = new YValueMarker(2, "y",
+                new HorizontalPosition(1, HorizontalPositioning.ABSOLUTE_FROM_LEFT), Color.CYAN, Color.MAGENTA);
+        assertEquals(Color.CYAN, y.getLinePaint().getColor());
+        assertEquals(Color.MAGENTA, y.getTextPaint().getColor());
+    }
+
+    @Test
+    public void setters_updateState() {
+        final XValueMarker x = new XValueMarker(1, "x");
+        final Paint line = new Paint();
+        final Paint text = new Paint();
+        final VerticalPosition vpos = new VerticalPosition(9, VerticalPositioning.ABSOLUTE_FROM_BOTTOM);
+        x.setValue(7.5);
+        x.setText("seven");
+        x.setLinePaint(line);
+        x.setTextPaint(text);
+        x.setTextPosition(vpos);
+        x.setTextMargin(4);
+        x.setTextOrientation(TextOrientation.VERTICAL_ASCENDING);
+        assertEquals(7.5, x.getValue());
+        assertEquals("seven", x.getText());
+        assertSame(line, x.getLinePaint());
+        assertSame(text, x.getTextPaint());
+        assertSame(vpos, x.getTextPosition());
+        assertEquals(4, x.getTextMargin());
+        assertEquals(TextOrientation.VERTICAL_ASCENDING, x.getTextOrientation());
+    }
+
+    // ---- XValueMarker.draw ----
+
+    @Test
+    public void xMarker_draw_drawsVerticalLineAtTransformedXAndLabelBelowTextPosition() {
+        // text is positioned 20px from the top of the grid
+        final XValueMarker marker = new XValueMarker(5, "five",
+                new VerticalPosition(20, VerticalPositioning.ABSOLUTE_FROM_TOP), linePaint, textPaint);
+
+        marker.draw(canvas, plot, GRID);
+
+        // x = 5 of 0..10 across 0..100 -> 50
+        verify(canvas).drawLine(50, GRID.top, 50, GRID.bottom, linePaint);
+        // label origin: x + 2 = 52, baseline y - 2 = 18; the 60px wide label overflows the right
+        // edge by 12 and is shifted left to end at 100 (top = 18 - 12 = 6 is inside the grid)
+        verify(canvas).drawText("five", 40, 18, textPaint);
+    }
+
+    @Test
+    public void xMarker_draw_clampsLabelInsideGrid() {
+        // x near the right edge and text at the very top: label would overflow right and top
+        final XValueMarker marker = new XValueMarker(9, "nine",
+                new VerticalPosition(0, VerticalPositioning.ABSOLUTE_FROM_TOP), linePaint, textPaint);
+
+        marker.draw(canvas, plot, GRID);
+
+        verify(canvas).drawLine(90, 0, 90, 200, linePaint);
+        // unclamped rect: left 92, right 152, top -2 - 12 = -14, bottom -2
+        // shifted left by 52 to right edge 100 and down by 14 to top 0:
+        verify(canvas).drawText("nine", 100 - TEXT_WIDTH, TEXT_HEIGHT, textPaint);
+    }
+
+    @Test
+    public void xMarker_draw_relativeTextPosition() {
+        final XValueMarker marker = new XValueMarker(2, "two",
+                new VerticalPosition(0.5f, VerticalPositioning.RELATIVE_TO_TOP), linePaint, textPaint);
+        marker.draw(canvas, plot, new RectF(10, 20, 110, 220));
+
+        // x = 2 of 0..10 across 10..110 -> 30; y = 50% of 200 + top 20 = 120
+        verify(canvas).drawLine(30, 20, 30, 220, linePaint);
+        verify(canvas).drawText("two", 32, 118, textPaint);
+    }
+
+    @Test
+    public void xMarker_draw_nullText_drawsLineOnly() {
+        final XValueMarker marker = new XValueMarker(5, null,
+                new VerticalPosition(0, VerticalPositioning.ABSOLUTE_FROM_TOP), linePaint, textPaint);
+        marker.draw(canvas, plot, GRID);
+        verify(canvas).drawLine(50, 0, 50, 200, linePaint);
+        verify(canvas, never()).drawText(anyString(), anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    @Test
+    public void xMarker_draw_nullValue_drawsNothing() {
+        final XValueMarker marker = new XValueMarker(null, "text");
+        marker.draw(canvas, plot, GRID);
+        verify(canvas, never()).drawLine(anyFloat(), anyFloat(), anyFloat(), anyFloat(), any(Paint.class));
+        verify(canvas, never()).drawText(anyString(), anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    // ---- YValueMarker.draw ----
+
+    @Test
+    public void yMarker_draw_drawsHorizontalLineAtFlippedYAndLabelRightOfTextPosition() {
+        final YValueMarker marker = new YValueMarker(25, "quarter",
+                new HorizontalPosition(10, HorizontalPositioning.ABSOLUTE_FROM_LEFT), linePaint, textPaint);
+
+        marker.draw(canvas, plot, GRID);
+
+        // y = 25 of 0..100 flipped across 0..200 -> 150
+        verify(canvas).drawLine(GRID.left, 150, GRID.right, 150, linePaint);
+        // label: x = 10 + 2 = 12, baseline y = 150 - 2 = 148 (top 136, not clamped)
+        verify(canvas).drawText("quarter", 12, 148, textPaint);
+    }
+
+    @Test
+    public void yMarker_draw_clampsLabelInsideGrid() {
+        // text anchored 10px from the right edge with a 60px wide label: overflows right;
+        // value at the top of the range: overflows top
+        final YValueMarker marker = new YValueMarker(100, "top",
+                new HorizontalPosition(10, HorizontalPositioning.ABSOLUTE_FROM_RIGHT), linePaint, textPaint);
+
+        marker.draw(canvas, plot, GRID);
+
+        verify(canvas).drawLine(0, 0, 100, 0, linePaint);
+        verify(canvas).drawText("top", 100 - TEXT_WIDTH, TEXT_HEIGHT, textPaint);
+    }
+
+    @Test
+    public void yMarker_draw_nullText_drawsLineOnly() {
+        final YValueMarker marker = new YValueMarker(50, null,
+                new HorizontalPosition(0, HorizontalPositioning.ABSOLUTE_FROM_LEFT), linePaint, textPaint);
+        marker.draw(canvas, plot, GRID);
+        verify(canvas).drawLine(0, 100, 100, 100, linePaint);
+        verify(canvas, never()).drawText(anyString(), anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    @Test
+    public void yMarker_draw_nullValue_drawsNothing() {
+        final YValueMarker marker = new YValueMarker(null, "text");
+        marker.draw(canvas, plot, GRID);
+        verify(canvas, never()).drawLine(anyFloat(), anyFloat(), anyFloat(), anyFloat(), any(Paint.class));
+        verify(canvas, never()).drawText(anyString(), anyFloat(), anyFloat(), any(Paint.class));
+    }
+
+    @Test
+    public void draw_withRealTextPaint_doesNotThrow() {
+        final XValueMarker x = new XValueMarker(5, "x");
+        final YValueMarker y = new YValueMarker(50, "y");
+        x.draw(canvas, plot, GRID);
+        y.draw(canvas, plot, GRID);
+        verify(canvas).drawText(eq("x"), anyFloat(), anyFloat(), eq(x.getTextPaint()));
+        verify(canvas).drawText(eq("y"), anyFloat(), anyFloat(), eq(y.getTextPaint()));
+        assertNotNull(x.getTextPaint());
+    }
+}

--- a/androidplot-core/src/test/java/com/androidplot/xy/XYPlotAttrsTest.java
+++ b/androidplot-core/src/test/java/com/androidplot/xy/XYPlotAttrsTest.java
@@ -1,0 +1,620 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.xy;
+
+import android.graphics.Paint;
+import android.util.AttributeSet;
+
+import com.androidplot.Plot;
+import com.androidplot.R;
+import com.androidplot.test.AndroidplotTest;
+import com.androidplot.ui.Anchor;
+import com.androidplot.ui.HorizontalPositioning;
+import com.androidplot.ui.PositionMetrics;
+import com.androidplot.ui.Size;
+import com.androidplot.ui.SizeMode;
+import com.androidplot.ui.VerticalPositioning;
+import com.androidplot.ui.widget.Widget;
+import com.androidplot.xy.XYGraphWidget.Edge;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.Robolectric;
+import org.robolectric.android.AttributeSetBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * XML attribute processing of {@link XYPlot} (and the {@link Plot} base attrs) driven through a
+ * real {@link AttributeSet}, so the styleable ids, attr formats and enum ordinals declared in
+ * attrs.xml are all exercised.  Each group of attrs is checked to land on its own widget and to
+ * leave the sibling widgets untouched.
+ *
+ * Note: tests run at density 1.0 so "Npx" == "Ndp" == N.
+ */
+public class XYPlotAttrsTest extends AndroidplotTest {
+
+    private static final int COLOR_1 = 0xFF112233;
+    private static final int COLOR_2 = 0xFF445566;
+    private static final String COLOR_1_HEX = "#FF112233";
+    private static final String COLOR_2_HEX = "#FF445566";
+
+    /** an XYPlot inflated from an empty attribute set, for comparing untouched state against. */
+    XYPlot defaults;
+
+    @Before
+    public void setUp() {
+        defaults = new XYPlot(getContext(), attrs().build());
+    }
+
+    private static AttributeSetBuilder attrs() {
+        return Robolectric.buildAttributeSet();
+    }
+
+    private XYPlot plot(AttributeSetBuilder builder) {
+        return new XYPlot(getContext(), builder.build());
+    }
+
+    // ---- Plot base attrs ----
+
+    @Test
+    public void plotAttrs_title() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.title, "The Title")
+                .addAttribute(R.attr.titleTextSize, "21px")
+                .addAttribute(R.attr.titleTextColor, COLOR_1_HEX));
+
+        assertEquals("The Title", plot.getTitle().getText());
+        assertEquals(21f, plot.getTitle().getLabelPaint().getTextSize(), 0);
+        assertEquals(COLOR_1, plot.getTitle().getLabelPaint().getColor());
+
+        // and nothing leaked into the sibling widgets:
+        assertTextLabelUnchanged(defaults.getDomainTitle(), plot.getDomainTitle());
+        assertTextLabelUnchanged(defaults.getRangeTitle(), plot.getRangeTitle());
+        assertEquals(defaults.getLegend().getTextPaint().getTextSize(),
+                plot.getLegend().getTextPaint().getTextSize(), 0);
+    }
+
+    @Test
+    public void plotAttrs_noTitleAttr_clearsTitleText() {
+        // base attrs are applied unconditionally: an absent title attr yields a null title
+        final XYPlot plot = plot(attrs().addAttribute(R.attr.domainTitle, "x"));
+        assertNull(plot.getTitle().getText());
+        assertEquals(defaults.getTitle().getLabelPaint().getTextSize(),
+                plot.getTitle().getLabelPaint().getTextSize(), 0);
+    }
+
+    @Test
+    public void plotAttrs_backgroundAndBorder() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.backgroundColor, COLOR_1_HEX)
+                .addAttribute(R.attr.borderColor, COLOR_2_HEX)
+                .addAttribute(R.attr.borderThickness, "7px"));
+
+        assertEquals(COLOR_1, plot.getBackgroundPaint().getColor());
+        assertEquals(COLOR_2, plot.getBorderPaint().getColor());
+        assertEquals(7f, plot.getBorderPaint().getStrokeWidth(), 0);
+
+        // graph background is a separate attr:
+        assertEquals(defaults.getGraph().getBackgroundPaint().getColor(),
+                plot.getGraph().getBackgroundPaint().getColor());
+    }
+
+    @Test
+    public void plotAttrs_marginsAndPadding() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.marginTop, "1px")
+                .addAttribute(R.attr.marginBottom, "2px")
+                .addAttribute(R.attr.marginLeft, "3px")
+                .addAttribute(R.attr.marginRight, "4px")
+                .addAttribute(R.attr.paddingTop, "5px")
+                .addAttribute(R.attr.paddingBottom, "6px")
+                .addAttribute(R.attr.paddingLeft, "7px")
+                .addAttribute(R.attr.paddingRight, "8px"));
+
+        assertEquals(1f, plot.getPlotMarginTop(), 0);
+        assertEquals(2f, plot.getPlotMarginBottom(), 0);
+        assertEquals(3f, plot.getPlotMarginLeft(), 0);
+        assertEquals(4f, plot.getPlotMarginRight(), 0);
+        assertEquals(5f, plot.getPlotPaddingTop(), 0);
+        assertEquals(6f, plot.getPlotPaddingBottom(), 0);
+        assertEquals(7f, plot.getPlotPaddingLeft(), 0);
+        assertEquals(8f, plot.getPlotPaddingRight(), 0);
+
+        // graph margins are separate attrs:
+        assertEquals(defaults.getGraph().getMarginTop(), plot.getGraph().getMarginTop(), 0);
+        assertEquals(defaults.getGraph().getPaddingLeft(), plot.getGraph().getPaddingLeft(), 0);
+    }
+
+    @Test
+    public void plotAttrs_partialMargins_keepDefaultsForTheRest() {
+        final XYPlot plot = plot(attrs().addAttribute(R.attr.marginTop, "99px"));
+        assertEquals(99f, plot.getPlotMarginTop(), 0);
+        assertEquals(defaults.getPlotMarginBottom(), plot.getPlotMarginBottom(), 0);
+        assertEquals(defaults.getPlotMarginLeft(), plot.getPlotMarginLeft(), 0);
+        assertEquals(defaults.getPlotMarginRight(), plot.getPlotMarginRight(), 0);
+    }
+
+    @Test
+    public void plotAttrs_renderModeAndMarkup() {
+        assertEquals(Plot.RenderMode.USE_MAIN_THREAD, defaults.getRenderMode());
+        assertFalse(defaults.getLayoutManager().isDrawOutlinesEnabled());
+
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.renderMode, "use_background_thread")
+                .addAttribute(R.attr.markupEnabled, "true"));
+
+        assertEquals(Plot.RenderMode.USE_BACKGROUND_THREAD, plot.getRenderMode());
+        assertTrue(plot.getLayoutManager().isDrawOutlinesEnabled());
+        assertTrue(plot.getLayoutManager().isDrawAnchorsEnabled());
+        assertTrue(plot.getLayoutManager().isDrawMarginsEnabled());
+        assertTrue(plot.getLayoutManager().isDrawPaddingEnabled());
+
+        assertEquals(Plot.RenderMode.USE_MAIN_THREAD,
+                plot(attrs().addAttribute(R.attr.renderMode, "use_main_thread")).getRenderMode());
+    }
+
+    // ---- domain / range title widgets ----
+
+    /**
+     * Note: the size attrs are only effective when no title text is set, since a
+     * {@link com.androidplot.ui.widget.TextLabelWidget} with text auto-packs its size to the
+     * text (again in onPostInit, after attrs are applied).  Text is covered separately below.
+     */
+    @Test
+    public void domainTitleAttrs_landOnDomainTitleWidgetOnly() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.domainTitleTextColor, COLOR_1_HEX)
+                .addAttribute(R.attr.domainTitleTextSize, "17px")
+                .addAttribute(R.attr.domainTitleHeightMode, "absolute")
+                .addAttribute(R.attr.domainTitleHeight, "31px")
+                .addAttribute(R.attr.domainTitleWidthMode, "relative")
+                .addAttribute(R.attr.domainTitleWidth, "0.25")
+                .addAttribute(R.attr.domainTitleHorizontalPositioning, "absolute_from_right")
+                .addAttribute(R.attr.domainTitleHorizontalPosition, "12px")
+                .addAttribute(R.attr.domainTitleVerticalPositioning, "relative_from_center")
+                .addAttribute(R.attr.domainTitleVerticalPosition, "0.5")
+                .addAttribute(R.attr.domainTitleAnchor, "right_top")
+                .addAttribute(R.attr.domainTitleVisible, "false"));
+
+        assertEquals(COLOR_1, plot.getDomainTitle().getLabelPaint().getColor());
+        assertEquals(17f, plot.getDomainTitle().getLabelPaint().getTextSize(), 0);
+        assertSize(plot.getDomainTitle().getSize(), 31, SizeMode.ABSOLUTE, 0.25f, SizeMode.RELATIVE);
+        assertPosition(plot.getDomainTitle().getPositionMetrics(),
+                12, HorizontalPositioning.ABSOLUTE_FROM_RIGHT,
+                0.5f, VerticalPositioning.RELATIVE_TO_CENTER, Anchor.RIGHT_TOP);
+        assertFalse(plot.getDomainTitle().isVisible());
+
+        assertTextLabelUnchanged(defaults.getRangeTitle(), plot.getRangeTitle());
+        assertWidgetUnchanged(defaults.getGraph(), plot.getGraph());
+        assertWidgetUnchanged(defaults.getLegend(), plot.getLegend());
+        assertTextLabelUnchanged(defaults.getTitle(), plot.getTitle());
+    }
+
+    @Test
+    public void rangeTitleAttrs_landOnRangeTitleWidgetOnly() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.rangeTitleTextColor, COLOR_2_HEX)
+                .addAttribute(R.attr.rangeTitleTextSize, "19px")
+                .addAttribute(R.attr.rangeTitleHeightMode, "fill")
+                .addAttribute(R.attr.rangeTitleHeight, "3px")
+                .addAttribute(R.attr.rangeTitleWidthMode, "absolute")
+                .addAttribute(R.attr.rangeTitleWidth, "45px")
+                .addAttribute(R.attr.rangeTitleHorizontalPositioning, "relative_from_left")
+                .addAttribute(R.attr.rangeTitleHorizontalPosition, "0.125")
+                .addAttribute(R.attr.rangeTitleVerticalPositioning, "absolute_from_bottom")
+                .addAttribute(R.attr.rangeTitleVerticalPosition, "9px")
+                .addAttribute(R.attr.rangeTitleAnchor, "bottom_middle")
+                .addAttribute(R.attr.rangeTitleVisible, "false"));
+
+        assertEquals(COLOR_2, plot.getRangeTitle().getLabelPaint().getColor());
+        assertEquals(19f, plot.getRangeTitle().getLabelPaint().getTextSize(), 0);
+        assertSize(plot.getRangeTitle().getSize(), 3, SizeMode.FILL, 45, SizeMode.ABSOLUTE);
+        assertPosition(plot.getRangeTitle().getPositionMetrics(),
+                0.125f, HorizontalPositioning.RELATIVE_TO_LEFT,
+                9, VerticalPositioning.ABSOLUTE_FROM_BOTTOM, Anchor.BOTTOM_MIDDLE);
+        assertFalse(plot.getRangeTitle().isVisible());
+
+        assertTextLabelUnchanged(defaults.getDomainTitle(), plot.getDomainTitle());
+        assertWidgetUnchanged(defaults.getGraph(), plot.getGraph());
+        assertWidgetUnchanged(defaults.getLegend(), plot.getLegend());
+        assertTextLabelUnchanged(defaults.getTitle(), plot.getTitle());
+    }
+
+    @Test
+    public void titleTextAttrs_landOnMatchingTitleWidget() {
+        final XYPlot domainOnly = plot(attrs().addAttribute(R.attr.domainTitle, "D"));
+        assertEquals("D", domainOnly.getDomainTitle().getText());
+        assertNull(domainOnly.getRangeTitle().getText());
+        assertNull(domainOnly.getTitle().getText());
+
+        final XYPlot rangeOnly = plot(attrs().addAttribute(R.attr.rangeTitle, "R"));
+        assertEquals("R", rangeOnly.getRangeTitle().getText());
+        assertNull(rangeOnly.getDomainTitle().getText());
+        assertNull(rangeOnly.getTitle().getText());
+
+        final XYPlot both = plot(attrs()
+                .addAttribute(R.attr.domainTitle, "D")
+                .addAttribute(R.attr.rangeTitle, "R")
+                .addAttribute(R.attr.title, "T"));
+        assertEquals("D", both.getDomainTitle().getText());
+        assertEquals("R", both.getRangeTitle().getText());
+        assertEquals("T", both.getTitle().getText());
+
+        // text does not disturb position, anchor or visibility (size auto-packs to the text):
+        for (XYPlot plot : new XYPlot[]{domainOnly, rangeOnly, both}) {
+            assertPositionUnchanged(defaults.getDomainTitle(), plot.getDomainTitle());
+            assertPositionUnchanged(defaults.getRangeTitle(), plot.getRangeTitle());
+            assertTrue(plot.getDomainTitle().isVisible());
+            assertTrue(plot.getRangeTitle().isVisible());
+        }
+    }
+
+    @Test
+    public void titleSizeAttrs_withText_areOverriddenByAutoPack() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.domainTitle, "Domain")
+                .addAttribute(R.attr.domainTitleHeightMode, "absolute")
+                .addAttribute(R.attr.domainTitleHeight, "31px")
+                .addAttribute(R.attr.domainTitleWidthMode, "absolute")
+                .addAttribute(R.attr.domainTitleWidth, "41px"));
+        assertTrue(plot.getDomainTitle().isAutoPackEnabled());
+        assertEquals(SizeMode.ABSOLUTE, plot.getDomainTitle().getSize().getHeight().getLayoutType());
+        assertEquals(SizeMode.ABSOLUTE, plot.getDomainTitle().getSize().getWidth().getLayoutType());
+        // packed to the (Robolectric: empty) text bounds rather than the attr values:
+        assertFalse(31f == plot.getDomainTitle().getSize().getHeight().getValue());
+        assertFalse(41f == plot.getDomainTitle().getSize().getWidth().getValue());
+    }
+
+    // ---- legend ----
+
+    @Test
+    public void legendAttrs_landOnLegendWidgetOnly() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.legendTextColor, COLOR_1_HEX)
+                .addAttribute(R.attr.legendTextSize, "13px")
+                .addAttribute(R.attr.legendHeightMode, "absolute")
+                .addAttribute(R.attr.legendHeight, "22px")
+                .addAttribute(R.attr.legendWidthMode, "fill")
+                .addAttribute(R.attr.legendWidth, "2px")
+                .addAttribute(R.attr.legendHorizontalPositioning, "absolute_from_center")
+                .addAttribute(R.attr.legendHorizontalPosition, "-4px")
+                .addAttribute(R.attr.legendVerticalPositioning, "relative_from_top")
+                .addAttribute(R.attr.legendVerticalPosition, "0.75")
+                .addAttribute(R.attr.legendAnchor, "top_middle")
+                .addAttribute(R.attr.legendIconHeightMode, "relative")
+                .addAttribute(R.attr.legendIconHeight, "0.5")
+                .addAttribute(R.attr.legendIconWidthMode, "absolute")
+                .addAttribute(R.attr.legendIconWidth, "8px")
+                .addAttribute(R.attr.legendVisible, "false"));
+
+        assertEquals(COLOR_1, plot.getLegend().getTextPaint().getColor());
+        assertEquals(13f, plot.getLegend().getTextPaint().getTextSize(), 0);
+        assertSize(plot.getLegend().getSize(), 22, SizeMode.ABSOLUTE, 2, SizeMode.FILL);
+        assertPosition(plot.getLegend().getPositionMetrics(),
+                -4, HorizontalPositioning.ABSOLUTE_FROM_CENTER,
+                0.75f, VerticalPositioning.RELATIVE_TO_TOP, Anchor.TOP_MIDDLE);
+        assertSize(plot.getLegend().getIconSize(), 0.5f, SizeMode.RELATIVE, 8, SizeMode.ABSOLUTE);
+        assertFalse(plot.getLegend().isVisible());
+
+        assertTextLabelUnchanged(defaults.getDomainTitle(), plot.getDomainTitle());
+        assertTextLabelUnchanged(defaults.getRangeTitle(), plot.getRangeTitle());
+        assertWidgetUnchanged(defaults.getGraph(), plot.getGraph());
+        assertTextLabelUnchanged(defaults.getTitle(), plot.getTitle());
+    }
+
+    // ---- graph widget ----
+
+    @Test
+    public void graphAttrs_landOnGraphWidgetOnly() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.graphHeightMode, "relative")
+                .addAttribute(R.attr.graphHeight, "0.75")
+                .addAttribute(R.attr.graphWidthMode, "absolute")
+                .addAttribute(R.attr.graphWidth, "150px")
+                .addAttribute(R.attr.graphHorizontalPositioning, "absolute_from_left")
+                .addAttribute(R.attr.graphHorizontalPosition, "11px")
+                .addAttribute(R.attr.graphVerticalPositioning, "absolute_from_top")
+                .addAttribute(R.attr.graphVerticalPosition, "13px")
+                .addAttribute(R.attr.graphAnchor, "left_top")
+                .addAttribute(R.attr.graphRotation, "ninety_degrees")
+                .addAttribute(R.attr.graphVisible, "false")
+                .addAttribute(R.attr.graphMarginTop, "1px")
+                .addAttribute(R.attr.graphMarginBottom, "2px")
+                .addAttribute(R.attr.graphMarginLeft, "3px")
+                .addAttribute(R.attr.graphMarginRight, "4px")
+                .addAttribute(R.attr.graphPaddingTop, "5px")
+                .addAttribute(R.attr.graphPaddingBottom, "6px")
+                .addAttribute(R.attr.graphPaddingLeft, "7px")
+                .addAttribute(R.attr.graphPaddingRight, "8px")
+                .addAttribute(R.attr.graphBackgroundColor, COLOR_1_HEX)
+                .addAttribute(R.attr.gridBackgroundColor, COLOR_2_HEX));
+
+        final XYGraphWidget graph = plot.getGraph();
+        assertSize(graph.getSize(), 0.75f, SizeMode.RELATIVE, 150, SizeMode.ABSOLUTE);
+        assertPosition(graph.getPositionMetrics(),
+                11, HorizontalPositioning.ABSOLUTE_FROM_LEFT,
+                13, VerticalPositioning.ABSOLUTE_FROM_TOP, Anchor.LEFT_TOP);
+        assertEquals(Widget.Rotation.NINETY_DEGREES, graph.getRotation());
+        assertFalse(graph.isVisible());
+        assertEquals(1f, graph.getMarginTop(), 0);
+        assertEquals(2f, graph.getMarginBottom(), 0);
+        assertEquals(3f, graph.getMarginLeft(), 0);
+        assertEquals(4f, graph.getMarginRight(), 0);
+        assertEquals(5f, graph.getPaddingTop(), 0);
+        assertEquals(6f, graph.getPaddingBottom(), 0);
+        assertEquals(7f, graph.getPaddingLeft(), 0);
+        assertEquals(8f, graph.getPaddingRight(), 0);
+        assertEquals(COLOR_1, graph.getBackgroundPaint().getColor());
+        assertEquals(COLOR_2, graph.getGridBackgroundPaint().getColor());
+
+        // plot-level background & box model untouched:
+        assertEquals(defaults.getBackgroundPaint().getColor(), plot.getBackgroundPaint().getColor());
+        assertEquals(defaults.getPlotMarginTop(), plot.getPlotMarginTop(), 0);
+        assertEquals(defaults.getPlotPaddingLeft(), plot.getPlotPaddingLeft(), 0);
+
+        assertTextLabelUnchanged(defaults.getDomainTitle(), plot.getDomainTitle());
+        assertTextLabelUnchanged(defaults.getRangeTitle(), plot.getRangeTitle());
+        assertWidgetUnchanged(defaults.getLegend(), plot.getLegend());
+        assertTextLabelUnchanged(defaults.getTitle(), plot.getTitle());
+    }
+
+    @Test
+    public void graphRotation_everyValue() {
+        assertEquals(Widget.Rotation.NONE, defaults.getGraph().getRotation());
+        assertEquals(Widget.Rotation.NONE,
+                plot(attrs().addAttribute(R.attr.graphRotation, "none")).getGraph().getRotation());
+        assertEquals(Widget.Rotation.NINETY_DEGREES,
+                plot(attrs().addAttribute(R.attr.graphRotation, "ninety_degrees")).getGraph().getRotation());
+        assertEquals(Widget.Rotation.NEGATIVE_NINETY_DEGREES,
+                plot(attrs().addAttribute(R.attr.graphRotation, "negative_ninety_degrees"))
+                        .getGraph().getRotation());
+        assertEquals(Widget.Rotation.ONE_HUNDRED_EIGHTY_DEGREES,
+                plot(attrs().addAttribute(R.attr.graphRotation, "one_hundred_eighty_degrees"))
+                        .getGraph().getRotation());
+    }
+
+    @Test
+    public void gridAttrs() {
+        assertFalse(defaults.getGraph().isDrawGridOnTop());
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.drawGridOnTop, "true")
+                .addAttribute(R.attr.gridClippingEnabled, "false")
+                .addAttribute(R.attr.gridInsetTop, "1px")
+                .addAttribute(R.attr.gridInsetBottom, "2px")
+                .addAttribute(R.attr.gridInsetLeft, "3px")
+                .addAttribute(R.attr.gridInsetRight, "4px")
+                .addAttribute(R.attr.domainLineColor, COLOR_1_HEX)
+                .addAttribute(R.attr.domainLineThickness, "5px")
+                .addAttribute(R.attr.rangeLineColor, COLOR_2_HEX)
+                .addAttribute(R.attr.rangeLineThickness, "6px")
+                .addAttribute(R.attr.domainOriginLineColor, "#FF0000FF")
+                .addAttribute(R.attr.domainOriginLineThickness, "7px")
+                .addAttribute(R.attr.rangeOriginLineColor, "#FF00FF00")
+                .addAttribute(R.attr.rangeOriginLineThickness, "8px"));
+
+        final XYGraphWidget graph = plot.getGraph();
+        assertTrue(graph.isDrawGridOnTop());
+        assertFalse(graph.isGridClippingEnabled());
+        assertEquals(1f, graph.getGridInsets().getTop(), 0);
+        assertEquals(2f, graph.getGridInsets().getBottom(), 0);
+        assertEquals(3f, graph.getGridInsets().getLeft(), 0);
+        assertEquals(4f, graph.getGridInsets().getRight(), 0);
+        assertEquals(COLOR_1, graph.getDomainGridLinePaint().getColor());
+        assertEquals(5f, graph.getDomainGridLinePaint().getStrokeWidth(), 0);
+        assertEquals(COLOR_2, graph.getRangeGridLinePaint().getColor());
+        assertEquals(6f, graph.getRangeGridLinePaint().getStrokeWidth(), 0);
+        assertEquals(0xFF0000FF, graph.getDomainOriginLinePaint().getColor());
+        assertEquals(7f, graph.getDomainOriginLinePaint().getStrokeWidth(), 0);
+        assertEquals(0xFF00FF00, graph.getRangeOriginLinePaint().getColor());
+        assertEquals(8f, graph.getRangeOriginLinePaint().getStrokeWidth(), 0);
+
+        // line label insets are separate attrs:
+        assertEquals(defaults.getGraph().getLineLabelInsets().getTop(),
+                graph.getLineLabelInsets().getTop(), 0);
+    }
+
+    @Test
+    public void lineLabelAttrs() {
+        for (Edge edge : Edge.values()) {
+            assertFalse(edge.toString(), defaults.getGraph().isLineLabelEnabled(edge));
+        }
+
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.lineLabels, "left|bottom")
+                .addAttribute(R.attr.lineLabelAlignTop, "center")
+                .addAttribute(R.attr.lineLabelAlignBottom, "right")
+                .addAttribute(R.attr.lineLabelAlignLeft, "left")
+                .addAttribute(R.attr.lineLabelAlignRight, "center")
+                .addAttribute(R.attr.lineLabelRotationTop, "10")
+                .addAttribute(R.attr.lineLabelRotationBottom, "-45.5")
+                .addAttribute(R.attr.lineLabelRotationLeft, "90")
+                .addAttribute(R.attr.lineLabelRotationRight, "1.5")
+                .addAttribute(R.attr.lineLabelTextSizeTop, "11px")
+                .addAttribute(R.attr.lineLabelTextSizeBottom, "12px")
+                .addAttribute(R.attr.lineLabelTextSizeLeft, "13px")
+                .addAttribute(R.attr.lineLabelTextSizeRight, "14px")
+                .addAttribute(R.attr.lineLabelTextColorTop, "#FF000001")
+                .addAttribute(R.attr.lineLabelTextColorBottom, "#FF000002")
+                .addAttribute(R.attr.lineLabelTextColorLeft, "#FF000003")
+                .addAttribute(R.attr.lineLabelTextColorRight, "#FF000004")
+                .addAttribute(R.attr.lineLabelInsetTop, "1px")
+                .addAttribute(R.attr.lineLabelInsetBottom, "2px")
+                .addAttribute(R.attr.lineLabelInsetLeft, "3px")
+                .addAttribute(R.attr.lineLabelInsetRight, "4px")
+                .addAttribute(R.attr.lineExtensionTop, "5px")
+                .addAttribute(R.attr.lineExtensionBottom, "6px")
+                .addAttribute(R.attr.lineExtensionLeft, "7px")
+                .addAttribute(R.attr.lineExtensionRight, "8px"));
+
+        final XYGraphWidget graph = plot.getGraph();
+        assertTrue(graph.isLineLabelEnabled(Edge.LEFT));
+        assertTrue(graph.isLineLabelEnabled(Edge.BOTTOM));
+        assertFalse(graph.isLineLabelEnabled(Edge.TOP));
+        assertFalse(graph.isLineLabelEnabled(Edge.RIGHT));
+
+        assertLineLabelStyle(graph.getLineLabelStyle(Edge.TOP), Paint.Align.CENTER, 10, 11, 0xFF000001);
+        assertLineLabelStyle(graph.getLineLabelStyle(Edge.BOTTOM), Paint.Align.RIGHT, -45.5f, 12, 0xFF000002);
+        assertLineLabelStyle(graph.getLineLabelStyle(Edge.LEFT), Paint.Align.LEFT, 90, 13, 0xFF000003);
+        assertLineLabelStyle(graph.getLineLabelStyle(Edge.RIGHT), Paint.Align.CENTER, 1.5f, 14, 0xFF000004);
+
+        assertEquals(1f, graph.getLineLabelInsets().getTop(), 0);
+        assertEquals(2f, graph.getLineLabelInsets().getBottom(), 0);
+        assertEquals(3f, graph.getLineLabelInsets().getLeft(), 0);
+        assertEquals(4f, graph.getLineLabelInsets().getRight(), 0);
+        assertEquals(5f, graph.getLineExtensionTop(), 0);
+        assertEquals(6f, graph.getLineExtensionBottom(), 0);
+        assertEquals(7f, graph.getLineExtensionLeft(), 0);
+        assertEquals(8f, graph.getLineExtensionRight(), 0);
+
+        // grid insets are separate attrs:
+        assertEquals(defaults.getGraph().getGridInsets().getTop(), graph.getGridInsets().getTop(), 0);
+    }
+
+    @Test
+    public void lineLabels_singleEdgeAndNone() {
+        final XYGraphWidget top = plot(attrs().addAttribute(R.attr.lineLabels, "top")).getGraph();
+        assertTrue(top.isLineLabelEnabled(Edge.TOP));
+        assertFalse(top.isLineLabelEnabled(Edge.LEFT));
+        assertFalse(top.isLineLabelEnabled(Edge.BOTTOM));
+        assertFalse(top.isLineLabelEnabled(Edge.RIGHT));
+
+        final XYGraphWidget all = plot(attrs()
+                .addAttribute(R.attr.lineLabels, "top|bottom|left|right")).getGraph();
+        assertTrue(all.isLineLabelEnabled(Edge.TOP));
+        assertTrue(all.isLineLabelEnabled(Edge.LEFT));
+        assertTrue(all.isLineLabelEnabled(Edge.BOTTOM));
+        assertTrue(all.isLineLabelEnabled(Edge.RIGHT));
+
+        final XYGraphWidget none = plot(attrs().addAttribute(R.attr.lineLabels, "none")).getGraph();
+        assertFalse(none.isLineLabelEnabled(Edge.TOP));
+        assertFalse(none.isLineLabelEnabled(Edge.LEFT));
+        assertFalse(none.isLineLabelEnabled(Edge.BOTTOM));
+        assertFalse(none.isLineLabelEnabled(Edge.RIGHT));
+    }
+
+    @Test
+    public void lineLabelAlign_absent_keepsDefaultAlignment() {
+        final XYPlot plot = plot(attrs().addAttribute(R.attr.lineLabelTextSizeTop, "11px"));
+        for (Edge edge : new Edge[]{Edge.TOP, Edge.BOTTOM, Edge.LEFT, Edge.RIGHT}) {
+            assertEquals(edge.toString(),
+                    defaults.getGraph().getLineLabelStyle(edge).getPaint().getTextAlign(),
+                    plot.getGraph().getLineLabelStyle(edge).getPaint().getTextAlign());
+        }
+    }
+
+    // ---- step models ----
+
+    @Test
+    public void stepAttrs_landOnMatchingStepModel() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.domainStepMode, "increment_by_val")
+                .addAttribute(R.attr.domainStep, "7")
+                .addAttribute(R.attr.rangeStepMode, "increment_by_pixels")
+                .addAttribute(R.attr.rangeStep, "2.5"));
+
+        assertEquals(StepMode.INCREMENT_BY_VAL, plot.getDomainStepModel().getMode());
+        assertEquals(7.0, plot.getDomainStepModel().getValue(), 0);
+        assertEquals(StepMode.INCREMENT_BY_PIXELS, plot.getRangeStepModel().getMode());
+        assertEquals(2.5, plot.getRangeStepModel().getValue(), 0);
+    }
+
+    @Test
+    public void stepAttrs_valueOnly_keepsMode() {
+        final XYPlot plot = plot(attrs().addAttribute(R.attr.domainStep, "5"));
+        assertEquals(StepMode.SUBDIVIDE, plot.getDomainStepModel().getMode());
+        assertEquals(5.0, plot.getDomainStepModel().getValue(), 0);
+        assertEquals(defaults.getRangeStepModel().getValue(), plot.getRangeStepModel().getValue(), 0);
+    }
+
+    @Test
+    public void stepAttrs_dimensionValue() {
+        final XYPlot plot = plot(attrs()
+                .addAttribute(R.attr.rangeStepMode, "increment_by_pixels")
+                .addAttribute(R.attr.rangeStep, "40dp"));
+        assertEquals(StepMode.INCREMENT_BY_PIXELS, plot.getRangeStepModel().getMode());
+        assertEquals(40.0, plot.getRangeStepModel().getValue(), 0);
+    }
+
+    // ---- int|float|dimension value handling ----
+
+    @Test
+    public void sizeValue_acceptsIntFloatAndDimension() {
+        assertEquals(50f, plot(attrs().addAttribute(R.attr.domainTitleHeight, "50"))
+                .getDomainTitle().getSize().getHeight().getValue(), 0);
+        assertEquals(12.5f, plot(attrs().addAttribute(R.attr.domainTitleHeight, "12.5"))
+                .getDomainTitle().getSize().getHeight().getValue(), 0);
+        assertEquals(33f, plot(attrs().addAttribute(R.attr.domainTitleHeight, "33px"))
+                .getDomainTitle().getSize().getHeight().getValue(), 0);
+        assertEquals(34f, plot(attrs().addAttribute(R.attr.domainTitleHeight, "34dp"))
+                .getDomainTitle().getSize().getHeight().getValue(), 0);
+    }
+
+    @Test
+    public void relativeModeWithOutOfRangeValue_throws() {
+        try {
+            plot(attrs()
+                    .addAttribute(R.attr.graphWidthMode, "relative")
+                    .addAttribute(R.attr.graphWidth, "150px"));
+            fail("expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // ok
+        }
+    }
+
+    // ---- helpers ----
+
+    private static void assertLineLabelStyle(XYGraphWidget.LineLabelStyle style, Paint.Align align,
+            float rotation, float textSize, int color) {
+        assertEquals(align, style.getPaint().getTextAlign());
+        assertEquals(rotation, style.getRotation(), 0);
+        assertEquals(textSize, style.getPaint().getTextSize(), 0);
+        assertEquals(color, style.getPaint().getColor());
+    }
+
+    private static void assertSize(Size size, float height, SizeMode heightMode, float width, SizeMode widthMode) {
+        assertEquals(height, size.getHeight().getValue(), 0);
+        assertEquals(heightMode, size.getHeight().getLayoutType());
+        assertEquals(width, size.getWidth().getValue(), 0);
+        assertEquals(widthMode, size.getWidth().getLayoutType());
+    }
+
+    private static void assertPosition(PositionMetrics metrics, float x, HorizontalPositioning hp,
+            float y, VerticalPositioning vp, Anchor anchor) {
+        assertEquals(x, metrics.getXPositionMetric().getValue(), 0);
+        assertEquals(hp, metrics.getXPositionMetric().getLayoutType());
+        assertEquals(y, metrics.getYPositionMetric().getValue(), 0);
+        assertEquals(vp, metrics.getYPositionMetric().getLayoutType());
+        assertEquals(anchor, metrics.getAnchor());
+    }
+
+    private static void assertPositionUnchanged(Widget expected, Widget actual) {
+        assertPosition(actual.getPositionMetrics(),
+                expected.getPositionMetrics().getXPositionMetric().getValue(),
+                expected.getPositionMetrics().getXPositionMetric().getLayoutType(),
+                expected.getPositionMetrics().getYPositionMetric().getValue(),
+                expected.getPositionMetrics().getYPositionMetric().getLayoutType(),
+                expected.getAnchor());
+    }
+
+    /** Size, position, anchor, visibility and rotation of actual match those of expected. */
+    private static void assertWidgetUnchanged(Widget expected, Widget actual) {
+        assertSize(actual.getSize(),
+                expected.getSize().getHeight().getValue(), expected.getSize().getHeight().getLayoutType(),
+                expected.getSize().getWidth().getValue(), expected.getSize().getWidth().getLayoutType());
+        assertPositionUnchanged(expected, actual);
+        assertEquals(expected.isVisible(), actual.isVisible());
+        assertEquals(expected.getRotation(), actual.getRotation());
+    }
+
+    private static void assertTextLabelUnchanged(com.androidplot.ui.widget.TextLabelWidget expected,
+            com.androidplot.ui.widget.TextLabelWidget actual) {
+        assertWidgetUnchanged(expected, actual);
+        assertEquals(expected.getText(), actual.getText());
+        assertEquals(expected.getLabelPaint().getTextSize(), actual.getLabelPaint().getTextSize(), 0);
+        assertEquals(expected.getLabelPaint().getColor(), actual.getLabelPaint().getColor());
+    }
+}

--- a/androidplot-core/src/test/res/xml/fig_params_cfg.xml
+++ b/androidplot-core/src/test/res/xml/fig_params_cfg.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Fig configuration used by FigParamsTest -->
+<config
+    size="3dp"
+    mode="relative"
+    label="from xml"
+    margins="1|2|3|4"
+    paint.color="#FF102030"
+    boxedBool="true"/>

--- a/androidplot-core/src/test/res/xml/segment_formatter_cfg.xml
+++ b/androidplot-core/src/test/res/xml/segment_formatter_cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Fig configuration used by SegmentFormatterTest -->
+<config
+    fillPaint.color="#FF00AA00"
+    outerEdgePaint.color="#FF112233"
+    outerEdgePaint.strokeWidth="4px"
+    labelPaint.textSize="15px"
+    labelPaint.textAlign="left"
+    offset="6dp"
+    radialInset="1px"
+    innerInset="2px"
+    outerInset="3px"
+    legendIconEnabled="false"/>

--- a/androidplot-core/src/test/resources/robolectric.properties
+++ b/androidplot-core/src/test/resources/robolectric.properties
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Pin the Robolectric SDK: with includeAndroidResources enabled Robolectric reads the
+# merged manifest, whose targetSdk (37) exceeds the max supported by Robolectric 4.16.1.
+# 23 is the level the suite ran under before resources were included.
+sdk=23

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -23,7 +23,11 @@ dependencies {
 }
 
 kotlin {
-    jvmToolchain(17)
+    // emit Java 17 bytecode from whichever JDK runs the build (CI uses 21); a toolchain pin
+    // would instead require a JDK 17 installation to be present.
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }
 
 // Every merge to master publishes the demoapp to the Play beta track, so the version code is

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -15,6 +15,11 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.4.0'
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.14'
+
+    // Robolectric tests exercising every example activity; same versions as androidplot-core.
+    // The Robolectric SDK level is pinned in src/test/resources/robolectric.properties.
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "org.robolectric:robolectric:4.16.1"
 }
 
 kotlin {
@@ -84,6 +89,13 @@ android {
             debuggable = true
         }
     }
+    testOptions {
+        unitTests {
+            // lets Robolectric inflate the example layouts and read the manifest
+            includeAndroidResources = true
+        }
+    }
+
     lint {
         abortOnError = false
     }

--- a/demoapp/src/test/java/com/androidplot/demos/AboutActivityTest.kt
+++ b/demoapp/src/test/java/com/androidplot/demos/AboutActivityTest.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos
+
+import android.content.Intent
+import android.widget.TextView
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+
+@RunWith(RobolectricTestRunner::class)
+class AboutActivityTest {
+
+    private lateinit var controller: ActivityController<AboutActivity>
+    private lateinit var activity: AboutActivity
+
+    private val links = mapOf(
+        R.id.aboutWebsite to "https://androidplot.com",
+        R.id.aboutSource to "https://github.com/halfhp/androidplot",
+        R.id.aboutDocs to "https://github.com/halfhp/androidplot/blob/master/docs/index.md",
+        R.id.aboutIssues to "https://github.com/halfhp/androidplot/issues",
+        R.id.aboutLicense to "https://www.apache.org/licenses/LICENSE-2.0",
+    )
+
+    @Before
+    fun setUp() {
+        controller = DemoAppTest.launch(AboutActivity::class.java)
+        activity = controller.get()
+    }
+
+    @After
+    fun tearDown() {
+        DemoAppTest.finish(controller)
+    }
+
+    @Test
+    fun showsTheVersion() {
+        val versionName = activity.packageManager.getPackageInfo(activity.packageName, 0).versionName
+        assertFalse(versionName.isNullOrBlank())
+        val text = activity.findViewById<TextView>(R.id.aboutVersion).text.toString()
+        assertEquals(activity.getString(R.string.about_version, versionName), text)
+        assertTrue(text, text.contains(versionName!!))
+    }
+
+    @Test
+    fun linkButtonsOpenTheirUrls() {
+        assertNull(shadowOf(activity).nextStartedActivity)
+        links.forEach { (id, url) ->
+            activity.findViewById<TextView>(id).performClick()
+            DemoAppTest.idle()
+            val intent = shadowOf(activity).nextStartedActivity
+            val name = activity.resources.getResourceEntryName(id)
+            assertEquals(name, Intent.ACTION_VIEW, intent?.action)
+            assertEquals(name, url, intent?.data?.toString())
+        }
+        assertNull(shadowOf(activity).nextStartedActivity)
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/ActivityLifecycleTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/ActivityLifecycleTest.java
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import android.view.View;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+
+/**
+ * Runs every example activity through its full lifecycle: this is the automated version of the
+ * "open each example on an emulator and make sure it doesn't crash" smoke test.
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class ActivityLifecycleTest {
+
+    @Parameters(name = "{0}")
+    public static List<Object[]> activities() {
+        List<Object[]> params = new ArrayList<>();
+        for (Class<? extends Activity> cls : DemoActivities.ALL) {
+            params.add(new Object[] {cls.getSimpleName(), cls});
+        }
+        return params;
+    }
+
+    private final Class<? extends Activity> activityClass;
+
+    public ActivityLifecycleTest(String name, Class<? extends Activity> activityClass) {
+        this.activityClass = activityClass;
+    }
+
+    @Test
+    public void fullLifecycle_noExceptionsAndNoLeakedThreads() throws Exception {
+        Set<Thread> before = DemoAppTest.liveThreads();
+        List<Throwable> uncaught = DemoAppTest.recordUncaughtExceptions();
+
+        ActivityController<? extends Activity> controller =
+                Robolectric.buildActivity(activityClass).create();
+        View decor = controller.get().getWindow().getDecorView();
+        if (controller.get().isFinishing()) {
+            // finished during onCreate (eg. OrientationSensorExampleActivity when the device has
+            // no sensor): the framework would go straight to onDestroy without resuming.
+            controller.destroy();
+        } else {
+            controller.start().postCreate(null).resume().visible();
+            DemoAppTest.idle();
+            assertTrue(decor.isAttachedToWindow());
+
+            // Robolectric attaches and lays the window out but never draws it, so draw the whole
+            // screen once: this runs every main-thread plot's renderers.  (Background-thread
+            // plots render on their own thread as soon as they have a size; an exception there
+            // would surface via the uncaught exception handler.)
+            DemoAppTest.draw(decor);
+
+            DemoAppTest.finish(controller);
+        }
+        assertFalse(decor.isAttachedToWindow());
+
+        DemoAppTest.assertThreadsExited(before);
+        assertEquals("uncaught exceptions on background threads: " + uncaught,
+                0, uncaught.size());
+        DemoAppTest.assertNoLoggedErrors();
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/BarPlotExampleActivityTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/BarPlotExampleActivityTest.java
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.graphics.PointF;
+import android.graphics.RectF;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.SeekBar;
+import android.widget.Spinner;
+import com.androidplot.ui.SeriesRenderer;
+import com.androidplot.ui.widget.TextLabelWidget;
+import com.androidplot.ui.widget.Widget;
+import com.androidplot.xy.BarRenderer;
+import com.androidplot.xy.XYPlot;
+import com.androidplot.xy.XYSeries;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+@RunWith(RobolectricTestRunner.class)
+public class BarPlotExampleActivityTest {
+
+    private static final String NO_SELECTION_TXT = "Touch bar to select.";
+
+    private ActivityController<BarPlotExampleActivity> controller;
+    private BarPlotExampleActivity activity;
+    private XYPlot plot;
+
+    @Before
+    public void setUp() {
+        controller = DemoAppTest.launch(BarPlotExampleActivity.class);
+        activity = controller.get();
+        plot = activity.findViewById(R.id.plot);
+    }
+
+    @After
+    public void tearDown() {
+        DemoAppTest.finish(controller);
+        DemoAppTest.assertNoLoggedErrors();
+    }
+
+    @Test
+    public void initialState() {
+        assertEquals(2, plot.getRegistry().getSeriesList().size());
+        assertEquals(10, plot.getRegistry().getSeriesList().get(0).size());
+        assertEquals(BarRenderer.BarOrientation.OVERLAID, barRenderer().getBarOrientation());
+        assertEquals(BarRenderer.BarGroupWidthMode.FIXED_WIDTH, barRenderer().getBarGroupWidthMode());
+        assertEquals(50, barRenderer().getBarGroupWidth(), 0.001f);
+        assertEquals(NO_SELECTION_TXT, selectionWidget().getText());
+        assertEquals(View.VISIBLE, activity.findViewById(R.id.sbFixed).getVisibility());
+        assertEquals(View.INVISIBLE, activity.findViewById(R.id.sbVariable).getVisibility());
+    }
+
+    @Test
+    public void seriesSizeSpinner_changesSeriesSize() {
+        Spinner spinner = activity.findViewById(R.id.spSeriesSize);
+        assertEquals("TEN", spinner.getSelectedItem().toString());
+
+        select(spinner, 2);
+        assertEquals("SIXTY", spinner.getSelectedItem().toString());
+        for (XYSeries series : plot.getRegistry().getSeriesList()) {
+            assertEquals(60, series.size());
+        }
+        DemoAppTest.draw(plot);
+
+        select(spinner, 1);
+        for (XYSeries series : plot.getRegistry().getSeriesList()) {
+            assertEquals(20, series.size());
+        }
+        DemoAppTest.draw(plot);
+    }
+
+    @Test
+    public void renderStyleSpinner_changesBarOrientation() {
+        Spinner spinner = activity.findViewById(R.id.spRenderStyle);
+        for (BarRenderer.BarOrientation orientation : BarRenderer.BarOrientation.values()) {
+            select(spinner, orientation.ordinal());
+            assertEquals(orientation, barRenderer().getBarOrientation());
+            // stacked bars need more head room
+            assertEquals(orientation == BarRenderer.BarOrientation.STACKED ? 15 : 0,
+                    plot.getInnerLimits().getMaxY().intValue());
+            DemoAppTest.draw(plot);
+        }
+    }
+
+    @Test
+    public void widthStyleSpinner_changesWidthModeAndSeekBars() {
+        Spinner spinner = activity.findViewById(R.id.spWidthStyle);
+        SeekBar fixed = activity.findViewById(R.id.sbFixed);
+        SeekBar variable = activity.findViewById(R.id.sbVariable);
+
+        select(spinner, BarRenderer.BarGroupWidthMode.FIXED_GAP.ordinal());
+        assertEquals(BarRenderer.BarGroupWidthMode.FIXED_GAP, barRenderer().getBarGroupWidthMode());
+        assertEquals(variable.getProgress(), barRenderer().getBarGroupWidth(), 0.001f);
+        assertEquals(View.INVISIBLE, fixed.getVisibility());
+        assertEquals(View.VISIBLE, variable.getVisibility());
+        DemoAppTest.draw(plot);
+
+        variable.setProgress(7);
+        DemoAppTest.idle();
+        assertEquals(7, barRenderer().getBarGroupWidth(), 0.001f);
+
+        select(spinner, BarRenderer.BarGroupWidthMode.FIXED_WIDTH.ordinal());
+        assertEquals(BarRenderer.BarGroupWidthMode.FIXED_WIDTH, barRenderer().getBarGroupWidthMode());
+        assertEquals(View.VISIBLE, fixed.getVisibility());
+        assertEquals(View.INVISIBLE, variable.getVisibility());
+
+        fixed.setProgress(20);
+        DemoAppTest.idle();
+        assertEquals(20, barRenderer().getBarGroupWidth(), 0.001f);
+        DemoAppTest.draw(plot);
+    }
+
+    @Test
+    public void seriesCheckBoxes_addAndRemoveSeries() {
+        CheckBox us = activity.findViewById(R.id.s1CheckBox);
+        CheckBox them = activity.findViewById(R.id.s2CheckBox);
+
+        us.performClick();
+        DemoAppTest.idle();
+        assertEquals(1, plot.getRegistry().getSeriesList().size());
+        assertEquals("Them", plot.getRegistry().getSeriesList().get(0).getTitle());
+        DemoAppTest.draw(plot);
+
+        them.performClick();
+        DemoAppTest.idle();
+        assertEquals(0, plot.getRegistry().getSeriesList().size());
+        DemoAppTest.draw(plot);
+
+        us.performClick();
+        them.performClick();
+        DemoAppTest.idle();
+        assertEquals(2, plot.getRegistry().getSeriesList().size());
+        DemoAppTest.draw(plot);
+    }
+
+    @Test
+    public void tappingTheGraph_selectsABar() {
+        // the graph's grid rect, which screen-to-series conversion needs, is computed on the
+        // first draw; on a device that always happens before the user can tap
+        DemoAppTest.draw(plot);
+        RectF grid = plot.getGraph().getGridRect();
+        assertNotNull("the plot must be drawn for touch handling", grid);
+        assertTrue(grid.width() > 0 && grid.height() > 0);
+
+        // the domain is fixed to -1..10 for 10 bars, so the middle of the grid is over bar 4 or 5
+        PointF onBar = new PointF(grid.centerX(), grid.centerY());
+        assertTrue(plot.containsPoint(onBar));
+        DemoAppTest.tap(plot, onBar);
+        String text = selectionWidget().getText();
+        assertTrue(text, text.startsWith("Selected: "));
+        assertTrue(text, text.contains(" Value: "));
+        assertTrue(text, text.contains("Us") || text.contains("Them"));
+        assertTrue(text, text.equals("Selected: Us Value: 7") || text.equals("Selected: Them Value: 2")
+                || text.equals("Selected: Us Value: 4") || text.equals("Selected: Them Value: 0"));
+        DemoAppTest.draw(plot);
+
+        // a tap outside the graph area clears the selection
+        PointF offGraph = new PointF(1, 1);
+        assertFalse(plot.containsPoint(offGraph));
+        DemoAppTest.tap(plot, offGraph);
+        assertEquals(NO_SELECTION_TXT, selectionWidget().getText());
+        DemoAppTest.draw(plot);
+    }
+
+    /**
+     * Selects a spinner item the way the framework does: the selection is applied and the
+     * listener notified during the next layout pass.
+     */
+    private void select(Spinner spinner, int position) {
+        spinner.setSelection(position);
+        DemoAppTest.layoutPass(activity);
+        assertEquals(position, spinner.getSelectedItemPosition());
+    }
+
+    private BarRenderer<?> barRenderer() {
+        for (SeriesRenderer<?, ?, ?> renderer : plot.getRendererList()) {
+            if (renderer instanceof BarRenderer) {
+                return (BarRenderer<?>) renderer;
+            }
+        }
+        throw new AssertionError("no BarRenderer on the plot");
+    }
+
+    /** The extra label the example adds to the plot: the only TextLabelWidget that isn't a title. */
+    private TextLabelWidget selectionWidget() {
+        for (Widget widget : plot.getLayoutManager().elements()) {
+            if (widget instanceof TextLabelWidget && widget != plot.getTitle()
+                    && widget != plot.getDomainTitle() && widget != plot.getRangeTitle()) {
+                return (TextLabelWidget) widget;
+            }
+        }
+        throw new AssertionError("no selection widget on the plot");
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/DemoActivities.java
+++ b/demoapp/src/test/java/com/androidplot/demos/DemoActivities.java
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import android.app.Activity;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Every activity declared in the demoapp's AndroidManifest.xml.  Hand-maintained, but
+ * {@link DemoActivitiesTest} fails if it ever disagrees with the manifest, so an example added to
+ * the app cannot be left out of {@link ActivityLifecycleTest}.
+ */
+final class DemoActivities {
+
+    static final List<Class<? extends Activity>> ALL = Collections.unmodifiableList(Arrays.asList(
+            MainActivity.class,
+            SimplePieChartActivity.class,
+            AnimatedXYPlotActivity.class,
+            SimpleXYPlotActivity.class,
+            ScatterPlotActivity.class,
+            BarPlotExampleActivity.class,
+            DynamicXYPlotActivity.class,
+            CandlestickChartActivity.class,
+            OrientationSensorExampleActivity.class,
+            StepChartExampleActivity.class,
+            TouchZoomExampleActivity.class,
+            ListViewActivity.class,
+            RecyclerViewActivity.class,
+            XYRegionExampleActivity.class,
+            TimeSeriesActivity.class,
+            XYPlotWithBgImgActivity.class,
+            ECGExample.class,
+            FXPlotExampleActivity.class,
+            BubbleChartActivity.class,
+            DualScaleActivity.class,
+            AboutActivity.class));
+
+    private DemoActivities() {}
+}

--- a/demoapp/src/test/java/com/androidplot/demos/DemoActivitiesTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/DemoActivitiesTest.java
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertEquals;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import java.util.TreeSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+/**
+ * Guards {@link DemoActivities#ALL} against drifting from the manifest.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DemoActivitiesTest {
+
+    @Test
+    public void listMatchesManifest() throws Exception {
+        Context ctx = RuntimeEnvironment.getApplication();
+        PackageInfo info = ctx.getPackageManager()
+                .getPackageInfo(ctx.getPackageName(), PackageManager.GET_ACTIVITIES);
+
+        // the debug manifest also merges in activities from dependencies (eg. LeakCanary);
+        // only the demoapp's own activities are of interest here.
+        TreeSet<String> manifest = new TreeSet<>();
+        for (ActivityInfo activity : info.activities) {
+            if (activity.name.startsWith(ctx.getPackageName() + ".")) {
+                manifest.add(activity.name);
+            }
+        }
+
+        TreeSet<String> listed = new TreeSet<>();
+        for (Class<? extends Activity> cls : DemoActivities.ALL) {
+            listed.add(cls.getName());
+        }
+
+        assertEquals("DemoActivities.ALL must list exactly the activities in AndroidManifest.xml",
+                manifest, listed);
+        assertEquals("DemoActivities.ALL contains a duplicate", DemoActivities.ALL.size(), listed.size());
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/DemoAppTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/DemoAppTest.java
@@ -28,9 +28,11 @@ import org.robolectric.shadows.ShadowLog;
  *
  * <p>Sizing: {@link ActivityController#setup()} ends with {@code visible()}, which attaches the
  * activity's decor view to a window and lays it out at the emulated display size (320x470 by
- * default), so every plot in the layout has real dimensions, widget rects and grid rects after
+ * default), so every plot in the layout has real dimensions and widget rects after
  * {@link #launch}; nothing needs to be measured or laid out by hand.  Only a view that is not in
- * the window (eg. a list row that has not been created yet) needs {@link #layOut}.
+ * the window (eg. a list row that has not been created yet) needs {@link #layOut}.  Robolectric
+ * does not draw the window though, and a graph's grid rect (needed for screen/series conversion)
+ * is computed on its first draw, so tests that touch a plot call {@link #draw} first.
  *
  * <p>Threads: {@code destroy()} removes the decor view from the window, which is what stops each
  * plot's render thread; the examples' Redrawer and data threads are stopped by the activities
@@ -97,6 +99,19 @@ final class DemoAppTest {
         view.layout(0, 0, width, height);
     }
 
+    /**
+     * Runs a synchronous measure/layout pass over the activity's window at its current size,
+     * then drains the main looper.  Robolectric schedules the traversal a requestLayout() asks
+     * for through the Choreographer, which only runs when the test clock is advanced; doing the
+     * pass directly keeps tests deterministic.  Widgets such as Spinner apply a pending
+     * selection (and notify their listener) during layout, so call this after setSelection().
+     */
+    static void layoutPass(Activity activity) {
+        View decor = activity.getWindow().getDecorView();
+        layOut(decor, decor.getWidth(), decor.getHeight());
+        idle();
+    }
+
     /** Draws a laid-out view (and its children) onto a bitmap of its own size. */
     static void draw(View view) {
         assertTrue("view has no size: " + view, view.getWidth() > 0 && view.getHeight() > 0);
@@ -132,14 +147,18 @@ final class DemoAppTest {
         }
     }
 
-    /** Delivers a down/up tap at the given view-relative point. */
+    /**
+     * Delivers a tap at the given view-relative point.  As a parent ViewGroup would, the UP is
+     * only delivered if the view consumed the DOWN.
+     */
     static void tap(View view, PointF point) {
         long now = SystemClock.uptimeMillis();
         MotionEvent down = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, point.x, point.y, 0);
         MotionEvent up = MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, point.x, point.y, 0);
         try {
-            view.dispatchTouchEvent(down);
-            view.dispatchTouchEvent(up);
+            if (view.dispatchTouchEvent(down)) {
+                view.dispatchTouchEvent(up);
+            }
         } finally {
             down.recycle();
             up.recycle();

--- a/demoapp/src/test/java/com/androidplot/demos/DemoAppTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/DemoAppTest.java
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.PointF;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowLog;
+
+/**
+ * Helpers shared by the demoapp tests.
+ *
+ * <p>Sizing: {@link ActivityController#setup()} ends with {@code visible()}, which attaches the
+ * activity's decor view to a window and lays it out at the emulated display size (320x470 by
+ * default), so every plot in the layout has real dimensions, widget rects and grid rects after
+ * {@link #launch}; nothing needs to be measured or laid out by hand.  Only a view that is not in
+ * the window (eg. a list row that has not been created yet) needs {@link #layOut}.
+ *
+ * <p>Threads: {@code destroy()} removes the decor view from the window, which is what stops each
+ * plot's render thread; the examples' Redrawer and data threads are stopped by the activities
+ * themselves.  {@link #assertThreadsExited} checks that all of them are gone afterwards.
+ */
+final class DemoAppTest {
+
+    /** How long a background thread may take to notice it has been stopped. */
+    private static final long THREAD_EXIT_TIMEOUT_MS = 2000;
+
+    private DemoAppTest() {}
+
+    /** Creates, starts, resumes and makes the activity visible, then drains the main looper. */
+    static <T extends Activity> ActivityController<T> launch(Class<T> cls) {
+        ActivityController<T> controller = Robolectric.buildActivity(cls).setup();
+        idle();
+        return controller;
+    }
+
+    /** Runs the activity through pause, stop and destroy, then drains the main looper. */
+    static void finish(ActivityController<?> controller) {
+        controller.pause().stop().destroy();
+        idle();
+    }
+
+    /** Runs everything currently queued on the main looper (Robolectric's default PAUSED mode). */
+    static void idle() {
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    /** Measures and lays a detached view out at exactly the given size. */
+    static void layOut(View view, int width, int height) {
+        view.measure(View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY));
+        view.layout(0, 0, width, height);
+    }
+
+    /** Draws a laid-out view (and its children) onto a bitmap of its own size. */
+    static void draw(View view) {
+        assertTrue("view has no size: " + view, view.getWidth() > 0 && view.getHeight() > 0);
+        Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), Bitmap.Config.ARGB_8888);
+        try {
+            view.draw(new Canvas(bitmap));
+        } finally {
+            bitmap.recycle();
+        }
+    }
+
+    /**
+     * Installs a default uncaught exception handler for the rest of the test (Robolectric resets
+     * it between tests) and returns the list it records exceptions from other threads into.
+     */
+    static List<Throwable> recordUncaughtExceptions() {
+        List<Throwable> uncaught = Collections.synchronizedList(new ArrayList<>());
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> uncaught.add(throwable));
+        return uncaught;
+    }
+
+    /**
+     * Fails if anything logged an exception at error level.  Plot catches and logs exceptions
+     * thrown while rendering rather than letting them propagate, so this is how a broken
+     * renderer shows up.
+     */
+    static void assertNoLoggedErrors() {
+        for (ShadowLog.LogItem item : ShadowLog.getLogs()) {
+            if (item.type >= Log.ERROR && item.throwable != null) {
+                throw new AssertionError("error logged by " + item.tag + ": " + item.msg,
+                        item.throwable);
+            }
+        }
+    }
+
+    /** Delivers a down/up tap at the given view-relative point. */
+    static void tap(View view, PointF point) {
+        long now = SystemClock.uptimeMillis();
+        MotionEvent down = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, point.x, point.y, 0);
+        MotionEvent up = MotionEvent.obtain(now, now, MotionEvent.ACTION_UP, point.x, point.y, 0);
+        try {
+            view.dispatchTouchEvent(down);
+            view.dispatchTouchEvent(up);
+        } finally {
+            down.recycle();
+            up.recycle();
+        }
+        idle();
+    }
+
+    /**
+     * @return the non-daemon threads that are alive right now.  Daemon threads are left out
+     * because the JVM, AWT and Robolectric start some lazily (eg. on the first bitmap draw) and
+     * never stop them; every thread the plots and examples start is a regular thread.
+     */
+    static Set<Thread> liveThreads() {
+        Set<Thread> threads = new HashSet<>();
+        for (Thread thread : Thread.getAllStackTraces().keySet()) {
+            if (thread.isAlive() && !thread.isDaemon()) {
+                threads.add(thread);
+            }
+        }
+        return threads;
+    }
+
+    /**
+     * Waits (briefly) for every thread started since {@code before} was taken to exit, and fails
+     * naming the survivors if any are still alive.  Covers Androidplot's named render and
+     * Redrawer threads as well as the examples' own unnamed data threads.
+     */
+    static void assertThreadsExited(Set<Thread> before) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + THREAD_EXIT_TIMEOUT_MS;
+        List<Thread> survivors;
+        while (true) {
+            survivors = new ArrayList<>();
+            for (Thread thread : liveThreads()) {
+                if (!before.contains(thread)) {
+                    survivors.add(thread);
+                }
+            }
+            if (survivors.isEmpty() || System.currentTimeMillis() > deadline) {
+                break;
+            }
+            Thread.sleep(10);
+        }
+        if (!survivors.isEmpty()) {
+            StringBuilder names = new StringBuilder();
+            for (Thread thread : survivors) {
+                names.append(names.length() == 0 ? "" : ", ").append(thread.getName());
+            }
+            fail("Threads still alive after destroy: " + names);
+        }
+        for (Thread thread : liveThreads()) {
+            assertTrue("Androidplot thread survived destroy: " + thread.getName(),
+                    !thread.getName().startsWith("Androidplot"));
+        }
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/DemoAppTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/DemoAppTest.java
@@ -50,10 +50,39 @@ final class DemoAppTest {
         return controller;
     }
 
-    /** Runs the activity through pause, stop and destroy, then drains the main looper. */
+    /**
+     * Runs the activity through pause, stop and destroy, drains the main looper and waits for
+     * the plots' render threads to exit.  The wait matters: Robolectric resets its native
+     * graphics state between tests, and a render thread still mid-frame at that point fails
+     * with a confusing NPE inside Canvas.
+     */
     static void finish(ActivityController<?> controller) {
         controller.pause().stop().destroy();
         idle();
+        awaitAndroidplotThreads();
+    }
+
+    /** Waits (bounded) for every "Androidplot ..." thread to exit; does not fail if one lingers. */
+    static void awaitAndroidplotThreads() {
+        long deadline = System.currentTimeMillis() + THREAD_EXIT_TIMEOUT_MS;
+        while (System.currentTimeMillis() < deadline && !androidplotThreads().isEmpty()) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private static List<Thread> androidplotThreads() {
+        List<Thread> threads = new ArrayList<>();
+        for (Thread thread : liveThreads()) {
+            if (thread.getName().startsWith("Androidplot")) {
+                threads.add(thread);
+            }
+        }
+        return threads;
     }
 
     /** Runs everything currently queued on the main looper (Robolectric's default PAUSED mode). */
@@ -160,9 +189,8 @@ final class DemoAppTest {
             }
             fail("Threads still alive after destroy: " + names);
         }
-        for (Thread thread : liveThreads()) {
-            assertTrue("Androidplot thread survived destroy: " + thread.getName(),
-                    !thread.getName().startsWith("Androidplot"));
+        for (Thread thread : androidplotThreads()) {
+            fail("Androidplot thread survived destroy: " + thread.getName());
         }
     }
 }

--- a/demoapp/src/test/java/com/androidplot/demos/MainActivityTest.kt
+++ b/demoapp/src/test/java/com/androidplot/demos/MainActivityTest.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos
+
+import android.app.Activity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+
+@RunWith(RobolectricTestRunner::class)
+class MainActivityTest {
+
+    private lateinit var controller: ActivityController<MainActivity>
+    private lateinit var activity: MainActivity
+
+    /** Which example each button on the main screen opens. */
+    private val expected: Map<Int, Class<out Activity>> = mapOf(
+        R.id.startSimplePieExButton to SimplePieChartActivity::class.java,
+        R.id.startSimpleXYExButton to SimpleXYPlotActivity::class.java,
+        R.id.animatedXYPlotExButton to AnimatedXYPlotActivity::class.java,
+        R.id.startScatterExButton to ScatterPlotActivity::class.java,
+        R.id.startDynamicXYExButton to DynamicXYPlotActivity::class.java,
+        R.id.startCandlestickExButton to CandlestickChartActivity::class.java,
+        R.id.startOrSensorExButton to OrientationSensorExampleActivity::class.java,
+        R.id.startDualScaleExButton to DualScaleActivity::class.java,
+        R.id.startTimeSeriesExButton to TimeSeriesActivity::class.java,
+        R.id.startStepChartExButton to StepChartExampleActivity::class.java,
+        R.id.startScrollZoomButton to TouchZoomExampleActivity::class.java,
+        R.id.startBarPlotExButton to BarPlotExampleActivity::class.java,
+        R.id.startXyRegionExampleButton to XYRegionExampleActivity::class.java,
+        R.id.startXyListViewExButton to ListViewActivity::class.java,
+        R.id.startXyRecyclerViewExButton to RecyclerViewActivity::class.java,
+        R.id.startXYPlotWithBgImgExample to XYPlotWithBgImgActivity::class.java,
+        R.id.startECGExample to ECGExample::class.java,
+        R.id.fxPlotExample to FXPlotExampleActivity::class.java,
+        R.id.bubbleChartExample to BubbleChartActivity::class.java,
+        R.id.aboutButton to AboutActivity::class.java,
+    )
+
+    @Before
+    fun setUp() {
+        controller = DemoAppTest.launch(MainActivity::class.java)
+        activity = controller.get()
+    }
+
+    @After
+    fun tearDown() {
+        DemoAppTest.finish(controller)
+    }
+
+    @Test
+    fun eachButtonStartsItsExample() {
+        assertNull(shadowOf(activity).nextStartedActivity)
+        expected.forEach { (id, cls) ->
+            val button = activity.findViewById<Button>(id)
+            button.performClick()
+            DemoAppTest.idle()
+            val intent = shadowOf(activity).nextStartedActivity
+            assertEquals("button ${activity.resources.getResourceEntryName(id)}",
+                cls.name, intent?.component?.className)
+        }
+        assertNull(shadowOf(activity).nextStartedActivity)
+    }
+
+    @Test
+    fun everyButtonIsWired() {
+        val buttons = buttonsIn(activity.window.decorView)
+        assertEquals(expected.keys, buttons.map { it.id }.toSet())
+        buttons.forEach { assertEquals(it.text.toString(), true, it.hasOnClickListeners()) }
+    }
+
+    @Test
+    fun eachExampleButtonOpensADifferentActivity() {
+        assertEquals(expected.size, expected.values.toSet().size)
+        // every example activity except the launcher itself has a button
+        assertEquals(DemoActivities.ALL.toSet() - MainActivity::class.java, expected.values.toSet())
+    }
+
+    private fun buttonsIn(view: View): List<Button> = when (view) {
+        is Button -> listOf(view)
+        is ViewGroup -> (0 until view.childCount).flatMap { buttonsIn(view.getChildAt(it)) }
+        else -> emptyList()
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/OrientationSensorExampleActivityTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/OrientationSensorExampleActivityTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.SensorEventBuilder;
 import org.robolectric.shadows.ShadowSensor;
 import org.robolectric.shadows.ShadowSensorManager;
 
@@ -45,7 +46,8 @@ public class OrientationSensorExampleActivityTest {
         // to that instance
         SensorManager sensorManager = controller.get().getSystemService(SensorManager.class);
         ShadowSensorManager shadowSensorManager = shadowOf(sensorManager);
-        shadowSensorManager.addSensor(ShadowSensor.newInstance(Sensor.TYPE_ROTATION_VECTOR));
+        Sensor sensor = ShadowSensor.newInstance(Sensor.TYPE_ROTATION_VECTOR);
+        shadowSensorManager.addSensor(sensor);
 
         controller.setup();
         DemoAppTest.idle();
@@ -62,12 +64,11 @@ public class OrientationSensorExampleActivityTest {
 
         // a rotation of -90 degrees about the z axis as a unit quaternion (x, y, z, w), which
         // SensorManager.getOrientation reports as an azimuth of +90 degrees
-        SensorEvent event = ShadowSensorManager.createSensorEvent(4, Sensor.TYPE_ROTATION_VECTOR);
         float halfAngle = (float) Math.toRadians(-45);
-        event.values[0] = 0;
-        event.values[1] = 0;
-        event.values[2] = (float) Math.sin(halfAngle);
-        event.values[3] = (float) Math.cos(halfAngle);
+        SensorEvent event = SensorEventBuilder.newBuilder()
+                .setSensor(sensor)
+                .setValues(new float[] {0, 0, (float) Math.sin(halfAngle), (float) Math.cos(halfAngle)})
+                .build();
         shadowSensorManager.sendSensorEventToListeners(event);
 
         // one sample of azimuth, pitch and roll each in the history and the levels

--- a/demoapp/src/test/java/com/androidplot/demos/OrientationSensorExampleActivityTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/OrientationSensorExampleActivityTest.java
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorManager;
+import com.androidplot.xy.XYPlot;
+import com.androidplot.xy.XYSeries;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowSensor;
+import org.robolectric.shadows.ShadowSensorManager;
+
+@RunWith(RobolectricTestRunner.class)
+public class OrientationSensorExampleActivityTest {
+
+    @Test
+    public void noOrientationSensor_finishesCleanly() throws Exception {
+        Set<Thread> before = DemoAppTest.liveThreads();
+
+        // Robolectric's SensorManager has no sensors unless some are added
+        ActivityController<OrientationSensorExampleActivity> controller =
+                Robolectric.buildActivity(OrientationSensorExampleActivity.class).create();
+        assertTrue(controller.get().isFinishing());
+
+        // the Redrawer created in onCreate must still be shut down by onDestroy
+        controller.destroy();
+        DemoAppTest.assertThreadsExited(before);
+    }
+
+    @Test
+    public void rotationVectorSensor_readingsArePlotted() throws Exception {
+        ActivityController<OrientationSensorExampleActivity> controller =
+                Robolectric.buildActivity(OrientationSensorExampleActivity.class);
+        // the activity looks its SensorManager up through its own context, so add the sensor
+        // to that instance
+        SensorManager sensorManager = controller.get().getSystemService(SensorManager.class);
+        ShadowSensorManager shadowSensorManager = shadowOf(sensorManager);
+        shadowSensorManager.addSensor(ShadowSensor.newInstance(Sensor.TYPE_ROTATION_VECTOR));
+
+        controller.setup();
+        DemoAppTest.idle();
+        OrientationSensorExampleActivity activity = controller.get();
+        assertFalse(activity.isFinishing());
+        assertTrue(shadowSensorManager.hasListener(activity));
+
+        XYPlot historyPlot = activity.findViewById(R.id.aprHistoryPlot);
+        XYPlot levelsPlot = activity.findViewById(R.id.aprLevelsPlot);
+        assertEquals(3, historyPlot.getRegistry().getSeriesList().size());
+        for (XYSeries series : historyPlot.getRegistry().getSeriesList()) {
+            assertEquals(0, series.size());
+        }
+
+        // a rotation of -90 degrees about the z axis as a unit quaternion (x, y, z, w), which
+        // SensorManager.getOrientation reports as an azimuth of +90 degrees
+        SensorEvent event = ShadowSensorManager.createSensorEvent(4, Sensor.TYPE_ROTATION_VECTOR);
+        float halfAngle = (float) Math.toRadians(-45);
+        event.values[0] = 0;
+        event.values[1] = 0;
+        event.values[2] = (float) Math.sin(halfAngle);
+        event.values[3] = (float) Math.cos(halfAngle);
+        shadowSensorManager.sendSensorEventToListeners(event);
+
+        // one sample of azimuth, pitch and roll each in the history and the levels
+        for (XYSeries series : historyPlot.getRegistry().getSeriesList()) {
+            assertEquals(1, series.size());
+        }
+        for (XYSeries series : levelsPlot.getRegistry().getSeriesList()) {
+            assertEquals(1, series.size());
+        }
+        XYSeries azimuth = historyPlot.getRegistry().getSeriesList().get(0);
+        assertEquals("Az.", azimuth.getTitle());
+        assertEquals(90, azimuth.getY(0).floatValue(), 0.01f);
+
+        shadowSensorManager.sendSensorEventToListeners(event);
+        assertEquals(2, azimuth.size());
+
+        // the listener is only registered while resumed
+        controller.pause();
+        assertFalse(shadowSensorManager.hasListener(activity));
+        controller.stop().destroy();
+        DemoAppTest.awaitAndroidplotThreads();
+        DemoAppTest.assertNoLoggedErrors();
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/SimplePieChartActivityTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/SimplePieChartActivityTest.java
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.graphics.PointF;
+import android.graphics.RectF;
+import android.widget.SeekBar;
+import android.widget.TextView;
+import com.androidplot.pie.PieChart;
+import com.androidplot.pie.PieRenderer;
+import com.androidplot.pie.Segment;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+@RunWith(RobolectricTestRunner.class)
+public class SimplePieChartActivityTest {
+
+    private static final float SELECTED_SEGMENT_OFFSET = 50;
+
+    private ActivityController<SimplePieChartActivity> controller;
+    private SimplePieChartActivity activity;
+    private PieChart pie;
+    private PieRenderer renderer;
+
+    @Before
+    public void setUp() {
+        controller = DemoAppTest.launch(SimplePieChartActivity.class);
+        activity = controller.get();
+        pie = activity.findViewById(R.id.mySimplePieChart);
+        renderer = pie.getRenderer(PieRenderer.class);
+        assertNotNull(renderer);
+    }
+
+    @After
+    public void tearDown() {
+        DemoAppTest.finish(controller);
+        DemoAppTest.assertNoLoggedErrors();
+    }
+
+    @Test
+    public void initialState() {
+        assertEquals(4, pie.getRegistry().getSeriesList().size());
+        for (Segment segment : pie.getRegistry().getSeriesList()) {
+            assertEquals(0, offsetOf(segment), 0.001f);
+        }
+        TextView donutSizeText = activity.findViewById(R.id.donutSizeTextView);
+        assertEquals("50%", donutSizeText.getText().toString());
+        DemoAppTest.draw(pie);
+    }
+
+    @Test
+    public void tappingASegment_togglesItsOffset() {
+        DemoAppTest.draw(pie);
+
+        // a point right of the pie's centre, on whichever segment the renderer puts there
+        RectF pieRect = pie.getPie().getWidgetDimensions().marginatedRect;
+        PointF point = new PointF(pieRect.centerX() + pieRect.width() / 4, pieRect.centerY());
+        assertTrue(pie.getPie().containsPoint(point));
+        Segment tapped = renderer.getContainingSegment(point);
+        assertNotNull(tapped);
+
+        shadowOf(pie).clearWasInvalidated();
+        DemoAppTest.tap(pie, point);
+        assertTrue(shadowOf(pie).wasInvalidated());
+        for (Segment segment : pie.getRegistry().getSeriesList()) {
+            assertEquals(segment.getTitle(),
+                    segment == tapped ? SELECTED_SEGMENT_OFFSET : 0, offsetOf(segment), 0.001f);
+        }
+        DemoAppTest.draw(pie);
+
+        // tapping a different segment moves the selection
+        PointF opposite = new PointF(pieRect.centerX() - pieRect.width() / 4, pieRect.centerY());
+        Segment other = renderer.getContainingSegment(opposite);
+        assertNotSame(tapped, other);
+        DemoAppTest.tap(pie, opposite);
+        assertEquals(0, offsetOf(tapped), 0.001f);
+        assertEquals(SELECTED_SEGMENT_OFFSET, offsetOf(other), 0.001f);
+
+        // tapping the selected segment again deselects it
+        DemoAppTest.tap(pie, opposite);
+        for (Segment segment : pie.getRegistry().getSeriesList()) {
+            assertEquals(0, offsetOf(segment), 0.001f);
+        }
+        DemoAppTest.draw(pie);
+    }
+
+    @Test
+    public void tappingOutsideThePie_changesNothing() {
+        DemoAppTest.draw(pie);
+        PointF corner = new PointF(1, 1);
+        DemoAppTest.tap(pie, corner);
+        for (Segment segment : pie.getRegistry().getSeriesList()) {
+            assertEquals(0, offsetOf(segment), 0.001f);
+        }
+    }
+
+    @Test
+    public void donutSeekBar_changesDonutSizeOnRelease() {
+        SeekBar seekBar = activity.findViewById(R.id.donutSizeSeekBar);
+        TextView donutSizeText = activity.findViewById(R.id.donutSizeTextView);
+
+        // the example only applies the new size when the user lets go of the thumb
+        seekBar.setProgress(30);
+        DemoAppTest.idle();
+        assertEquals("50%", donutSizeText.getText().toString());
+
+        shadowOf(pie).clearWasInvalidated();
+        shadowOf(seekBar).getOnSeekBarChangeListener().onStopTrackingTouch(seekBar);
+        DemoAppTest.idle();
+        assertEquals("30%", donutSizeText.getText().toString());
+        assertTrue(shadowOf(pie).wasInvalidated());
+        DemoAppTest.draw(pie);
+
+        // 0% (a plain pie) and the max (90%) are both legal
+        seekBar.setProgress(0);
+        shadowOf(seekBar).getOnSeekBarChangeListener().onStopTrackingTouch(seekBar);
+        assertEquals("0%", donutSizeText.getText().toString());
+        DemoAppTest.draw(pie);
+        seekBar.setProgress(seekBar.getMax());
+        shadowOf(seekBar).getOnSeekBarChangeListener().onStopTrackingTouch(seekBar);
+        assertEquals("90%", donutSizeText.getText().toString());
+        DemoAppTest.draw(pie);
+    }
+
+    private float offsetOf(Segment segment) {
+        return pie.getFormatter(segment, PieRenderer.class).getOffset();
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/ThreadedExamplesTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/ThreadedExamplesTest.java
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertTrue;
+
+import android.app.Activity;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+/**
+ * ECGExample and DynamicXYPlotActivity each run a data thread and a Redrawer on top of the
+ * plot's own render thread.  The lifecycle smoke test already checks those exit on destroy; this
+ * checks they were actually started, so that check is not passing vacuously.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ThreadedExamplesTest {
+
+    @Test
+    public void ecgExample_startsAndStopsItsThreads() throws Exception {
+        assertStartsAndStopsThreads(ECGExample.class);
+    }
+
+    @Test
+    public void dynamicXYPlot_startsAndStopsItsThreads() throws Exception {
+        assertStartsAndStopsThreads(DynamicXYPlotActivity.class);
+    }
+
+    private static void assertStartsAndStopsThreads(Class<? extends Activity> cls)
+            throws InterruptedException {
+        Set<Thread> before = DemoAppTest.liveThreads();
+
+        ActivityController<? extends Activity> controller = DemoAppTest.launch(cls);
+        Set<Thread> started = new HashSet<>(DemoAppTest.liveThreads());
+        started.removeAll(before);
+        Set<String> names = new HashSet<>();
+        for (Thread thread : started) {
+            names.add(thread.getName());
+        }
+        assertTrue("expected a data thread, a Redrawer and a render thread, got " + names,
+                started.size() >= 3);
+        assertTrue(names.toString(), names.contains("Androidplot Redrawer"));
+        assertTrue(names.toString(), names.contains("Androidplot renderThread"));
+
+        DemoAppTest.finish(controller);
+        DemoAppTest.assertThreadsExited(before);
+        DemoAppTest.assertNoLoggedErrors();
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/TouchZoomExampleActivityTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/TouchZoomExampleActivityTest.java
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import android.os.Bundle;
+import com.androidplot.xy.BoundaryMode;
+import com.androidplot.xy.PanZoom;
+import com.androidplot.xy.XYPlot;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+@RunWith(RobolectricTestRunner.class)
+public class TouchZoomExampleActivityTest {
+
+    private static final double DELTA = 0.0001;
+
+    @Test
+    @SuppressWarnings("deprecation") // the typed getSerializable needs API 33 but the app supports 23
+    public void savesPanZoomState() {
+        ActivityController<TouchZoomExampleActivity> controller =
+                DemoAppTest.launch(TouchZoomExampleActivity.class);
+
+        Bundle bundle = new Bundle();
+        controller.saveInstanceState(bundle);
+        assertTrue(bundle.getSerializable("pan-zoom-state") instanceof PanZoom.State);
+
+        DemoAppTest.finish(controller);
+    }
+
+    @Test
+    public void recreate_restoresPanZoomState() {
+        ActivityController<TouchZoomExampleActivity> controller =
+                DemoAppTest.launch(TouchZoomExampleActivity.class);
+        TouchZoomExampleActivity first = controller.get();
+        XYPlot plot = first.findViewById(R.id.plot);
+
+        // zoom in to a window the user could have panned / pinched to
+        plot.setDomainBoundaries(1000, 1500, BoundaryMode.FIXED);
+        plot.setRangeBoundaries(200, 600, BoundaryMode.FIXED);
+        plot.redraw();
+
+        // saves the instance state, destroys the activity and creates a new one from that state
+        controller.recreate();
+        DemoAppTest.idle();
+        TouchZoomExampleActivity second = controller.get();
+        assertNotSame(first, second);
+        XYPlot restored = second.findViewById(R.id.plot);
+        assertNotNull(restored);
+        assertNotSame(plot, restored);
+
+        restored.calculateMinMaxVals();
+        assertEquals(1000, restored.getBounds().getMinX().doubleValue(), DELTA);
+        assertEquals(1500, restored.getBounds().getMaxX().doubleValue(), DELTA);
+        assertEquals(200, restored.getBounds().getMinY().doubleValue(), DELTA);
+        assertEquals(600, restored.getBounds().getMaxY().doubleValue(), DELTA);
+        assertEquals(BoundaryMode.FIXED, restored.getDomainLowerBoundaryMode());
+        assertEquals(BoundaryMode.FIXED, restored.getRangeUpperBoundaryMode());
+
+        DemoAppTest.finish(controller);
+        DemoAppTest.assertNoLoggedErrors();
+    }
+
+    @Test
+    public void resetButton_restoresOuterLimits() {
+        ActivityController<TouchZoomExampleActivity> controller =
+                DemoAppTest.launch(TouchZoomExampleActivity.class);
+        XYPlot plot = controller.get().findViewById(R.id.plot);
+        plot.setDomainBoundaries(1000, 1500, BoundaryMode.FIXED);
+
+        controller.get().findViewById(R.id.resetButton).performClick();
+        DemoAppTest.idle();
+
+        plot.calculateMinMaxVals();
+        assertEquals(0, plot.getBounds().getMinX().doubleValue(), DELTA);
+        assertEquals(3000, plot.getBounds().getMaxX().doubleValue(), DELTA);
+
+        DemoAppTest.finish(controller);
+    }
+}

--- a/demoapp/src/test/java/com/androidplot/demos/XYRegionExampleActivityTest.java
+++ b/demoapp/src/test/java/com/androidplot/demos/XYRegionExampleActivityTest.java
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.androidplot.demos;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.widget.CheckBox;
+import com.androidplot.ui.SeriesBundle;
+import com.androidplot.xy.LineAndPointFormatter;
+import com.androidplot.xy.RectRegion;
+import com.androidplot.xy.XYPlot;
+import com.androidplot.xy.XYSeries;
+import com.androidplot.xy.XYSeriesFormatter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+@RunWith(RobolectricTestRunner.class)
+public class XYRegionExampleActivityTest {
+
+    private ActivityController<XYRegionExampleActivity> controller;
+    private XYRegionExampleActivity activity;
+    private XYPlot plot;
+
+    @Before
+    public void setUp() {
+        controller = DemoAppTest.launch(XYRegionExampleActivity.class);
+        activity = controller.get();
+        plot = activity.findViewById(R.id.xyRegionExamplePlot);
+    }
+
+    @After
+    public void tearDown() {
+        DemoAppTest.finish(controller);
+        DemoAppTest.assertNoLoggedErrors();
+    }
+
+    @Test
+    public void initialState_bothSeriesWithAllRegions() {
+        assertEquals(2, plot.getRegistry().getSeriesList().size());
+        for (String series : new String[] {"Tim", "Nick"}) {
+            assertEquals(series, Set.of("Short", "Warmup", "H. Run"), regionLabels(series));
+        }
+        for (int id : new int[] {R.id.s1CheckBox, R.id.s2CheckBox,
+                R.id.r2CheckBox, R.id.r3CheckBox, R.id.r4CheckBox}) {
+            assertTrue(((CheckBox) activity.findViewById(id)).isChecked());
+        }
+    }
+
+    @Test
+    public void regionCheckBoxes_addAndRemoveRegionsAndRedraw() {
+        assertRegionToggle(R.id.r2CheckBox, "Tim", "Short");
+        assertRegionToggle(R.id.r3CheckBox, "Nick", "Warmup");
+        assertRegionToggle(R.id.r4CheckBox, "Nick", "H. Run");
+    }
+
+    private void assertRegionToggle(int checkBoxId, String series, String regionLabel) {
+        CheckBox checkBox = activity.findViewById(checkBoxId);
+        Set<String> others = new HashSet<>(regionLabels(series));
+        assertTrue(others.remove(regionLabel));
+
+        shadowOf(plot).clearWasInvalidated();
+        checkBox.performClick();
+        DemoAppTest.idle();
+        assertFalse(checkBox.isChecked());
+        assertEquals(others, regionLabels(series));
+        assertTrue("unchecking must redraw", shadowOf(plot).wasInvalidated());
+
+        shadowOf(plot).clearWasInvalidated();
+        checkBox.performClick();
+        DemoAppTest.idle();
+        assertTrue(checkBox.isChecked());
+        assertTrue(regionLabels(series).contains(regionLabel));
+        assertTrue("checking must redraw", shadowOf(plot).wasInvalidated());
+    }
+
+    @Test
+    public void seriesCheckBoxes_removeAndRestoreSeries() {
+        CheckBox timCheckBox = activity.findViewById(R.id.s1CheckBox);
+        CheckBox nickCheckBox = activity.findViewById(R.id.s2CheckBox);
+        CheckBox r2CheckBox = activity.findViewById(R.id.r2CheckBox);
+        CheckBox r3CheckBox = activity.findViewById(R.id.r3CheckBox);
+        CheckBox r4CheckBox = activity.findViewById(R.id.r4CheckBox);
+
+        shadowOf(plot).clearWasInvalidated();
+        timCheckBox.performClick();
+        DemoAppTest.idle();
+        assertEquals(List.of("Nick"), seriesTitles());
+        assertFalse("Tim's region control is disabled with the series", r2CheckBox.isEnabled());
+        assertTrue(shadowOf(plot).wasInvalidated());
+
+        nickCheckBox.performClick();
+        DemoAppTest.idle();
+        assertEquals(List.of(), seriesTitles());
+        assertFalse(r3CheckBox.isEnabled());
+        assertFalse(r4CheckBox.isEnabled());
+
+        // an empty plot must still draw
+        DemoAppTest.draw(plot);
+
+        timCheckBox.performClick();
+        nickCheckBox.performClick();
+        DemoAppTest.idle();
+        assertEquals(List.of("Tim", "Nick"), seriesTitles());
+        assertTrue(r2CheckBox.isEnabled());
+        assertTrue(r3CheckBox.isEnabled());
+        assertTrue(r4CheckBox.isEnabled());
+
+        // the formatter (and its regions) survive the series being removed and re-added
+        assertEquals(Set.of("Short", "Warmup", "H. Run"), regionLabels("Tim"));
+        DemoAppTest.draw(plot);
+    }
+
+    private List<String> seriesTitles() {
+        List<String> titles = new ArrayList<>();
+        for (XYSeries series : plot.getRegistry().getSeriesList()) {
+            titles.add(series.getTitle());
+        }
+        return titles;
+    }
+
+    /** The labels of the regions on the named series' formatter (a layer list, so unordered). */
+    private Set<String> regionLabels(String seriesTitle) {
+        LineAndPointFormatter formatter = null;
+        for (SeriesBundle<XYSeries, ? extends XYSeriesFormatter> bundle
+                : plot.getRegistry().getSeriesAndFormatterList()) {
+            if (seriesTitle.equals(bundle.getSeries().getTitle())) {
+                formatter = (LineAndPointFormatter) bundle.getFormatter();
+            }
+        }
+        assertNotNull("no series titled " + seriesTitle, formatter);
+        Set<String> labels = new HashSet<>();
+        for (RectRegion region : formatter.getRegions().elements()) {
+            labels.add(region.getLabel());
+        }
+        return labels;
+    }
+}

--- a/demoapp/src/test/resources/robolectric.properties
+++ b/demoapp/src/test/resources/robolectric.properties
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# The app compiles against SDK 37, which Robolectric 4.16 does not support, so every demoapp
+# test is pinned to an older SDK.  35 rather than 36 because Robolectric's SDK 36 sandbox needs
+# Java 21 and both the demoapp toolchain (build.gradle) and CI run on Java 17.
+# A properties file (rather than @Config on a base class) applies to the Java and Kotlin tests
+# and to the parameterized runner alike.
+sdk=35

--- a/demoapp/src/test/resources/robolectric.properties
+++ b/demoapp/src/test/resources/robolectric.properties
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # The app compiles against SDK 37, which Robolectric 4.16 does not support, so every demoapp
-# test is pinned to an older SDK.  35 rather than 36 because Robolectric's SDK 36 sandbox needs
-# Java 21 and both the demoapp toolchain (build.gradle) and CI run on Java 17.
+# test is pinned to the newest supported SDK.  (Robolectric's SDK 36 sandbox needs Java 21,
+# which CI and the local toolchain use.)
 # A properties file (rather than @Config on a base class) applies to the Java and Kotlin tests
 # and to the parameterized runner alike.
-sdk=35
+sdk=36


### PR DESCRIPTION
## Summary

Fills the coverage gaps identified after the bug sweep. androidplot-core goes from 299 to 503 tests and 81.3% to 88.5% line coverage; the demoapp goes from no tests to 47. Four latent production bugs were found by the new tests and are fixed in their own commits.

### Demo app tests (new module test suite, ~8 s)
- A parameterized Robolectric test runs **every activity in the manifest** through create/start/resume/draw/pause/stop/destroy, asserting no exception, no error-level log with a throwable (Plot swallows render exceptions into `Log.e`), no uncaught background exception, and that every thread the activity started has exited. A companion test asserts the activity list matches the manifest so a new activity can't be forgotten.
- Control-level tests: region checkboxes add/remove regions and invalidate; bar plot spinners, seek bars and a tap selecting a bar; pie segment tap and donut slider; touch-zoom state survives `recreate()`; orientation example with no sensor finishes cleanly, and with a fake rotation-vector sensor grows its series; main menu buttons start the right activities; About links fire the expected intents.
- This replaces the manual emulator smoke run and executes in CI via the root `testDebugUnitTest`.

### Render smoke test
Every renderer and plot type drawn onto a real bitmap (Robolectric native graphics), asserting no logged exception and that pixels changed, then again over the edge cases the sweep found: empty, single point, flat, nulls, negatives, inverted bounds, windows wider than or outside the data, zero/negative bubble sizes, zero-value and zero-total pies. Table-driven: adding a case is one line.

### Pan/zoom gesture tests
Real `MotionEvent` sequences through `PanZoom.onTouch`: pan on each axis, `Pan.NONE`, every `Zoom` mode for pinch in and out, `ZoomLimit.MIN_TICKS`, outer-limit clamping preserving window width, a window wider than the limits, epoch-millisecond magnitudes, state round-trip, consuming delegates, `setEnabled(false)`, and `attach` wiring via `dispatchTouchEvent`.

### Layout, attributes and small gaps
- Table-driven positioning tests over every `HorizontalPositioning` × `VerticalPositioning` × `Anchor` combination, size modes, box model, layout manager z-order. `LayoutManager`, `BoxModel`, `Size` → 100%.
- XML attribute processing against every attribute in `attrs.xml` with a setter, built through `Robolectric.buildAttributeSet`, plus a test that keeps `AttrUtils` enum ordinals in sync with the `<enum>` declarations. This required enabling Android resources for core unit tests (`includeAndroidResources = true`) and pinning core tests to SDK 23, which they were already implicitly running at.
- `ValueMarker`/`XValueMarker`/`YValueMarker` and `BubbleSeries` → 100%; `PixelUtils` 62% → 97%; `Fig` 75% → 93%; `SegmentFormatter` and `PieChart` attrs.

### Production bugs found and fixed
1. **Fig picked setters by name only.** `Paint` has both `setColor(int)` and `setColor(long)` since API 29 and reflection order is unspecified, so any XML config setting a paint color could fail on a device depending on ART's method ordering. Lookup now prefers the overload matching the argument count whose parameters Fig can inflate. (Two workers found this independently; the arity-aware version was kept.)
2. **Negative dimension strings lost their sign** in `PixelUtils` and `FigUtils`: `"-12dp"` parsed as +12. Affects the negative-inset idiom the docs show.
3. **`Redrawer` could park forever.** It started its thread in the constructor but only armed `keepAlive` inside `run()`, so a `finish()` arriving before the thread was scheduled was undone and the thread waited with nothing to wake it. The demoapp lifecycle tests hit this on the CI runner (activity created and destroyed back to back). The flag is now set before the thread starts; a regression test replays the ordering and fails on the old code.

### CI: JDK 21
Robolectric's SDK 36 sandbox needs Java 21, so both workflows now build on JDK 21. The demoapp's `jvmToolchain(17)` is replaced with `jvmTarget = 17`, so one JDK does everything and the bytecode stays Java 17 (verified: class major version 61 for both Kotlin and Java output).

### Observations, not changed
- Outer limits are applied to the domain axis always but to the range axis only when the plot has a series. Probably a defensive guard; worth a look.
- `domainLineExtension`/`rangeLineExtension` are declared in `attrs.xml` but nothing consumes them.
- `domainTitleHeight/Width` attrs are overridden by the title widget's auto-pack when title text is set. Documented by a test.

## Verification
Clean build on JDK 21: `testDebugUnitTest lint :androidplot-core:assembleRelease :demoapp:assembleDebug jacocoTestDebugUnitTestReport` passes in 27 s. Threading tests rerun three times without flakes.

