### PR TITLE
CI: skip the build workflow for documentation-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,21 @@
 name: build androidplot
 
+# Documentation-only changes cannot affect the build, so they don't run it (and a docs-only
+# merge to master publishes no snapshot or beta). Everything else runs the full workflow.
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE.md'
+      - '_config.yml'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE.md'
+      - '_config.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `paths-ignore` to the build workflow's `push` and `pull_request` triggers for `docs/**`, any `*.md`, the issue template and the Jekyll config. A PR or merge touching only those files no longer runs tests, lint or builds, and a docs-only merge to master no longer publishes a redundant snapshot and beta.

Anything touching source, resources, Gradle files or the workflows still gets the full run.

Note for the future: the master ruleset does not require status checks, so a skipped workflow doesn't block merging. If a required check is ever added, GitHub treats a skipped workflow as missing; the usual fix then is a tiny always-run job that reports success for docs-only changes.