### PR TITLE
Prepare the 1.6.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you enjoy the lib, please [rate us on codix.io](https://codix.io/gh/repo/half
 
 ```groovy
 dependencies {
-    implementation "com.androidplot:androidplot-core:1.5.11"
+    implementation "com.androidplot:androidplot-core:1.6.0"
 }
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,7 +14,7 @@ To use the library in your gradle project add the following to your build.gradle
 
 ```groovy
 dependencies {
-    implementation "com.androidplot:androidplot-core:1.5.11"
+    implementation "com.androidplot:androidplot-core:1.6.0"
 }
 ```
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -3,6 +3,20 @@ For details on what to expect in general when updating to a new version of Andro
 [versioning doc](versioning.md).
 
 # 1.6.0
+A maintenance release focused on correctness and modernisation.  Highlights:
+
+* Builds with the current Android toolchain (compile/target SDK 37, AGP 9.4, Gradle 9.7); the core
+  library's minimum SDK is unchanged.
+* The core library's only dependency is now `androidx.annotation`; the XML configuration engine
+  (formerly the separate Fig library) lives in `androidplot-core`.
+* Nullability annotations across the whole public API for Kotlin callers.
+* Around forty bug fixes, including several crashes, found by a code review of the library and a
+  large expansion of the test suite (core line coverage is now above 95%).
+* A reworked background render loop and demo app; see **Behavior changes** below for the handful of
+  observable differences.
+
+Full list:
+
 * Nullability annotations (`androidx.annotation.NonNull` / `Nullable`) across the whole public API of
   `androidplot-core`: every reference-typed return value and parameter of every public or protected
   method and constructor is annotated, so Kotlin callers see real nullable / non-null types instead


### PR DESCRIPTION
## Summary

The release commit for 1.6.0. Merge this, then tag the merge commit:

```
git checkout master && git pull
git tag 1.6.0
git push origin 1.6.0
```

The tag push runs the release workflow: it checks the tag against `theVersionName` (already `1.6.0`), runs the tests, builds the signed APK, creates the GitHub release with the AAR and APK attached, publishes the library to Maven Central with automatic release, and uploads the demo app to Play production.

## Changes
- README and quickstart dependency snippets: `1.5.11` → `1.6.0`.
- A short summary at the top of the 1.6.0 release notes ahead of the full list.

## After the release
A follow-up PR will bump `theVersionName` to `1.6.1` so master's snapshots stop shadowing the released version, and point the quickstart's snapshot line at `1.6.1-SNAPSHOT`.
