### PR TITLE
Bump version to 1.6.1 after the 1.6.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ ext {
     theCompileSdkVersion = 37
     theTargetSdkVersion = 37
     theMinSdkVersion = 5
-    theVersionName = '1.6.0'
+    theVersionName = '1.6.1'
     // only used by the demoapp when the commit count cannot be determined; see demoapp/build.gradle
     theVersionCode = 228
     gitUrl = 'https://github.com/halfhp/androidplot.git'

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.androidplot:androidplot-core:1.6.0-SNAPSHOT"
+    implementation "com.androidplot:androidplot-core:1.6.1-SNAPSHOT"
 }
 ```
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -2,6 +2,9 @@
 For details on what to expect in general when updating to a new version of Androiplot, check out the
 [versioning doc](versioning.md).
 
+# 1.6.1
+_Unreleased._
+
 # 1.6.0
 A maintenance release focused on correctness and modernisation.  Highlights:
 


### PR DESCRIPTION
The post-release step from docs/releasing.md:

- `theVersionName` 1.6.0 → 1.6.1, so master snapshots become `1.6.1-SNAPSHOT` instead of shadowing the released version.
- Quickstart snapshot example → `1.6.1-SNAPSHOT`.
- Empty `# 1.6.1` section at the top of the release notes for changes to accumulate under.

The README and quickstart dependency snippets stay at 1.6.0, the current release.