### PR TITLE
Release workflow: plain version tags and curated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: release androidplot
 
 # Publishes the core library to Maven Central and the demoapp to Google Play.
-# Runs when a version tag (e.g. v1.5.11) is pushed, or on demand.
+# Runs when a version tag (e.g. 1.5.11, matching theVersionName) is pushed, or on demand.
 on:
   push:
-    tags: ['v*']
+    tags: ['[0-9]*']
   workflow_dispatch:
     inputs:
       publish_maven_central:
@@ -33,7 +33,7 @@ jobs:
         if: github.ref_type == 'tag'
         run: |
           version=$(sed -nE "s/.*theVersionName = '([^']+)'.*/\1/p" build.gradle)
-          if [ "v$version" != "${GITHUB_REF_NAME}" ]; then
+          if [ "$version" != "${GITHUB_REF_NAME}" ]; then
             echo "Tag ${GITHUB_REF_NAME} does not match theVersionName '$version' in build.gradle"
             exit 1
           fi
@@ -63,13 +63,24 @@ jobs:
           printf '%s' "$ENCODED" | base64 -d > "${GITHUB_WORKSPACE}/demoapp/keystore.jks"
           ./gradlew :demoapp:assembleRelease -Prelease
 
+      # The release body is this version's section of docs/release_notes.md, matching how
+      # earlier releases were written up.
       - name: Attach Artifacts to GitHub Release
         if: github.ref_type == 'tag'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          awk -v v="${GITHUB_REF_NAME}" '
+            $0 == "# " v { on = 1; next }
+            on && /^# / { exit }
+            on { print }
+          ' docs/release_notes.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "No '# ${GITHUB_REF_NAME}' section found in docs/release_notes.md"
+            exit 1
+          fi
           gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
-            || gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
+            || gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes-file /tmp/release-notes.md
           gh release upload "${GITHUB_REF_NAME}" --clobber \
             androidplot-core/build/outputs/aar/androidplot-core-release.aar \
             demoapp/build/outputs/apk/release/demoapp-release.apk

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,7 +35,7 @@ Every merge to master runs the full test suite and then:
   where `n` is the commit count, so no manual version bump is needed.
 
 ## Releasing
-Releases are cut by pushing a tag of the form `v<version>` matching `theVersionName` in
+Releases are cut by pushing a tag named exactly `<version>` (e.g. `1.6.0`) matching `theVersionName` in
 `build.gradle`.  The release workflow verifies the tag, runs the tests, publishes the library
 to Maven Central, publishes the demo app to the Play Store's production track, and creates a
 GitHub release with the artifacts attached.  Bump `theVersionName` and update the release notes


### PR DESCRIPTION
Two adjustments so the automated release matches how earlier releases were made:

- **Tag naming.** Existing releases are tagged `1.5.11`, `1.5.10`, etc.; the workflow expected `v1.5.11`. It now triggers on plain numeric tags and checks the tag equals `theVersionName` exactly.
- **Release body.** Instead of GitHub's auto-generated PR list, the workflow extracts this version's section from `docs/release_notes.md` (from its `# <version>` heading to the next heading) and uses it as the release body, failing early if the section is missing. Verified the extraction on the current notes.

`docs/contributing.md` updated to match. Merge before tagging 1.6.0.