### PR TITLE
README: note the core library's single, annotations-only dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A library for creating dynamic and static charts in Android apps.
 
 Androidplot runs on Android 2.0 (API 5) and up, works equally well from Kotlin and Java, and can be
-used from Jetpack Compose via `AndroidView`.
+used from Jetpack Compose via `AndroidView`.  The core library is lightweight: its only dependency is
+the `androidx.annotation` jar, which every Android app already has, so it adds nothing else to your APK.
 
 If you enjoy the lib, please [rate us on codix.io](https://codix.io/gh/repo/halfhp/androidplot)!
 


### PR DESCRIPTION
Adds a sentence to the intro: the core library's only dependency is `androidx.annotation`, which every Android app already has, so it adds nothing else to an APK.

Worded this way rather than "no dependencies" because the published POM does list that one artifact (annotations only, no code).